### PR TITLE
Asyncify handful of tests. Resolve issues with list expressions and add some more types.

### DIFF
--- a/src/elm/builder.ts
+++ b/src/elm/builder.ts
@@ -2,13 +2,13 @@
 import * as E from './expressions';
 import { typeIsArray } from '../util/util';
 
-function build(json: any): any {
+function build(json: any): E.Expression | E.Expression[] | null {
   if (json == null) {
     return json;
   }
 
   if (typeIsArray(json)) {
-    return (json as any[]).map(child => build(child));
+    return (json as any[]).map(child => build(child) as E.Expression);
   }
 
   if (json.type === 'FunctionRef') {
@@ -27,7 +27,7 @@ function functionExists(name: string) {
   return typeof E[name] === 'function';
 }
 
-function constructByName(name: string, json: any) {
+function constructByName(name: string, json: any): E.Expression {
   // @ts-ignore
   return new E[name](json);
 }

--- a/src/elm/expression.ts
+++ b/src/elm/expression.ts
@@ -5,16 +5,16 @@ import { build } from './builder';
 
 export class Expression {
   localId?: string;
-  arg?: any;
-  args?: any[];
+  arg?: Expression;
+  args?: Expression[];
 
   constructor(json: any) {
     if (json.operand != null) {
       const op = build(json.operand);
       if (typeIsArray(json.operand)) {
-        this.args = op;
+        this.args = op as Expression[];
       } else {
-        this.arg = op;
+        this.arg = op as Expression;
       }
     }
     if (json.localId != null) {

--- a/src/elm/expression.ts
+++ b/src/elm/expression.ts
@@ -39,7 +39,7 @@ export class Expression {
 
   async execArgs(ctx: Context) {
     if (this.args != null) {
-      // TODO (MATT): check this
+      // TODO (MATT) ALERT: check this. doesn't work at all. sad
       return Promise.all(this.args.map(async arg => arg.execute(ctx)));
     } else if (this.arg != null) {
       return this.arg.execute(ctx);

--- a/src/elm/interval.ts
+++ b/src/elm/interval.ts
@@ -223,7 +223,7 @@ class Width extends Expression {
   }
 
   async exec(ctx: Context) {
-    const interval = await this.arg.execute(ctx);
+    const interval = await this.arg?.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -237,7 +237,7 @@ class Size extends Expression {
   }
 
   async exec(ctx: Context) {
-    const interval = await this.arg.execute(ctx);
+    const interval = await this.arg?.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -251,7 +251,7 @@ class Start extends Expression {
   }
 
   async exec(ctx: Context) {
-    const interval = await this.arg.execute(ctx);
+    const interval = await this.arg?.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -270,7 +270,7 @@ class End extends Expression {
   }
 
   async exec(ctx: Context) {
-    const interval = await this.arg.execute(ctx);
+    const interval = await this.arg?.execute(ctx);
     if (interval == null) {
       return null;
     }

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -5,11 +5,11 @@ import { equals } from '../util/comparison';
 import { Context } from '../runtime/context';
 
 class List extends Expression {
-  elements: any[];
+  elements: Expression[];
 
   constructor(json: any) {
     super(json);
-    this.elements = build(json.element) || [];
+    this.elements = (build(json.element) as Expression[]) || [];
   }
 
   get isList() {
@@ -17,7 +17,7 @@ class List extends Expression {
   }
 
   async exec(ctx: Context) {
-    return this.elements.map(item => item.execute(ctx));
+    return await Promise.all(this.elements.map(async item => await item.execute(ctx)));
   }
 }
 
@@ -99,19 +99,19 @@ class ToList extends Expression {
 }
 
 class IndexOf extends Expression {
-  source: any;
-  element: any;
+  source: Expression;
+  element: Expression;
 
   constructor(json: any) {
     super(json);
-    this.source = build(json.source);
-    this.element = build(json.element);
+    this.source = build(json.source) as Expression;
+    this.element = build(json.element) as Expression;
   }
 
   async exec(ctx: Context) {
     let index;
-    const src = this.source.execute(ctx);
-    const el = this.element.execute(ctx);
+    const src = await this.source.execute(ctx);
+    const el = await this.element.execute(ctx);
     if (src == null || el == null) {
       return null;
     }
@@ -211,11 +211,11 @@ function removeDuplicateNulls(list: any[]) {
 class Current extends UnimplementedExpression {}
 
 class First extends Expression {
-  source: any;
+  source: Expression;
 
   constructor(json: any) {
     super(json);
-    this.source = build(json.source);
+    this.source = build(json.source) as Expression;
   }
 
   async exec(ctx: Context) {
@@ -229,11 +229,11 @@ class First extends Expression {
 }
 
 class Last extends Expression {
-  source: any;
+  source: Expression;
 
   constructor(json: any) {
     super(json);
-    this.source = build(json.source);
+    this.source = build(json.source) as Expression;
   }
 
   async exec(ctx: Context) {
@@ -247,15 +247,15 @@ class Last extends Expression {
 }
 
 class Slice extends Expression {
-  source: any;
-  startIndex: any;
-  endIndex: any;
+  source: Expression;
+  startIndex: Expression;
+  endIndex: Expression;
 
   constructor(json: any) {
     super(json);
-    this.source = build(json.source);
-    this.startIndex = build(json.startIndex);
-    this.endIndex = build(json.endIndex);
+    this.source = build(json.source) as Expression;
+    this.startIndex = build(json.startIndex) as Expression;
+    this.endIndex = build(json.endIndex) as Expression;
   }
 
   async exec(ctx: Context) {

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -17,7 +17,7 @@ class List extends Expression {
   }
 
   async exec(ctx: Context) {
-    return await Promise.all(this.elements.map(async item => await item.execute(ctx)));
+    return await Promise.all(this.elements.map(item => item.execute(ctx)));
   }
 }
 

--- a/src/elm/overloaded.ts
+++ b/src/elm/overloaded.ts
@@ -80,7 +80,7 @@ class Union extends Expression {
   }
 
   listTypeArgs() {
-    return this.args?.some(arg => {
+    return this.args?.some((arg: any) => {
       return arg.asTypeSpecifier != null && arg.asTypeSpecifier.type === 'ListTypeSpecifier';
     });
   }
@@ -259,7 +259,7 @@ class Length extends Expression {
     const arg = await this.execArgs(ctx);
     if (arg != null) {
       return arg.length;
-    } else if (this.arg.asTypeSpecifier.type === 'ListTypeSpecifier') {
+    } else if ((this.arg as any).asTypeSpecifier.type === 'ListTypeSpecifier') {
       return 0;
     } else {
       return null;

--- a/src/elm/query.ts
+++ b/src/elm/query.ts
@@ -216,7 +216,7 @@ class AggregateClause extends Expression {
 class Query extends Expression {
   sources: MultiSource;
   letClauses: LetClause[];
-  relationship: any[];
+  relationship: Expression[];
   where: any;
   returnClause: ReturnClause | null;
   aggregateClause: AggregateClause | null;
@@ -227,7 +227,7 @@ class Query extends Expression {
     super(json);
     this.sources = new MultiSource(json.source.map((s: any) => new AliasedQuerySource(s)));
     this.letClauses = json.let != null ? json.let.map((d: any) => new LetClause(d)) : [];
-    this.relationship = json.relationship != null ? build(json.relationship) : [];
+    this.relationship = json.relationship != null ? (build(json.relationship) as Expression[]) : [];
     this.where = build(json.where);
     this.returnClause = json.return != null ? new ReturnClause(json.return) : null;
     this.aggregateClause = json.aggregate != null ? new AggregateClause(json.aggregate) : null;

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -246,10 +246,9 @@ class ToTime extends Expression {
       const timeString = arg.toString();
       // Return null if string doesn't represent a valid ISO-8601 Time
       // hh:mm:ss.fff or hh:mm:ss.fff
-      const matches =
-        /^T?((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?$/.exec(
-          timeString
-        );
+      const matches = /^T?((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?$/.exec(
+        timeString
+      );
       if (matches == null) {
         return null;
       }

--- a/test/elm/executor/executor-test.ts
+++ b/test/elm/executor/executor-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 
@@ -5,27 +6,27 @@ const { p1, p2 } = require('./patients');
 import { Patient } from '../../../src/cql-patient';
 
 describe('Age', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, data, [p1, p2]);
-    this.results = this.executor.withLibrary(this.lib).exec(this.patientSource);
+    this.results = await this.executor.withLibrary(this.lib).exec(this.patientSource);
   });
 
   it('should have correct patient results', function () {
-    this.results.patientResults['1'].Age.should.equal(32);
-    this.results.patientResults['2'].Age.should.equal(5);
+    should(this.results.patientResults['1'].Age).equal(32);
+    should(this.results.patientResults['2'].Age).equal(5);
   });
 
   it('should have correct patientEvaluatedRecords for each patient', function () {
-    this.results.patientEvaluatedRecords['1'].should.eql([new Patient(p1)]);
-    this.results.patientEvaluatedRecords['2'].should.eql([new Patient(p2)]);
+    should(this.results.patientEvaluatedRecords['1']).eql([new Patient(p1)]);
+    should(this.results.patientEvaluatedRecords['2']).eql([new Patient(p2)]);
   });
 
   it('should support older evaluatedRecords array field', function () {
-    this.results.evaluatedRecords.should.eql([new Patient(p1), new Patient(p2)]);
+    should(this.results.evaluatedRecords).eql([new Patient(p1), new Patient(p2)]);
   });
 
   it('should have the correct unfiltered results', function () {
-    this.results.unfilteredResults.AgeSum.should.equal(37);
+    should(this.results.unfilteredResults.AgeSum).equal(37);
   });
 
   it('should be able to reference other unfiltered context expressions', function () {

--- a/test/elm/external/external-test.ts
+++ b/test/elm/external/external-test.ts
@@ -9,8 +9,8 @@ describe('Retrieve', () => {
     setup(this, data, [p1], vsets, {}, new Repository(data));
   });
 
-  it('should find conditions', function () {
-    const c = this.conditions.exec(this.ctx);
+  it('should find conditions', async function () {
+    const c = await this.conditions.exec(this.ctx);
     c.should.have.length(2);
     c[0].id.should.equal('http://cqframework.org/3/2');
     c[1].id.should.equal('http://cqframework.org/3/4');
@@ -18,8 +18,8 @@ describe('Retrieve', () => {
     this.ctx.evaluatedRecords.should.containDeep(c);
   });
 
-  it('should find encounter performances', function () {
-    const e = this.encounters.exec(this.ctx);
+  it('should find encounter performances', async function () {
+    const e = await this.encounters.exec(this.ctx);
     e.should.have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
@@ -28,16 +28,16 @@ describe('Retrieve', () => {
     this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
-  it('should find observations with a value set from included library', function () {
-    const p = this.pharyngitisConditions.exec(this.ctx);
+  it('should find observations with a value set from included library', async function () {
+    const p = await this.pharyngitisConditions.exec(this.ctx);
     p.should.have.length(1);
     p[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(p);
   });
 
-  it('should find encounter performances with a value set', function () {
-    const a = this.ambulatoryEncounters.exec(this.ctx);
+  it('should find encounter performances with a value set', async function () {
+    const a = await this.ambulatoryEncounters.exec(this.ctx);
     a.should.have.length(3);
     a[0].id.should.equal('http://cqframework.org/3/1');
     a[1].id.should.equal('http://cqframework.org/3/3');
@@ -46,8 +46,8 @@ describe('Retrieve', () => {
     this.ctx.evaluatedRecords.should.containDeep(a);
   });
 
-  it('should find encounter performances by code', function () {
-    const e = this.encountersByCode.exec(this.ctx);
+  it('should find encounter performances by code', async function () {
+    const e = await this.encountersByCode.exec(this.ctx);
     e.should.have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
@@ -56,28 +56,28 @@ describe('Retrieve', () => {
     this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
-  it('should not find conditions with wrong valueset', function () {
-    const e = this.wrongValueSet.exec(this.ctx);
+  it('should not find conditions with wrong valueset', async function () {
+    const e = await this.wrongValueSet.exec(this.ctx);
     e.should.be.empty();
     this.ctx.evaluatedRecords.should.be.empty;
   });
 
-  it('should not find encounter performances using wrong codeProperty', function () {
-    const e = this.wrongCodeProperty.exec(this.ctx);
+  it('should not find encounter performances using wrong codeProperty', async function () {
+    const e = await this.wrongCodeProperty.exec(this.ctx);
     e.should.be.empty();
     this.ctx.evaluatedRecords.should.be.empty;
   });
 
-  it('should find conditions by specific pharyngitis code', function () {
-    const e = this.conditionsByCode.exec(this.ctx);
+  it('should find conditions by specific pharyngitis code', async function () {
+    const e = await this.conditionsByCode.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
-  it('should find conditions by specific pharyngitis concept', function () {
-    const e = this.conditionsByConcept.exec(this.ctx);
+  it('should find conditions by specific pharyngitis concept', async function () {
+    const e = await this.conditionsByConcept.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);

--- a/test/elm/external/external-test.ts
+++ b/test/elm/external/external-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 const vsets = require('./valuesets');
@@ -11,7 +12,7 @@ describe('Retrieve', () => {
 
   it('should find conditions', async function () {
     const c = await this.conditions.exec(this.ctx);
-    c.should.have.length(2);
+    should(c).have.length(2);
     c[0].id.should.equal('http://cqframework.org/3/2');
     c[1].id.should.equal('http://cqframework.org/3/4');
     this.ctx.evaluatedRecords.should.have.length(2);
@@ -20,7 +21,7 @@ describe('Retrieve', () => {
 
   it('should find encounter performances', async function () {
     const e = await this.encounters.exec(this.ctx);
-    e.should.have.length(3);
+    should(e).have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[2].id.should.equal('http://cqframework.org/3/5');
@@ -30,7 +31,7 @@ describe('Retrieve', () => {
 
   it('should find observations with a value set from included library', async function () {
     const p = await this.pharyngitisConditions.exec(this.ctx);
-    p.should.have.length(1);
+    should(p).have.length(1);
     p[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(p);
@@ -38,7 +39,7 @@ describe('Retrieve', () => {
 
   it('should find encounter performances with a value set', async function () {
     const a = await this.ambulatoryEncounters.exec(this.ctx);
-    a.should.have.length(3);
+    should(a).have.length(3);
     a[0].id.should.equal('http://cqframework.org/3/1');
     a[1].id.should.equal('http://cqframework.org/3/3');
     a[2].id.should.equal('http://cqframework.org/3/5');
@@ -48,7 +49,7 @@ describe('Retrieve', () => {
 
   it('should find encounter performances by code', async function () {
     const e = await this.encountersByCode.exec(this.ctx);
-    e.should.have.length(3);
+    should(e).have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[2].id.should.equal('http://cqframework.org/3/5');
@@ -58,19 +59,19 @@ describe('Retrieve', () => {
 
   it('should not find conditions with wrong valueset', async function () {
     const e = await this.wrongValueSet.exec(this.ctx);
-    e.should.be.empty();
+    should(e).be.empty();
     this.ctx.evaluatedRecords.should.be.empty;
   });
 
   it('should not find encounter performances using wrong codeProperty', async function () {
     const e = await this.wrongCodeProperty.exec(this.ctx);
-    e.should.be.empty();
+    should(e).be.empty();
     this.ctx.evaluatedRecords.should.be.empty;
   });
 
   it('should find conditions by specific pharyngitis code', async function () {
     const e = await this.conditionsByCode.exec(this.ctx);
-    e.should.have.length(1);
+    should(e).have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(e);
@@ -78,7 +79,7 @@ describe('Retrieve', () => {
 
   it('should find conditions by specific pharyngitis concept', async function () {
     const e = await this.conditionsByConcept.exec(this.ctx);
-    e.should.have.length(1);
+    should(e).have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(e);

--- a/test/elm/instance/instance-test.ts
+++ b/test/elm/instance/instance-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 import { Code, Concept } from '../../../src/datatypes/clinical';
@@ -8,27 +9,27 @@ describe('Instance', () => {
     setup(this, data);
   });
 
-  it('should be able to construct a Quantity', function () {
-    const q = this.quantityA.exec(this.ctx);
-    q.should.be.instanceof(Quantity);
+  it('should be able to construct a Quantity', async function () {
+    const q = await this.quantityA.exec(this.ctx);
+    should(q).be.instanceof(Quantity);
     q.unit.should.eql('a');
     q.value.should.eql(12);
     q.toString().should.equal("12 'a'");
-    this.val.exec(this.ctx).should.eql(12);
+    (await this.val.exec(this.ctx)).should.eql(12);
   });
 
-  it('should be able to construct a Code', function () {
-    const c = this.codeA.exec(this.ctx);
-    c.should.be.instanceof(Code);
+  it('should be able to construct a Code', async function () {
+    const c = await this.codeA.exec(this.ctx);
+    should(c).be.instanceof(Code);
     c.code.should.equal('12345');
     c.system.should.equal('http://loinc.org');
     c.version.should.equal('1');
     c.display.should.equal('Test Code');
   });
 
-  it('should be able to construct a Concept', function () {
-    const c = this.conceptA.exec(this.ctx);
-    c.should.be.instanceof(Concept);
+  it('should be able to construct a Concept', async function () {
+    const c = await this.conceptA.exec(this.ctx);
+    should(c).be.instanceof(Concept);
     c.codes.should.have.length(1);
     c.codes[0].code.should.equal('12345');
     c.codes[0].system.should.equal('http://loinc.org');
@@ -37,8 +38,8 @@ describe('Instance', () => {
     c.display.should.equal('Test Concept');
   });
 
-  it('should create generic json objects with the correct key values', function () {
-    this.pharyngitis.exec(this.ctx).status.code.should.eql('active');
-    this.pharyngitis.exec(this.ctx).code.display.should.eql('Viral pharyngitis (disorder)');
+  it('should create generic json objects with the correct key values', async function () {
+    (await this.pharyngitis.exec(this.ctx)).status.code.should.eql('active');
+    (await this.pharyngitis.exec(this.ctx)).code.display.should.eql('Viral pharyngitis (disorder)');
   });
 });

--- a/test/elm/interval/interval-test.ts
+++ b/test/elm/interval/interval-test.ts
@@ -18,36 +18,36 @@ describe('Interval', () => {
     setup(this, data);
   });
 
-  it('should properly represent an open interval', function () {
+  it('should properly represent an open interval', async function () {
     this.open.lowClosed.should.be.false();
     this.open.highClosed.should.be.false();
-    this.open.low.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
-    this.open.high.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+    (await this.open.low.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
+    (await this.open.high.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should properly represent a left-open interval', function () {
+  it('should properly represent a left-open interval', async function () {
     this.leftOpen.lowClosed.should.be.false();
     this.leftOpen.highClosed.should.be.true();
-    this.leftOpen.low.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
-    this.leftOpen.high.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+    (await this.leftOpen.low.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
+    (await this.leftOpen.high.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should properly represent a right-open interval', function () {
+  it('should properly represent a right-open interval', async function () {
     this.rightOpen.lowClosed.should.be.true();
     this.rightOpen.highClosed.should.be.false();
-    this.rightOpen.low.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
-    this.rightOpen.high.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+    (await this.rightOpen.low.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
+    (await this.rightOpen.high.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should properly represent a closed interval', function () {
+  it('should properly represent a closed interval', async function () {
     this.closed.lowClosed.should.be.true();
     this.closed.highClosed.should.be.true();
-    this.closed.low.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
-    this.closed.high.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+    (await this.closed.low.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
+    (await this.closed.high.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should exec to native Interval datatype', function () {
-    const ivl = this.open.exec(this.ctx);
+  it('should exec to native Interval datatype', async function () {
+    const ivl = await this.open.exec(this.ctx);
     ivl.should.be.instanceOf(Interval);
     ivl.lowClosed.should.equal(this.open.lowClosed);
     ivl.highClosed.should.equal(this.open.highClosed);
@@ -61,39 +61,39 @@ describe('Equal', () => {
     setup(this, data);
   });
 
-  it('should determine equal integer intervals', function () {
-    this.equalClosed.exec(this.ctx).should.be.true();
-    this.equalOpen.exec(this.ctx).should.be.true();
-    this.equalOpenClosed.exec(this.ctx).should.be.true();
+  it('should determine equal integer intervals', async function () {
+    (await this.equalClosed.exec(this.ctx)).should.be.true();
+    (await this.equalOpen.exec(this.ctx)).should.be.true();
+    (await this.equalOpenClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('should determine unequal integer intervals', function () {
-    this.unequalClosed.exec(this.ctx).should.be.false();
-    this.unequalOpen.exec(this.ctx).should.be.false();
-    this.unequalClosedOpen.exec(this.ctx).should.be.false();
+  it('should determine unequal integer intervals', async function () {
+    (await this.unequalClosed.exec(this.ctx)).should.be.false();
+    (await this.unequalOpen.exec(this.ctx)).should.be.false();
+    (await this.unequalClosedOpen.exec(this.ctx)).should.be.false();
   });
 
-  it('should determine equal quantity intervals', function () {
-    this.equalQuantityClosed.exec(this.ctx).should.be.true();
-    this.equalQuantityOpen.exec(this.ctx).should.be.true();
-    this.equalQuantityOpenClosed.exec(this.ctx).should.be.true();
+  it('should determine equal quantity intervals', async function () {
+    (await this.equalQuantityClosed.exec(this.ctx)).should.be.true();
+    (await this.equalQuantityOpen.exec(this.ctx)).should.be.true();
+    (await this.equalQuantityOpenClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('should determine unequal quantity intervals', function () {
-    this.unequalQuantityClosed.exec(this.ctx).should.be.false();
-    this.unequalQuantityOpen.exec(this.ctx).should.be.false();
-    this.unequalQuantityClosedOpen.exec(this.ctx).should.be.false();
+  it('should determine unequal quantity intervals', async function () {
+    (await this.unequalQuantityClosed.exec(this.ctx)).should.be.false();
+    (await this.unequalQuantityOpen.exec(this.ctx)).should.be.false();
+    (await this.unequalQuantityClosedOpen.exec(this.ctx)).should.be.false();
   });
 
-  it('should determine equal datetime intervals', function () {
-    this.equalDates.exec(this.ctx).should.be.true();
-    this.equalDatesOpenClosed.exec(this.ctx).should.be.true();
+  it('should determine equal datetime intervals', async function () {
+    (await this.equalDates.exec(this.ctx)).should.be.true();
+    (await this.equalDatesOpenClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('should operate correctly with imprecision', function () {
-    this.sameDays.exec(this.ctx).should.be.true();
-    this.differentDays.exec(this.ctx).should.be.false();
-    should(this.differingPrecision.exec(this.ctx)).be.null();
+  it('should operate correctly with imprecision', async function () {
+    (await this.sameDays.exec(this.ctx)).should.be.true();
+    (await this.differentDays.exec(this.ctx)).should.be.false();
+    should(await this.differingPrecision.exec(this.ctx)).be.null();
   });
 });
 
@@ -102,39 +102,39 @@ describe('NotEqual', () => {
     setup(this, data);
   });
 
-  it('should determine equal integer intervals', function () {
-    this.equalClosed.exec(this.ctx).should.be.false();
-    this.equalOpen.exec(this.ctx).should.be.false();
-    this.equalOpenClosed.exec(this.ctx).should.be.false();
+  it('should determine equal integer intervals', async function () {
+    (await this.equalClosed.exec(this.ctx)).should.be.false();
+    (await this.equalOpen.exec(this.ctx)).should.be.false();
+    (await this.equalOpenClosed.exec(this.ctx)).should.be.false();
   });
 
-  it('should determine unequal integer intervals', function () {
-    this.unequalClosed.exec(this.ctx).should.be.true();
-    this.unequalOpen.exec(this.ctx).should.be.true();
-    this.unequalClosedOpen.exec(this.ctx).should.be.true();
+  it('should determine unequal integer intervals', async function () {
+    (await this.unequalClosed.exec(this.ctx)).should.be.true();
+    (await this.unequalOpen.exec(this.ctx)).should.be.true();
+    (await this.unequalClosedOpen.exec(this.ctx)).should.be.true();
   });
 
-  it('should determine equal quantity intervals', function () {
-    this.equalQuantityClosed.exec(this.ctx).should.be.false();
-    this.equalQuantityOpen.exec(this.ctx).should.be.false();
-    this.equalQuantityOpenClosed.exec(this.ctx).should.be.false();
+  it('should determine equal quantity intervals', async function () {
+    (await this.equalQuantityClosed.exec(this.ctx)).should.be.false();
+    (await this.equalQuantityOpen.exec(this.ctx)).should.be.false();
+    (await this.equalQuantityOpenClosed.exec(this.ctx)).should.be.false();
   });
 
-  it('should determine unequal quantity intervals', function () {
-    this.unequalQuantityClosed.exec(this.ctx).should.be.true();
-    this.unequalQuantityOpen.exec(this.ctx).should.be.true();
-    this.unequalQuantityClosedOpen.exec(this.ctx).should.be.true();
+  it('should determine unequal quantity intervals', async function () {
+    (await this.unequalQuantityClosed.exec(this.ctx)).should.be.true();
+    (await this.unequalQuantityOpen.exec(this.ctx)).should.be.true();
+    (await this.unequalQuantityClosedOpen.exec(this.ctx)).should.be.true();
   });
 
-  it('should determine equal datetime intervals', function () {
-    this.equalDates.exec(this.ctx).should.be.false();
-    this.equalDatesOpenClosed.exec(this.ctx).should.be.false();
+  it('should determine equal datetime intervals', async function () {
+    (await this.equalDates.exec(this.ctx)).should.be.false();
+    (await this.equalDatesOpenClosed.exec(this.ctx)).should.be.false();
   });
 
-  it('should operate correctly with imprecision', function () {
-    this.sameDays.exec(this.ctx).should.be.false();
-    this.differentDays.exec(this.ctx).should.be.true();
-    should(this.differingPrecision.exec(this.ctx)).be.null();
+  it('should operate correctly with imprecision', async function () {
+    (await this.sameDays.exec(this.ctx)).should.be.false();
+    (await this.differentDays.exec(this.ctx)).should.be.true();
+    should(await this.differingPrecision.exec(this.ctx)).be.null();
   });
 });
 
@@ -143,76 +143,76 @@ describe('Contains', () => {
     setup(this, data);
   });
 
-  it('should accept contained items', function () {
-    this.containsInt.exec(this.ctx).should.be.true();
-    this.containsReal.exec(this.ctx).should.be.true();
-    this.containsQuantity.exec(this.ctx).should.be.true();
-    this.containsQuantityInclusiveEdge.exec(this.ctx).should.be.true();
-    this.containsDate.exec(this.ctx).should.be.true();
+  it('should accept contained items', async function () {
+    (await this.containsInt.exec(this.ctx)).should.be.true();
+    (await this.containsReal.exec(this.ctx)).should.be.true();
+    (await this.containsQuantity.exec(this.ctx)).should.be.true();
+    (await this.containsQuantityInclusiveEdge.exec(this.ctx)).should.be.true();
+    (await this.containsDate.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject uncontained items', function () {
-    this.notContainsInt.exec(this.ctx).should.be.false();
-    this.notContainsReal.exec(this.ctx).should.be.false();
-    this.notContainsQuantity.exec(this.ctx).should.be.false();
-    this.notContainsQuantityExclusiveEdge.exec(this.ctx).should.be.false();
-    this.notContainsDate.exec(this.ctx).should.be.false();
+  it('should reject uncontained items', async function () {
+    (await this.notContainsInt.exec(this.ctx)).should.be.false();
+    (await this.notContainsReal.exec(this.ctx)).should.be.false();
+    (await this.notContainsQuantity.exec(this.ctx)).should.be.false();
+    (await this.notContainsQuantityExclusiveEdge.exec(this.ctx)).should.be.false();
+    (await this.notContainsDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegContainsInt.exec(this.ctx).should.be.true();
-    this.negInfBegNotContainsInt.exec(this.ctx).should.be.false();
-    this.unknownOpenBegContainsInt.exec(this.ctx).should.be.true();
-    this.unknownClosedBegContainsInt.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayContainInt.exec(this.ctx)).be.null();
-    this.unknownBegNotContainsInt.exec(this.ctx).should.be.false();
-    this.posInfEndContainsInt.exec(this.ctx).should.be.true();
-    this.posInfEndNotContainsInt.exec(this.ctx).should.be.false();
-    this.unknownOpenEndContainsInt.exec(this.ctx).should.be.true();
-    this.unknownClosedEndContainsInt.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayContainInt.exec(this.ctx)).be.null();
-    this.unknownEndNotContainsInt.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegContainsInt.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenBegContainsInt.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedBegContainsInt.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayContainInt.exec(this.ctx)).be.null();
+    (await this.unknownBegNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.posInfEndContainsInt.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenEndContainsInt.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedEndContainsInt.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayContainInt.exec(this.ctx)).be.null();
+    (await this.unknownEndNotContainsInt.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegContainsDate.exec(this.ctx).should.be.true();
-    this.negInfBegNotContainsDate.exec(this.ctx).should.be.false();
-    should(this.unknownOpenBegMayContainDate.exec(this.ctx)).be.null();
-    this.unknownClosedBegContainsDate.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayContainDate.exec(this.ctx)).be.null();
-    this.unknownBegNotContainsDate.exec(this.ctx).should.be.false();
-    this.posInfEndContainsDate.exec(this.ctx).should.be.true();
-    this.posInfEndNotContainsDate.exec(this.ctx).should.be.false();
-    this.unknownOpenEndContainsDate.exec(this.ctx).should.be.true();
-    this.unknownClosedEndContainsDate.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayContainDate.exec(this.ctx)).be.null();
-    this.unknownEndNotContainsDate.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegContainsDate.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotContainsDate.exec(this.ctx)).should.be.false();
+    should(await this.unknownOpenBegMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownClosedBegContainsDate.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownBegNotContainsDate.exec(this.ctx)).should.be.false();
+    (await this.posInfEndContainsDate.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotContainsDate.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenEndContainsDate.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedEndContainsDate.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownEndNotContainsDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.containsImpreciseDate.exec(this.ctx).should.be.true();
-    this.notContainsImpreciseDate.exec(this.ctx).should.be.false();
-    should(this.mayContainImpreciseDate.exec(this.ctx)).be.null();
-    this.impreciseContainsDate.exec(this.ctx).should.be.true();
-    this.impreciseNotContainsDate.exec(this.ctx).should.be.false();
-    should(this.impreciseMayContainDate.exec(this.ctx)).be.null();
+  it('should correctly handle imprecision', async function () {
+    (await this.containsImpreciseDate.exec(this.ctx)).should.be.true();
+    (await this.notContainsImpreciseDate.exec(this.ctx)).should.be.false();
+    should(await this.mayContainImpreciseDate.exec(this.ctx)).be.null();
+    (await this.impreciseContainsDate.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotContainsDate.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayContainDate.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.containsDayOfDateLowEdge.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx).should.be.false();
-    this.containsDayOfDateHighEdgeClosed.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateLowEdge.exec(this.ctx).should.be.false();
-    this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx).should.be.false();
-    this.containsDayOfDateImpreciseLowEdge.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx).should.be.false();
-    this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx).should.be.true();
-    this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx).should.be.false();
-    this.notContainsDayOfDateVeryImpreciseHighEdgeOpen.exec(this.ctx).should.be.false();
-    should(this.mayContainDayOfDateVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayContainDayOfDateVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayContainDayOfDateVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.containsDayOfDateLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateHighEdgeClosed.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx)).should.be.true();
+    (await this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx)).should.be.false();
+    (await this.notContainsDayOfDateVeryImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    should(await this.mayContainDayOfDateVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayContainDayOfDateVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayContainDayOfDateVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 });
 
@@ -221,76 +221,76 @@ describe('In', () => {
     setup(this, data);
   });
 
-  it('should accept contained items', function () {
-    this.containsInt.exec(this.ctx).should.be.true();
-    this.containsReal.exec(this.ctx).should.be.true();
-    this.containsQuantity.exec(this.ctx).should.be.true();
-    this.containsQuantityInclusiveEdge.exec(this.ctx).should.be.true();
-    this.containsDate.exec(this.ctx).should.be.true();
+  it('should accept contained items', async function () {
+    (await this.containsInt.exec(this.ctx)).should.be.true();
+    (await this.containsReal.exec(this.ctx)).should.be.true();
+    (await this.containsQuantity.exec(this.ctx)).should.be.true();
+    (await this.containsQuantityInclusiveEdge.exec(this.ctx)).should.be.true();
+    (await this.containsDate.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject uncontained items', function () {
-    this.notContainsInt.exec(this.ctx).should.be.false();
-    this.notContainsReal.exec(this.ctx).should.be.false();
-    this.notContainsQuantity.exec(this.ctx).should.be.false();
-    this.notContainsQuantityExclusiveEdge.exec(this.ctx).should.be.false();
-    this.notContainsDate.exec(this.ctx).should.be.false();
+  it('should reject uncontained items', async function () {
+    (await this.notContainsInt.exec(this.ctx)).should.be.false();
+    (await this.notContainsReal.exec(this.ctx)).should.be.false();
+    (await this.notContainsQuantity.exec(this.ctx)).should.be.false();
+    (await this.notContainsQuantityExclusiveEdge.exec(this.ctx)).should.be.false();
+    (await this.notContainsDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegContainsInt.exec(this.ctx).should.be.true();
-    this.negInfBegNotContainsInt.exec(this.ctx).should.be.false();
-    this.unknownOpenBegContainsInt.exec(this.ctx).should.be.true();
-    this.unknownClosedBegContainsInt.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayContainInt.exec(this.ctx)).be.null();
-    this.unknownBegNotContainsInt.exec(this.ctx).should.be.false();
-    this.posInfEndContainsInt.exec(this.ctx).should.be.true();
-    this.posInfEndNotContainsInt.exec(this.ctx).should.be.false();
-    this.unknownOpenEndContainsInt.exec(this.ctx).should.be.true();
-    this.unknownClosedEndContainsInt.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayContainInt.exec(this.ctx)).be.null();
-    this.unknownEndNotContainsInt.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegContainsInt.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenBegContainsInt.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedBegContainsInt.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayContainInt.exec(this.ctx)).be.null();
+    (await this.unknownBegNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.posInfEndContainsInt.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenEndContainsInt.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedEndContainsInt.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayContainInt.exec(this.ctx)).be.null();
+    (await this.unknownEndNotContainsInt.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegContainsDate.exec(this.ctx).should.be.true();
-    this.negInfBegNotContainsDate.exec(this.ctx).should.be.false();
-    should(this.unknownOpenBegMayContainDate.exec(this.ctx)).be.null();
-    this.unknownClosedBegContainsDate.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayContainDate.exec(this.ctx)).be.null();
-    this.unknownBegNotContainsDate.exec(this.ctx).should.be.false();
-    this.posInfEndContainsDate.exec(this.ctx).should.be.true();
-    this.posInfEndNotContainsDate.exec(this.ctx).should.be.false();
-    this.unknownOpenEndContainsDate.exec(this.ctx).should.be.true();
-    this.unknownClosedEndContainsDate.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayContainDate.exec(this.ctx)).be.null();
-    this.unknownEndNotContainsDate.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegContainsDate.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotContainsDate.exec(this.ctx)).should.be.false();
+    should(await this.unknownOpenBegMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownClosedBegContainsDate.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownBegNotContainsDate.exec(this.ctx)).should.be.false();
+    (await this.posInfEndContainsDate.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotContainsDate.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenEndContainsDate.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedEndContainsDate.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownEndNotContainsDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.containsImpreciseDate.exec(this.ctx).should.be.true();
-    this.notContainsImpreciseDate.exec(this.ctx).should.be.false();
-    should(this.mayContainImpreciseDate.exec(this.ctx)).be.null();
-    this.impreciseContainsDate.exec(this.ctx).should.be.true();
-    this.impreciseNotContainsDate.exec(this.ctx).should.be.false();
-    should(this.impreciseMayContainDate.exec(this.ctx)).be.null();
+  it('should correctly handle imprecision', async function () {
+    (await this.containsImpreciseDate.exec(this.ctx)).should.be.true();
+    (await this.notContainsImpreciseDate.exec(this.ctx)).should.be.false();
+    should(await this.mayContainImpreciseDate.exec(this.ctx)).be.null();
+    (await this.impreciseContainsDate.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotContainsDate.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayContainDate.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.containsDayOfDateLowEdge.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx).should.be.false();
-    this.containsDayOfDateHighEdgeClosed.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateLowEdge.exec(this.ctx).should.be.false();
-    this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx).should.be.false();
-    this.containsDayOfDateImpreciseLowEdge.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx).should.be.false();
-    this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx).should.be.true();
-    this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx).should.be.false();
-    this.notContainsDayOfDateVeryImpreciseHighEdgeOpen.exec(this.ctx).should.be.false();
-    should(this.mayContainDayOfDateVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayContainDayOfDateVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayContainDayOfDateVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.containsDayOfDateLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateHighEdgeClosed.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx)).should.be.true();
+    (await this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx)).should.be.false();
+    (await this.notContainsDayOfDateVeryImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    should(await this.mayContainDayOfDateVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayContainDayOfDateVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayContainDayOfDateVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 });
 
@@ -299,73 +299,73 @@ describe('Includes', () => {
     setup(this, data);
   });
 
-  it('should accept included items', function () {
-    this.includesIntIvl.exec(this.ctx).should.be.true();
-    this.includesRealIvl.exec(this.ctx).should.be.true();
-    this.includesDateIvl.exec(this.ctx).should.be.true();
+  it('should accept included items', async function () {
+    (await this.includesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.includesRealIvl.exec(this.ctx)).should.be.true();
+    (await this.includesDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject unincluded items', function () {
-    this.notIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.notIncludesRealIvl.exec(this.ctx).should.be.false();
-    this.notIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should reject unincluded items', async function () {
+    (await this.notIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notIncludesRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.unknownBegIncludesIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayIncludeIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.unknownEndIncludesIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayIncludeIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotIncludesIntIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegIncludesIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayIncludeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndIncludesIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayIncludeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotIncludesIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegIncludesDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    this.unknownBegIncludesDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayIncludeDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndIncludesDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    this.unknownEndIncludesDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayIncludeDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegIncludesDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegIncludesDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayIncludeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndIncludesDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndIncludesDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayIncludeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.includesImpreciseDateIvl.exec(this.ctx).should.be.true();
-    this.notIncludesImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.mayIncludeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.impreciseIncludesDateIvl.exec(this.ctx).should.be.true();
-    this.impreciseNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayIncludeDateIvl.exec(this.ctx)).be.null();
+  it('should correctly handle imprecision', async function () {
+    (await this.includesImpreciseDateIvl.exec(this.ctx)).should.be.true();
+    (await this.notIncludesImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayIncludeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseIncludesDateIvl.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayIncludeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.includesDayOfIvlLowEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlHighEdge.exec(this.ctx).should.be.true();
-    this.notIncludesDayOfIvlLowEdge.exec(this.ctx).should.be.false();
-    this.notIncludesDayOfIvlHighEdge.exec(this.ctx).should.be.false();
-    this.includesDayOfIvlImpreciseLowEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlImpreciseHighEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlVeryImpreciseMiddle.exec(this.ctx).should.be.true();
-    this.notIncludesDayOfIvlVeryImpreciseLow.exec(this.ctx).should.be.false();
-    this.notIncludesDayOfIvlVeryImpreciseHigh.exec(this.ctx).should.be.false();
-    should(this.mayIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.includesDayOfIvlLowEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlHighEdge.exec(this.ctx)).should.be.true();
+    (await this.notIncludesDayOfIvlLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDayOfIvlHighEdge.exec(this.ctx)).should.be.false();
+    (await this.includesDayOfIvlImpreciseLowEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlImpreciseHighEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
+    (await this.notIncludesDayOfIvlVeryImpreciseLow.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDayOfIvlVeryImpreciseHigh.exec(this.ctx)).should.be.false();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle point inclusion', function () {
-    this.impreciseIncludesDate.exec(this.ctx).should.be.true();
-    this.impreciseDoesntIncludeDate.exec(this.ctx).should.be.false();
-    this.intervalIncludesQuantity.exec(this.ctx).should.be.true();
-    this.intervalDoesntIncludeQuantity.exec(this.ctx).should.be.false();
+  it('should correctly handle point inclusion', async function () {
+    (await this.impreciseIncludesDate.exec(this.ctx)).should.be.true();
+    (await this.impreciseDoesntIncludeDate.exec(this.ctx)).should.be.false();
+    (await this.intervalIncludesQuantity.exec(this.ctx)).should.be.true();
+    (await this.intervalDoesntIncludeQuantity.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -374,35 +374,35 @@ describe('ProperlyIncludes', () => {
     setup(this, data);
   });
 
-  it('should accept properly included intervals', function () {
-    this.properlyIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesIntBeginsIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesIntEndsIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesRealIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesDateIvl.exec(this.ctx).should.be.true();
+  it('should accept properly included intervals', async function () {
+    (await this.properlyIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesIntBeginsIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesIntEndsIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesRealIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals not properly included', function () {
-    this.notProperlyIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.notProperlyIncludesRealIvl.exec(this.ctx).should.be.false();
-    this.notProperlyIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not properly included', async function () {
+    (await this.notProperlyIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notProperlyIncludesRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notProperlyIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.posInfEndProperlyIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotProperlyIncludesIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayProperlyIncludeIntIvl.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.posInfEndProperlyIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotProperlyIncludesIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayProperlyIncludeIntIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.properlyIncludesDayOfIvlLowEdge.exec(this.ctx).should.be.true();
-    this.properlyIncludesDayOfIvlHighEdge.exec(this.ctx).should.be.true();
-    this.properlyIncludesDayOfIvlNearEdges.exec(this.ctx).should.be.true();
-    this.notProperlyIncludesDayOfIvlSameEdges.exec(this.ctx).should.be.false();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.properlyIncludesDayOfIvlLowEdge.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDayOfIvlHighEdge.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDayOfIvlNearEdges.exec(this.ctx)).should.be.true();
+    (await this.notProperlyIncludesDayOfIvlSameEdges.exec(this.ctx)).should.be.false();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 });
 
@@ -411,73 +411,73 @@ describe('IncludedIn', () => {
     setup(this, data);
   });
 
-  it('should accept included items', function () {
-    this.includesIntIvl.exec(this.ctx).should.be.true();
-    this.includesRealIvl.exec(this.ctx).should.be.true();
-    this.includesDateIvl.exec(this.ctx).should.be.true();
+  it('should accept included items', async function () {
+    (await this.includesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.includesRealIvl.exec(this.ctx)).should.be.true();
+    (await this.includesDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject unincluded items', function () {
-    this.notIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.notIncludesRealIvl.exec(this.ctx).should.be.false();
-    this.notIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should reject unincluded items', async function () {
+    (await this.notIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notIncludesRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegIncludedInIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotIncludedInIntIvl.exec(this.ctx).should.be.false();
-    this.unknownBegIncludedInIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayBeIncludedInIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotIncludedInIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndIncludedInIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotIncludedInIntIvl.exec(this.ctx).should.be.false();
-    this.unknownEndIncludedInIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayBeIncludedInIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotIncludedInIntIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegIncludedInIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotIncludedInIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegIncludedInIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayBeIncludedInIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotIncludedInIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndIncludedInIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotIncludedInIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndIncludedInIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayBeIncludedInIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotIncludedInIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegIncludedInDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotIncludedInDateIvl.exec(this.ctx).should.be.false();
-    this.unknownBegIncludedInDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayBeIncludedInDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotIncludedInDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndIncludedInDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotIncludedInDateIvl.exec(this.ctx).should.be.false();
-    this.unknownEndIncludedInDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayBeIncludedInDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotIncludedInDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotIncludedInDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayBeIncludedInDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotIncludedInDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotIncludedInDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayBeIncludedInDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotIncludedInDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.includesImpreciseDateIvl.exec(this.ctx).should.be.true();
-    this.notIncludesImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.mayIncludeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.impreciseIncludesDateIvl.exec(this.ctx).should.be.true();
-    this.impreciseNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayIncludeDateIvl.exec(this.ctx)).be.null();
+  it('should correctly handle imprecision', async function () {
+    (await this.includesImpreciseDateIvl.exec(this.ctx)).should.be.true();
+    (await this.notIncludesImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayIncludeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseIncludesDateIvl.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayIncludeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.includesDayOfIvlLowEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlHighEdge.exec(this.ctx).should.be.true();
-    this.notIncludesDayOfIvlLowEdge.exec(this.ctx).should.be.false();
-    this.notIncludesDayOfIvlHighEdge.exec(this.ctx).should.be.false();
-    this.includesDayOfIvlImpreciseLowEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlImpreciseHighEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlVeryImpreciseMiddle.exec(this.ctx).should.be.true();
-    this.notIncludesDayOfIvlVeryImpreciseLow.exec(this.ctx).should.be.false();
-    this.notIncludesDayOfIvlVeryImpreciseHigh.exec(this.ctx).should.be.false();
-    should(this.mayIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.includesDayOfIvlLowEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlHighEdge.exec(this.ctx)).should.be.true();
+    (await this.notIncludesDayOfIvlLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDayOfIvlHighEdge.exec(this.ctx)).should.be.false();
+    (await this.includesDayOfIvlImpreciseLowEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlImpreciseHighEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
+    (await this.notIncludesDayOfIvlVeryImpreciseLow.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDayOfIvlVeryImpreciseHigh.exec(this.ctx)).should.be.false();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle point comparisons', function () {
-    this.includesDayInInterval.exec(this.ctx).should.be.true();
-    this.doesNotIncludeDayInInterval.exec(this.ctx).should.be.false();
-    this.quantityIncludedInterval.exec(this.ctx).should.be.true();
-    this.quantityNotIncludedInterval.exec(this.ctx).should.be.false();
+  it('should correctly handle point comparisons', async function () {
+    (await this.includesDayInInterval.exec(this.ctx)).should.be.true();
+    (await this.doesNotIncludeDayInInterval.exec(this.ctx)).should.be.false();
+    (await this.quantityIncludedInterval.exec(this.ctx)).should.be.true();
+    (await this.quantityNotIncludedInterval.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -486,35 +486,35 @@ describe('ProperlyIncludedIn', () => {
     setup(this, data);
   });
 
-  it('should accept properly included intervals', function () {
-    this.properlyIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesIntBeginsIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesIntEndsIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesRealIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesDateIvl.exec(this.ctx).should.be.true();
+  it('should accept properly included intervals', async function () {
+    (await this.properlyIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesIntBeginsIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesIntEndsIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesRealIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals not properly included', function () {
-    this.notProperlyIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.notProperlyIncludesRealIvl.exec(this.ctx).should.be.false();
-    this.notProperlyIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not properly included', async function () {
+    (await this.notProperlyIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notProperlyIncludesRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notProperlyIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.posInfEndProperlyIncludedInDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotProperlyIncludedInDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayBeProperlyIncludedInDateIvl.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.posInfEndProperlyIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotProperlyIncludedInDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayBeProperlyIncludedInDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.properlyIncludesDayOfIvlLowEdge.exec(this.ctx).should.be.true();
-    this.properlyIncludesDayOfIvlHighEdge.exec(this.ctx).should.be.true();
-    this.properlyIncludesDayOfIvlNearEdges.exec(this.ctx).should.be.true();
-    this.notProperlyIncludesDayOfIvlSameEdges.exec(this.ctx).should.be.false();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.properlyIncludesDayOfIvlLowEdge.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDayOfIvlHighEdge.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDayOfIvlNearEdges.exec(this.ctx)).should.be.true();
+    (await this.notProperlyIncludesDayOfIvlSameEdges.exec(this.ctx)).should.be.false();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 });
 
@@ -523,55 +523,55 @@ describe('After', () => {
     setup(this, data);
   });
 
-  it('should accept intervals before it', function () {
-    this.afterIntIvl.exec(this.ctx).should.be.true();
-    this.afterRealIvl.exec(this.ctx).should.be.true();
-    this.afterDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals before it', async function () {
+    (await this.afterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.afterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.afterDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals on or after it', function () {
-    this.notAfterIntIvl.exec(this.ctx).should.be.false();
-    this.notAfterRealIvl.exec(this.ctx).should.be.false();
-    this.notAfterDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals on or after it', async function () {
+    (await this.notAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notAfterRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notAfterDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegNotAfterIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownBegMayBeAfterIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotAfterIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndAfterIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotAfterIntIvl.exec(this.ctx).should.be.false();
-    this.unknownEndAfterIntIvl.exec(this.ctx).should.be.true();
-    this.unknownEndNotAfterIntIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegNotAfterIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownBegMayBeAfterIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownEndNotAfterIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegNotAfterDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownBegMayBeAfterDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotAfterDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndAfterDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotAfterDateIvl.exec(this.ctx).should.be.false();
-    this.unknownEndAfterDateIvl.exec(this.ctx).should.be.true();
-    this.unknownEndNotAfterDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegNotAfterDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownBegMayBeAfterDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownEndNotAfterDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.afterImpreciseDateIvl.exec(this.ctx).should.be.true();
-    should(this.notAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    should(this.mayBeAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.impreciseAfterDateIvl.exec(this.ctx).should.be.true();
+  it('should correctly handle imprecision', async function () {
+    (await this.afterImpreciseDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.notAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    should(await this.mayBeAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseAfterDateIvl.exec(this.ctx)).should.be.true();
     // meets with uncertainty due to toClose
-    should(this.impreciseNotAfterDateIvl.exec(this.ctx)).be.null();
-    should(this.impreciseMayBeAfterDateIvl.exec(this.ctx)).be.null();
+    should(await this.impreciseNotAfterDateIvl.exec(this.ctx)).be.null();
+    should(await this.impreciseMayBeAfterDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.afterDayOfIvl.exec(this.ctx).should.be.true();
-    this.beforeDayOfIvl.exec(this.ctx).should.be.false();
-    this.startsSameDayOfIvlEnd.exec(this.ctx).should.be.false();
-    this.endsSameDayOfIvlStart.exec(this.ctx).should.be.false();
-    should(this.mayBeAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    this.mayBeBeforeDayOfImpreciseIvl.exec(this.ctx).should.be.false();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.afterDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.beforeDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.startsSameDayOfIvlEnd.exec(this.ctx)).should.be.false();
+    (await this.endsSameDayOfIvlStart.exec(this.ctx)).should.be.false();
+    should(await this.mayBeAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    (await this.mayBeBeforeDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -580,55 +580,55 @@ describe('Before', () => {
     setup(this, data);
   });
 
-  it('should accept intervals before it', function () {
-    this.beforeIntIvl.exec(this.ctx).should.be.true();
-    this.beforeRealIvl.exec(this.ctx).should.be.true();
-    this.beforeDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals before it', async function () {
+    (await this.beforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.beforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.beforeDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals on or after it', function () {
-    this.notBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.notBeforeRealIvl.exec(this.ctx).should.be.false();
-    this.notBeforeDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals on or after it', async function () {
+    (await this.notBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notBeforeRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notBeforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.unknownBegBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.unknownBegNotBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndNotBeforeIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayBeBeforeIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotBeforeIntIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownBegNotBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndNotBeforeIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayBeBeforeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotBeforeIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.unknownBegBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.unknownBegNotBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndNotBeforeDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayBeBeforeDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotBeforeDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownBegNotBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndNotBeforeDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayBeBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotBeforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.beforeImpreciseDateIvl.exec(this.ctx).should.be.true();
+  it('should correctly handle imprecision', async function () {
+    (await this.beforeImpreciseDateIvl.exec(this.ctx)).should.be.true();
     // meets with uncertaintity due to toClose
-    should(this.notBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    should(this.mayBeBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.impreciseBeforeDateIvl.exec(this.ctx).should.be.true();
-    should(this.impreciseNotBeforeDateIvl.exec(this.ctx)).be.null();
-    should(this.impreciseMayBeBeforeDateIvl.exec(this.ctx)).be.null();
+    should(await this.notBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    should(await this.mayBeBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseBeforeDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.impreciseNotBeforeDateIvl.exec(this.ctx)).be.null();
+    should(await this.impreciseMayBeBeforeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.afterDayOfIvl.exec(this.ctx).should.be.false();
-    this.beforeDayOfIvl.exec(this.ctx).should.be.true();
-    this.startsSameDayOfIvlEnd.exec(this.ctx).should.be.false();
-    this.endsSameDayOfIvlStart.exec(this.ctx).should.be.false();
-    this.mayBeAfterDayOfImpreciseIvl.exec(this.ctx).should.be.false();
-    should(this.mayBeBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.afterDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.beforeDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.startsSameDayOfIvlEnd.exec(this.ctx)).should.be.false();
+    (await this.endsSameDayOfIvlStart.exec(this.ctx)).should.be.false();
+    (await this.mayBeAfterDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayBeBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -640,61 +640,61 @@ describe('BeforeOrOn', () => {
     setup(this, data);
   });
 
-  it('should handle nominal datetime interval situations', function () {
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.afterDateIvl.exec(this.ctx).should.be.false();
-    this.beforeDateIvl.exec(this.ctx).should.be.true();
+  it('should handle nominal datetime interval situations', async function () {
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.afterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.beforeDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.mayMeetAfterImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseMayMeetAfterDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseMayMeetBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    (await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.true();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.false();
-    this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx).should.be.false();
-    should(this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.false();
+    (await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle intervals with null end', function () {
-    this.beforeNullEndIvl.exec(this.ctx).should.be.true();
-    this.afterStartNullEndIvl.exec(this.ctx).should.be.false();
-    should(this.nullEndStartBeforeIvl.exec(this.ctx)).be.null();
-    should(this.nullEndStartAfterIvl.exec(this.ctx)).be.null();
+  it('should handle intervals with null end', async function () {
+    (await this.beforeNullEndIvl.exec(this.ctx)).should.be.true();
+    (await this.afterStartNullEndIvl.exec(this.ctx)).should.be.false();
+    should(await this.nullEndStartBeforeIvl.exec(this.ctx)).be.null();
+    should(await this.nullEndStartAfterIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle intervals with null start', function () {
-    should(this.endsBeforeNullStartIvlEnds.exec(this.ctx)).be.null();
-    should(this.afterEndOfNullStartIvl.exec(this.ctx)).be.null();
-    this.nullStartStartBeforeIvl.exec(this.ctx).should.be.true();
-    this.nullStartStartAfterIvl.exec(this.ctx).should.be.false();
+  it('should handle intervals with null start', async function () {
+    should(await this.endsBeforeNullStartIvlEnds.exec(this.ctx)).be.null();
+    should(await this.afterEndOfNullStartIvl.exec(this.ctx)).be.null();
+    (await this.nullStartStartBeforeIvl.exec(this.ctx)).should.be.true();
+    (await this.nullStartStartAfterIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle null on either side', function () {
-    should(this.dateIvlBeforeNull.exec(this.ctx)).be.null();
-    should(this.nullBeforeDateIvl.exec(this.ctx)).be.null();
+  it('should handle null on either side', async function () {
+    should(await this.dateIvlBeforeNull.exec(this.ctx)).be.null();
+    should(await this.nullBeforeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle Date and DateTime on either side', function () {
-    this.dateTimeBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.dateBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.dateIvlBeforeDateTime.exec(this.ctx).should.be.true();
-    this.dateIvlBeforeDate.exec(this.ctx).should.be.true();
+  it('should handle Date and DateTime on either side', async function () {
+    (await this.dateTimeBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.dateBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.dateIvlBeforeDateTime.exec(this.ctx)).should.be.true();
+    (await this.dateIvlBeforeDate.exec(this.ctx)).should.be.true();
   });
 
-  it('should handle Interval<Date> and Interval<DateTime> on either side', function () {
-    this.dateOnlyIvlBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.dateIvlAfterDateOnlyIvl.exec(this.ctx).should.be.false();
-    this.dateOnlyMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
+  it('should handle Interval<Date> and Interval<DateTime> on either side', async function () {
+    (await this.dateOnlyIvlBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.dateIvlAfterDateOnlyIvl.exec(this.ctx)).should.be.false();
+    (await this.dateOnlyMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
   });
 });
 
@@ -706,61 +706,61 @@ describe('AfterOrOn', () => {
     setup(this, data);
   });
 
-  it('should handle nominal datetime interval situations', function () {
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.afterDateIvl.exec(this.ctx).should.be.true();
-    this.beforeDateIvl.exec(this.ctx).should.be.false();
+  it('should handle nominal datetime interval situations', async function () {
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.afterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.beforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    should(this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseMayMeetAfterDateIvl.exec(this.ctx).should.be.true();
-    this.impreciseMayMeetBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    should(await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.true();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.true();
-    should(this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx).should.be.false();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.true();
+    should(await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    (await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle intervals with null end', function () {
-    should(this.beforeNullEndIvl.exec(this.ctx)).be.null();
-    should(this.afterStartNullEndIvl.exec(this.ctx)).be.null();
-    this.nullEndStartBeforeIvl.exec(this.ctx).should.be.false();
-    this.nullEndStartAfterIvl.exec(this.ctx).should.be.true();
+  it('should handle intervals with null end', async function () {
+    should(await this.beforeNullEndIvl.exec(this.ctx)).be.null();
+    should(await this.afterStartNullEndIvl.exec(this.ctx)).be.null();
+    (await this.nullEndStartBeforeIvl.exec(this.ctx)).should.be.false();
+    (await this.nullEndStartAfterIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should handle intervals with null start', function () {
-    this.endsBeforeNullStartIvlEnds.exec(this.ctx).should.be.false();
-    this.afterEndOfNullStartIvl.exec(this.ctx).should.be.true();
-    should(this.nullStartStartBeforeIvl.exec(this.ctx)).be.null();
-    should(this.nullStartStartAfterIvl.exec(this.ctx)).be.null();
+  it('should handle intervals with null start', async function () {
+    (await this.endsBeforeNullStartIvlEnds.exec(this.ctx)).should.be.false();
+    (await this.afterEndOfNullStartIvl.exec(this.ctx)).should.be.true();
+    should(await this.nullStartStartBeforeIvl.exec(this.ctx)).be.null();
+    should(await this.nullStartStartAfterIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle null on either side', function () {
-    should(this.dateIvlBeforeNull.exec(this.ctx)).be.null();
-    should(this.nullBeforeDateIvl.exec(this.ctx)).be.null();
+  it('should handle null on either side', async function () {
+    should(await this.dateIvlBeforeNull.exec(this.ctx)).be.null();
+    should(await this.nullBeforeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle Date and DateTime on either side', function () {
-    this.dateTimeBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.dateBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlBeforeDateTime.exec(this.ctx).should.be.false();
-    this.dateIvlBeforeDate.exec(this.ctx).should.be.false();
+  it('should handle Date and DateTime on either side', async function () {
+    (await this.dateTimeBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlBeforeDateTime.exec(this.ctx)).should.be.false();
+    (await this.dateIvlBeforeDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle Interval<Date> and Interval<DateTime> on either side', function () {
-    this.dateOnlyIvlBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlAfterDateOnlyIvl.exec(this.ctx).should.be.true();
-    this.dateOnlyMeetsAfterDateIvl.exec(this.ctx).should.be.true();
+  it('should handle Interval<Date> and Interval<DateTime> on either side', async function () {
+    (await this.dateOnlyIvlBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlAfterDateOnlyIvl.exec(this.ctx)).should.be.true();
+    (await this.dateOnlyMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
   });
 });
 
@@ -769,74 +769,74 @@ describe('Meets', () => {
     setup(this, data);
   });
 
-  it('should accept intervals meeting after it', function () {
-    this.meetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeRealIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals meeting after it', async function () {
+    (await this.meetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept intervals meeting before it', function () {
-    this.meetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.meetsAfterRealIvl.exec(this.ctx).should.be.true();
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals meeting before it', async function () {
+    (await this.meetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsAfterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals not meeting it', function () {
-    this.notMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.notMeetsRealIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not meeting it', async function () {
+    (await this.notMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegMeetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    should(this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
-    this.posInfEndMeetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    should(this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
+    (await this.posInfEndMeetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    should(this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
-    this.posInfEndMeetsAfterDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    should(this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
+    (await this.posInfEndMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle imprecision', function () {
-    should(this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    should(this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).be.null();
-    should(this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    should(await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    should(await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).be.null();
+    should(await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.true();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.false();
-    should(this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    should(this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    should(await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -845,74 +845,74 @@ describe('MeetsAfter', () => {
     setup(this, data);
   });
 
-  it('should accept intervals meeting before it', function () {
-    this.meetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.meetsAfterRealIvl.exec(this.ctx).should.be.true();
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals meeting before it', async function () {
+    (await this.meetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsAfterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals meeting after it', function () {
-    this.meetsBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeRealIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals meeting after it', async function () {
+    (await this.meetsBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeRealIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject intervals not meeting it', function () {
-    this.notMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.notMeetsRealIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not meeting it', async function () {
+    (await this.notMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegMeetsBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.negInfBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx).should.be.false();
-    this.posInfEndMeetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.unknownEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    should(this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.negInfBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).should.be.false();
+    (await this.posInfEndMeetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegMeetsBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.negInfBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx).should.be.false();
-    this.posInfEndMeetsAfterDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterDateIvl.exec(this.ctx).should.be.true();
-    this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.unknownEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    should(this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.negInfBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).should.be.false();
+    (await this.posInfEndMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle imprecision', function () {
-    should(this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).be.null();
-    this.impreciseMayMeetBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    should(await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.false();
-    should(this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx).should.be.false();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    (await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -921,74 +921,74 @@ describe('MeetsBefore', () => {
     setup(this, data);
   });
 
-  it('should accept intervals meeting after it', function () {
-    this.meetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeRealIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals meeting after it', async function () {
+    (await this.meetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals meeting before it', function () {
-    this.meetsAfterIntIvl.exec(this.ctx).should.be.false();
-    this.meetsAfterRealIvl.exec(this.ctx).should.be.false();
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals meeting before it', async function () {
+    (await this.meetsAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsAfterRealIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject intervals not meeting it', function () {
-    this.notMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.notMeetsRealIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not meeting it', async function () {
+    (await this.notMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegMeetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.unknownBegMayMeetAfterIntIvl.exec(this.ctx).should.be.false();
-    this.unknownBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    should(this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
-    this.posInfEndMeetsAfterIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
+    (await this.posInfEndMeetsAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.unknownBegMayMeetAfterDateIvl.exec(this.ctx).should.be.false();
-    this.unknownBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    should(this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
-    this.posInfEndMeetsAfterDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
+    (await this.posInfEndMeetsAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.mayMeetAfterImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseMayMeetAfterDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    (await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.true();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.false();
-    this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx).should.be.false();
-    should(this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.false();
+    (await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -997,28 +997,28 @@ describe('Overlaps', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps (integer)', function () {
-    this.overlapsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.overlapsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryIntIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps (integer)', async function () {
+    (await this.overlapsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryIntIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept overlaps (real)', function () {
-    this.overlapsBeforeRealIvl.exec(this.ctx).should.be.true();
-    this.overlapsAfterRealIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryRealIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps (real)', async function () {
+    (await this.overlapsBeforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryRealIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject non-overlaps (integer)', function () {
-    this.noOverlapsIntIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (integer)', async function () {
+    (await this.noOverlapsIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (real)', function () {
-    this.noOverlapsRealIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (real)', async function () {
+    (await this.noOverlapsRealIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null for null value', function () {
-    should(this.overlapsIsNull.exec(this.ctx)).be.null();
+  it('should return null for null value', async function () {
+    should(await this.overlapsIsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -1027,42 +1027,42 @@ describe('OverlapsDateTime', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps', function () {
-    this.overlapsBefore.exec(this.ctx).should.be.true();
-    this.overlapsAfter.exec(this.ctx).should.be.true();
-    this.overlapsContained.exec(this.ctx).should.be.true();
-    this.overlapsContains.exec(this.ctx).should.be.true();
+  it('should accept overlaps', async function () {
+    (await this.overlapsBefore.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfter.exec(this.ctx)).should.be.true();
+    (await this.overlapsContained.exec(this.ctx)).should.be.true();
+    (await this.overlapsContains.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept imprecise overlaps', function () {
-    this.impreciseOverlap.exec(this.ctx).should.be.true();
+  it('should accept imprecise overlaps', async function () {
+    (await this.impreciseOverlap.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject non-overlaps', function () {
-    this.noOverlap.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps', async function () {
+    (await this.noOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise non-overlaps', function () {
-    this.noImpreciseOverlap.exec(this.ctx).should.be.false();
+  it('should reject imprecise non-overlaps', async function () {
+    (await this.noImpreciseOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null for imprecise overlaps with differing precision', function () {
-    should(this.unknownOverlap.exec(this.ctx)).be.null();
+  it('should return null for imprecise overlaps with differing precision', async function () {
+    should(await this.unknownOverlap.exec(this.ctx)).be.null();
   });
 
-  it('should return true for imprecise overlaps with matching precision', function () {
-    this.matchingPrecisionOverlap.exec(this.ctx).should.be.true();
+  it('should return true for imprecise overlaps with matching precision', async function () {
+    (await this.matchingPrecisionOverlap.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.overlapsBeforeDayOfIvlEdge.exec(this.ctx).should.be.true();
-    this.overlapsAfterDayOfIvlEdge.exec(this.ctx).should.be.true();
-    this.overlapsContainsDayOfIvl.exec(this.ctx).should.be.true();
-    this.overlapsContainedByDayOfIvl.exec(this.ctx).should.be.true();
-    this.notOverlapsDayOfIvl.exec(this.ctx).should.be.false();
-    this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx).should.be.true();
-    should(this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    should(this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.overlapsBeforeDayOfIvlEdge.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfterDayOfIvlEdge.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainsDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainedByDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notOverlapsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx)).should.be.true();
+    should(await this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    should(await this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -1071,30 +1071,30 @@ describe('OverlapsAfter', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps that are after (integer)', function () {
-    this.overlapsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryIntIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are after (integer)', async function () {
+    (await this.overlapsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryIntIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept overlaps that are after (real)', function () {
-    this.overlapsAfterRealIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryRealIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are after (real)', async function () {
+    (await this.overlapsAfterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryRealIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject overlaps that are before (integer)', function () {
-    this.overlapsBeforeIntIvl.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are before (integer)', async function () {
+    (await this.overlapsBeforeIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject overlaps that are before (real)', function () {
-    this.overlapsBeforeRealIvl.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are before (real)', async function () {
+    (await this.overlapsBeforeRealIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (integer)', function () {
-    this.noOverlapsIntIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (integer)', async function () {
+    (await this.noOverlapsIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (real)', function () {
-    this.noOverlapsRealIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (real)', async function () {
+    (await this.noOverlapsRealIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1103,49 +1103,49 @@ describe('OverlapsAfterDateTime', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps that are after', function () {
-    this.overlapsAfter.exec(this.ctx).should.be.true();
-    this.overlapsContains.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are after', async function () {
+    (await this.overlapsAfter.exec(this.ctx)).should.be.true();
+    (await this.overlapsContains.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept imprecise overlaps that are after', function () {
-    this.impreciseOverlapAfter.exec(this.ctx).should.be.true();
+  it('should accept imprecise overlaps that are after', async function () {
+    (await this.impreciseOverlapAfter.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject overlaps that are not before', function () {
-    this.overlapsBefore.exec(this.ctx).should.be.false();
-    this.overlapsContained.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are not before', async function () {
+    (await this.overlapsBefore.exec(this.ctx)).should.be.false();
+    (await this.overlapsContained.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise overlaps that are not before', function () {
-    this.impreciseOverlapBefore.exec(this.ctx).should.be.false();
+  it('should reject imprecise overlaps that are not before', async function () {
+    (await this.impreciseOverlapBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps', function () {
-    this.noOverlap.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps', async function () {
+    (await this.noOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise non-overlaps', function () {
-    this.noImpreciseOverlap.exec(this.ctx).should.be.false();
+  it('should reject imprecise non-overlaps', async function () {
+    (await this.noImpreciseOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true for imprecise overlaps with matching precision', function () {
-    this.matchingPrecisionOverlap.exec(this.ctx).should.be.true();
+  it('should return true for imprecise overlaps with matching precision', async function () {
+    (await this.matchingPrecisionOverlap.exec(this.ctx)).should.be.true();
   });
 
-  it('should return null for imprecise overlaps that are unknown', function () {
-    should(this.unknownOverlap.exec(this.ctx)).be.null();
+  it('should return null for imprecise overlaps that are unknown', async function () {
+    should(await this.unknownOverlap.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.overlapsBeforeDayOfIvlEdge.exec(this.ctx).should.be.false();
-    this.overlapsAfterDayOfIvlEdge.exec(this.ctx).should.be.true();
-    this.overlapsContainsDayOfIvl.exec(this.ctx).should.be.true();
-    this.overlapsContainedByDayOfIvl.exec(this.ctx).should.be.false();
-    this.notOverlapsDayOfIvl.exec(this.ctx).should.be.false();
-    this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx).should.be.true();
-    this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx).should.be.false();
-    should(this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.overlapsBeforeDayOfIvlEdge.exec(this.ctx)).should.be.false();
+    (await this.overlapsAfterDayOfIvlEdge.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainsDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainedByDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notOverlapsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx)).should.be.true();
+    (await this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -1154,30 +1154,30 @@ describe('OverlapsBefore', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps that are before (integer)', function () {
-    this.overlapsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryIntIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are before (integer)', async function () {
+    (await this.overlapsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryIntIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept overlaps that are before (real)', function () {
-    this.overlapsBeforeRealIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryRealIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are before (real)', async function () {
+    (await this.overlapsBeforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryRealIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject overlaps that are after (integer)', function () {
-    this.overlapsAfterIntIvl.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are after (integer)', async function () {
+    (await this.overlapsAfterIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject overlaps that are after (real)', function () {
-    this.overlapsAfterRealIvl.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are after (real)', async function () {
+    (await this.overlapsAfterRealIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (integer)', function () {
-    this.noOverlapsIntIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (integer)', async function () {
+    (await this.noOverlapsIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (real)', function () {
-    this.noOverlapsRealIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (real)', async function () {
+    (await this.noOverlapsRealIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1186,49 +1186,49 @@ describe('OverlapsBeforeDateTime', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps that are before', function () {
-    this.overlapsBefore.exec(this.ctx).should.be.true();
-    this.overlapsContains.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are before', async function () {
+    (await this.overlapsBefore.exec(this.ctx)).should.be.true();
+    (await this.overlapsContains.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept imprecise overlaps that are before', function () {
-    this.impreciseOverlapBefore.exec(this.ctx).should.be.true();
+  it('should accept imprecise overlaps that are before', async function () {
+    (await this.impreciseOverlapBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject overlaps that are not before', function () {
-    this.overlapsAfter.exec(this.ctx).should.be.false();
-    this.overlapsContained.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are not before', async function () {
+    (await this.overlapsAfter.exec(this.ctx)).should.be.false();
+    (await this.overlapsContained.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise overlaps that are not before', function () {
-    this.impreciseOverlapAfter.exec(this.ctx).should.be.false();
+  it('should reject imprecise overlaps that are not before', async function () {
+    (await this.impreciseOverlapAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps', function () {
-    this.noOverlap.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps', async function () {
+    (await this.noOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise non-overlaps', function () {
-    this.noImpreciseOverlap.exec(this.ctx).should.be.false();
+  it('should reject imprecise non-overlaps', async function () {
+    (await this.noImpreciseOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true for imprecise overlaps with matching precision', function () {
-    this.matchingPrecisionOverlap.exec(this.ctx).should.be.true();
+  it('should return true for imprecise overlaps with matching precision', async function () {
+    (await this.matchingPrecisionOverlap.exec(this.ctx)).should.be.true();
   });
 
-  it('should return null for imprecise overlaps that are unknown', function () {
-    should(this.unknownOverlap.exec(this.ctx)).be.null();
+  it('should return null for imprecise overlaps that are unknown', async function () {
+    should(await this.unknownOverlap.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.overlapsBeforeDayOfIvlEdge.exec(this.ctx).should.be.true();
-    this.overlapsAfterDayOfIvlEdge.exec(this.ctx).should.be.false();
-    this.overlapsContainsDayOfIvl.exec(this.ctx).should.be.true();
-    this.overlapsContainedByDayOfIvl.exec(this.ctx).should.be.false();
-    this.notOverlapsDayOfIvl.exec(this.ctx).should.be.false();
-    this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx).should.be.false();
-    should(this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx).should.be.false();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.overlapsBeforeDayOfIvlEdge.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfterDayOfIvlEdge.exec(this.ctx)).should.be.false();
+    (await this.overlapsContainsDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainedByDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notOverlapsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx)).should.be.false();
+    should(await this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    (await this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1237,54 +1237,54 @@ describe('Width', () => {
     setup(this, data);
   });
 
-  it('should calculate the width of integer intervals', function () {
+  it('should calculate the width of integer intervals', async function () {
     // define IntWidth: width of Interval[-2, 5]
-    this.intWidth.exec(this.ctx).should.equal(7);
+    (await this.intWidth.exec(this.ctx)).should.equal(7);
     // define IntOpenWidth: width of Interval(-2, 5)
-    this.intOpenWidth.exec(this.ctx).should.equal(5);
+    (await this.intOpenWidth.exec(this.ctx)).should.equal(5);
   });
 
-  it('should calculate the width of real intervals', function () {
+  it('should calculate the width of real intervals', async function () {
     // define RealWidth: width of Interval[1.23, 4.56]
-    this.realWidth.exec(this.ctx).should.equal(3.33);
+    (await this.realWidth.exec(this.ctx)).should.equal(3.33);
     // define RealOpenWidth: width of Interval(1.23, 4.56)
-    this.realOpenWidth.exec(this.ctx).should.equal(3.32999998);
+    (await this.realOpenWidth.exec(this.ctx)).should.equal(3.32999998);
   });
 
-  it('should calculate the width of infinite intervals', function () {
+  it('should calculate the width of infinite intervals', async function () {
     // define IntWidthThreeToMax: width of Interval[3, null]
-    this.intWidthThreeToMax.exec(this.ctx).should.equal(Math.pow(2, 31) - 4);
+    (await this.intWidthThreeToMax.exec(this.ctx)).should.equal(Math.pow(2, 31) - 4);
     // define IntWidthMinToThree: width of Interval[null, 3]
-    this.intWidthMinToThree.exec(this.ctx).should.equal(Math.pow(2, 31) + 3);
+    (await this.intWidthMinToThree.exec(this.ctx)).should.equal(Math.pow(2, 31) + 3);
   });
 
-  it('should calculate the width of infinite intervals that result in null', function () {
+  it('should calculate the width of infinite intervals that result in null', async function () {
     // define IntWidthThreeToUnknown: width of Interval[3, null)
-    should(this.intWidthThreeToUnknown.exec(this.ctx)).be.null();
+    should(await this.intWidthThreeToUnknown.exec(this.ctx)).be.null();
     // define IntWidthUnknownToThree: width of Interval(null, 3]
-    should(this.intWidthUnknownToThree.exec(this.ctx)).be.null();
+    should(await this.intWidthUnknownToThree.exec(this.ctx)).be.null();
   });
 
-  it('should calculate the width of interval of quantities', function () {
+  it('should calculate the width of interval of quantities', async function () {
     // define WidthOfQuantityInterval: width of Interval[Quantity{value: 1, unit: 'mm'}, Quantity{value: 10, unit: 'mm'}]
-    const width = this.widthOfQuantityInterval.exec(this.ctx);
+    const width = await this.widthOfQuantityInterval.exec(this.ctx);
     width.value.should.equal(9);
     width.unit.should.equal('mm');
   });
 
   it('should throw for DateTime Intervals', function () {
     // define WidthOfDateTimeInterval: width of Interval[DateTime(2012,01,01), DateTime(2012,01,03)]
-    should(() => this.widthOfDateTimeInterval.exec(this.ctx)).throw();
+    return this.widthOfDateTimeInterval.exec(this.ctx).should.be.rejected();
   });
 
   it('should throw for Date Intervals', function () {
     // define WidthOfDateInterval: width of Interval[Date(2012,01,01), Date(2012,01,03)]
-    should(() => this.widthOfDateInterval.exec(this.ctx)).throw();
+    return this.widthOfDateInterval.exec(this.ctx).should.be.rejected();
   });
 
   it('should throw for Time Intervals', function () {
     // define WidthOfTimeInterval: width of Interval[Time(12,00,00), Time(12,30,02)]
-    should(() => this.widthOfTimeInterval.exec(this.ctx)).throw();
+    return this.widthOfTimeInterval.exec(this.ctx).should.be.rejected();
   });
 });
 
@@ -1293,64 +1293,64 @@ describe('Size', () => {
     setup(this, data);
   });
 
-  it('should calculate the size of integer intervals', function () {
+  it('should calculate the size of integer intervals', async function () {
     // define IntSize: Size(Interval[-2, 5])
-    this.intSize.exec(this.ctx).should.equal(8);
+    (await this.intSize.exec(this.ctx)).should.equal(8);
     // define IntOpenSize: Size(Interval(-2, 5))
-    this.intOpenSize.exec(this.ctx).should.equal(6);
+    (await this.intOpenSize.exec(this.ctx)).should.equal(6);
   });
 
-  it('should calculate the size of real intervals', function () {
+  it('should calculate the size of real intervals', async function () {
     // define RealSize: Size(Interval[1.23, 4.56])
-    this.realSize.exec(this.ctx).should.equal(3.33 + MIN_FLOAT_PRECISION_VALUE);
+    (await this.realSize.exec(this.ctx)).should.equal(3.33 + MIN_FLOAT_PRECISION_VALUE);
     // define RealOpenSize: Size(Interval(1.23, 4.56))
-    this.realOpenSize.exec(this.ctx).should.equal(3.32999998 + MIN_FLOAT_PRECISION_VALUE);
+    (await this.realOpenSize.exec(this.ctx)).should.equal(3.32999998 + MIN_FLOAT_PRECISION_VALUE);
   });
 
-  it('should calculate the size of infinite intervals', function () {
+  it('should calculate the size of infinite intervals', async function () {
     // define IntSizeThreeToMax: Size(Interval[3, null])
-    this.intSizeThreeToMax.exec(this.ctx).should.equal(Math.pow(2, 31) - 4 + 1);
+    (await this.intSizeThreeToMax.exec(this.ctx)).should.equal(Math.pow(2, 31) - 4 + 1);
     // define IntSizeMinToThree: Size(Interval[null, 3])
-    this.intSizeMinToThree.exec(this.ctx).should.equal(Math.pow(2, 31) + 3 + 1);
+    (await this.intSizeMinToThree.exec(this.ctx)).should.equal(Math.pow(2, 31) + 3 + 1);
   });
 
-  it('should calculate the size of infinite intervals that result in null', function () {
+  it('should calculate the size of infinite intervals that result in null', async function () {
     // define IntSizeThreeToUnknown: Size(Interval[3, null))
-    should(this.intSizeThreeToUnknown.exec(this.ctx)).be.null();
+    should(await this.intSizeThreeToUnknown.exec(this.ctx)).be.null();
     // define IntSizeUnknownToThree: Size(Interval(null, 3])
-    should(this.intSizeUnknownToThree.exec(this.ctx)).be.null();
+    should(await this.intSizeUnknownToThree.exec(this.ctx)).be.null();
   });
 
-  it('should return null if integer is null', function () {
+  it('should return null if integer is null', async function () {
     // define SizeIsNull: Size(null as Interval<Integer>)
-    should(this.sizeIsNull.exec(this.ctx)).be.null();
+    should(await this.sizeIsNull.exec(this.ctx)).be.null();
   });
 
-  it('should return null if integer is null', function () {
+  it('should return null if integer is null', async function () {
     // define SizeIsNull: Size(null as Interval<Integer>)
-    should(this.sizeIsNull.exec(this.ctx)).be.null();
+    should(await this.sizeIsNull.exec(this.ctx)).be.null();
   });
 
-  it('should calculate size of interval of quantities', function () {
+  it('should calculate size of interval of quantities', async function () {
     // define SizeOfQuantityInterval: Size(Interval[Quantity{value: 1, unit: 'mm'}, Quantity{value: 10, unit: 'mm'}])
-    const size = this.sizeOfQuantityInterval.exec(this.ctx);
+    const size = await this.sizeOfQuantityInterval.exec(this.ctx);
     size.value.should.equal(10);
     size.unit.should.equal('mm');
   });
 
-  it('should throw for Date Interval', function () {
+  it('should throw for Date Interval', async function () {
     // define SizeOfDateTimeInterval: Size(Interval[DateTime(2012,01,01), DateTime(2012,01,03)])
-    should(() => this.sizeOfDateTimeInterval.exec(this.ctx)).throw();
+    return this.sizeOfDateTimeInterval.exec(this.ctx).should.be.rejected();
   });
 
-  it('should throw for DateTime Interval', function () {
+  it('should throw for DateTime Interval', async function () {
     // define SizeOfDateInterval: Size(Interval[Date(2012,01,01), Date(2012,01,03)])
-    should(() => this.sizeOfDateInterval.exec(this.ctx)).throw();
+    return this.sizeOfDateInterval.exec(this.ctx).should.be.rejected();
   });
 
-  it('should throw for Time Interval', function () {
+  it('should throw for Time Interval', async function () {
     // define SizeOfTimeInterval: Size(Interval[Time(12,00,00), Time(12,30,02)])
-    should(() => this.sizeOfTimeInterval.exec(this.ctx)).throw();
+    return await this.sizeOfTimeInterval.exec(this.ctx).should.be.rejected();
   });
 });
 
@@ -1359,38 +1359,38 @@ describe('Start', () => {
     setup(this, data);
   });
 
-  it('should return the low of the interval', function () {
-    this.closedNotNull.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
+  it('should return the low of the interval', async function () {
+    (await this.closedNotNull.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
   });
 
-  it('should return the minimum possible DateTime', function () {
-    this.closedNullDateTime.exec(this.ctx).should.eql(MIN_DATETIME_VALUE);
+  it('should return the minimum possible DateTime', async function () {
+    (await this.closedNullDateTime.exec(this.ctx)).should.eql(MIN_DATETIME_VALUE);
   });
 
-  it('should return the minimum possible DateTime in timzoneOffset of context', function () {
+  it('should return the minimum possible DateTime in timzoneOffset of context', async function () {
     // set execution timestamp to be +5
     this.ctx.executionDateTime = new DateTime(2019, 10, 1, 12, 31, 31, 2, 5);
-    this.closedNullDateTime.exec(this.ctx).timezoneOffset.should.eql(5);
+    (await this.closedNullDateTime.exec(this.ctx)).timezoneOffset.should.eql(5);
   });
 
-  it('should return the minimum possible Integer', function () {
-    this.closedNullInteger.exec(this.ctx).should.eql(MIN_INT_VALUE);
+  it('should return the minimum possible Integer', async function () {
+    (await this.closedNullInteger.exec(this.ctx)).should.eql(MIN_INT_VALUE);
   });
 
-  it('should return the minimum possible Decimal', function () {
-    this.closedNullDecimal.exec(this.ctx).should.eql(MIN_FLOAT_VALUE);
+  it('should return the minimum possible Decimal', async function () {
+    (await this.closedNullDecimal.exec(this.ctx)).should.eql(MIN_FLOAT_VALUE);
   });
 
-  it('should return null when the interval is null', function () {
-    should(this.nullInterval.exec(this.ctx)).be.null();
+  it('should return null when the interval is null', async function () {
+    should(await this.nullInterval.exec(this.ctx)).be.null();
   });
 
-  it('should return successor of low when the interval is open', function () {
-    this.openNotNull.exec(this.ctx).should.eql(new DateTime(2012, 1, 1).successor());
+  it('should return successor of low when the interval is open', async function () {
+    (await this.openNotNull.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1).successor());
   });
 
-  it('should return null for open interval with null high value', function () {
-    should(this.openNull.exec(this.ctx)).be.null();
+  it('should return null for open interval with null high value', async function () {
+    should(await this.openNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -1399,38 +1399,38 @@ describe('End', () => {
     setup(this, data);
   });
 
-  it('should return the high of the interval', function () {
-    this.closedNotNull.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+  it('should return the high of the interval', async function () {
+    (await this.closedNotNull.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should return the maximum possible DateTime', function () {
-    this.closedNullDateTime.exec(this.ctx).should.eql(MAX_DATETIME_VALUE);
+  it('should return the maximum possible DateTime', async function () {
+    (await this.closedNullDateTime.exec(this.ctx)).should.eql(MAX_DATETIME_VALUE);
   });
 
-  it('should return the maximum possible DateTime in timzoneOffset of context', function () {
+  it('should return the maximum possible DateTime in timzoneOffset of context', async function () {
     // set execution timestamp to be +5
     this.ctx.executionDateTime = new DateTime(2019, 10, 1, 12, 31, 31, 2, 5);
-    this.closedNullDateTime.exec(this.ctx).timezoneOffset.should.eql(5);
+    (await this.closedNullDateTime.exec(this.ctx)).timezoneOffset.should.eql(5);
   });
 
-  it('should return the maximum possible Integer', function () {
-    this.closedNullInteger.exec(this.ctx).should.eql(MAX_INT_VALUE);
+  it('should return the maximum possible Integer', async function () {
+    (await this.closedNullInteger.exec(this.ctx)).should.eql(MAX_INT_VALUE);
   });
 
-  it('should return the maximum possible Decimal', function () {
-    this.closedNullDecimal.exec(this.ctx).should.eql(MAX_FLOAT_VALUE);
+  it('should return the maximum possible Decimal', async function () {
+    (await this.closedNullDecimal.exec(this.ctx)).should.eql(MAX_FLOAT_VALUE);
   });
 
-  it('should return null when the interval is null', function () {
-    should(this.nullInterval.exec(this.ctx)).be.null();
+  it('should return null when the interval is null', async function () {
+    should(await this.nullInterval.exec(this.ctx)).be.null();
   });
 
-  it('should return predecessor of high when the interval is open', function () {
-    this.openNotNull.exec(this.ctx).should.eql(new DateTime(2013, 1, 1).predecessor());
+  it('should return predecessor of high when the interval is open', async function () {
+    (await this.openNotNull.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1).predecessor());
   });
 
-  it('should return null for open interval with null low value', function () {
-    should(this.openNull.exec(this.ctx)).be.null();
+  it('should return null for open interval with null low value', async function () {
+    should(await this.openNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -1439,33 +1439,33 @@ describe('Starts', () => {
     setup(this, data);
   });
 
-  it('should calculate to null', function () {
-    should(this.testStartsNull.exec(this.ctx)).be.null();
+  it('should calculate to null', async function () {
+    should(await this.testStartsNull.exec(this.ctx)).be.null();
   });
 
-  it('should calculate integer intervals properly', function () {
-    this.integerIntervalStartsTrue.exec(this.ctx).should.be.true();
-    this.integerIntervalStartsFalse.exec(this.ctx).should.be.false();
-    this.integerIntervalStartEndsFalse.exec(this.ctx).should.be.false();
+  it('should calculate integer intervals properly', async function () {
+    (await this.integerIntervalStartsTrue.exec(this.ctx)).should.be.true();
+    (await this.integerIntervalStartsFalse.exec(this.ctx)).should.be.false();
+    (await this.integerIntervalStartEndsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate decimal intervals properly', function () {
-    this.decimalIntervalStartsTrue.exec(this.ctx).should.be.true();
-    this.decimalIntervalStartsFalse.exec(this.ctx).should.be.false();
-    this.decimalIntervalStartsEndsFalse.exec(this.ctx).should.be.false();
+  it('should calculate decimal intervals properly', async function () {
+    (await this.decimalIntervalStartsTrue.exec(this.ctx)).should.be.true();
+    (await this.decimalIntervalStartsFalse.exec(this.ctx)).should.be.false();
+    (await this.decimalIntervalStartsEndsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate quantity intervals properly', function () {
-    this.quantityIntervalStartsTrue.exec(this.ctx).should.be.true();
-    this.quantityIntervalStartsFalse.exec(this.ctx).should.be.false();
-    this.quantityIntervalStartsEndsFalse.exec(this.ctx).should.be.false();
+  it('should calculate quantity intervals properly', async function () {
+    (await this.quantityIntervalStartsTrue.exec(this.ctx)).should.be.true();
+    (await this.quantityIntervalStartsFalse.exec(this.ctx)).should.be.false();
+    (await this.quantityIntervalStartsEndsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate datetime intervals properly', function () {
-    this.dateTimeIntervalStartsTrue.exec(this.ctx).should.be.true();
-    this.dateTimeIntervalStartsFalse.exec(this.ctx).should.be.false();
-    this.dateTimeIntervalStartsDayOfTrue.exec(this.ctx).should.be.true();
-    this.dateTimeIntervalStartsEndsFalse.exec(this.ctx).should.be.false();
+  it('should calculate datetime intervals properly', async function () {
+    (await this.dateTimeIntervalStartsTrue.exec(this.ctx)).should.be.true();
+    (await this.dateTimeIntervalStartsFalse.exec(this.ctx)).should.be.false();
+    (await this.dateTimeIntervalStartsDayOfTrue.exec(this.ctx)).should.be.true();
+    (await this.dateTimeIntervalStartsEndsFalse.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1474,33 +1474,33 @@ describe('Ends', () => {
     setup(this, data);
   });
 
-  it('should calculate to null', function () {
-    should(this.testEndsNull.exec(this.ctx)).be.null();
+  it('should calculate to null', async function () {
+    should(await this.testEndsNull.exec(this.ctx)).be.null();
   });
 
-  it('should calculate integer intervals properly', function () {
-    this.integerIntervalEndsTrue.exec(this.ctx).should.be.true();
-    this.integerIntervalEndsFalse.exec(this.ctx).should.be.false();
-    this.integerIntervalEndsStartsFalse.exec(this.ctx).should.be.false();
+  it('should calculate integer intervals properly', async function () {
+    (await this.integerIntervalEndsTrue.exec(this.ctx)).should.be.true();
+    (await this.integerIntervalEndsFalse.exec(this.ctx)).should.be.false();
+    (await this.integerIntervalEndsStartsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate decimal intervals properly', function () {
-    this.decimalIntervalEndsTrue.exec(this.ctx).should.be.true();
-    this.decimalIntervalEndsFalse.exec(this.ctx).should.be.false();
-    this.decimalIntervalEndsStartsFalse.exec(this.ctx).should.be.false();
+  it('should calculate decimal intervals properly', async function () {
+    (await this.decimalIntervalEndsTrue.exec(this.ctx)).should.be.true();
+    (await this.decimalIntervalEndsFalse.exec(this.ctx)).should.be.false();
+    (await this.decimalIntervalEndsStartsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate quantity intervals properly', function () {
-    this.quantityIntervalEndsTrue.exec(this.ctx).should.be.true();
-    this.quantityIntervalEndsFalse.exec(this.ctx).should.be.false();
-    this.quantityIntervalEndsStartsFalse.exec(this.ctx).should.be.false();
+  it('should calculate quantity intervals properly', async function () {
+    (await this.quantityIntervalEndsTrue.exec(this.ctx)).should.be.true();
+    (await this.quantityIntervalEndsFalse.exec(this.ctx)).should.be.false();
+    (await this.quantityIntervalEndsStartsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate datetime intervals properly', function () {
-    this.dateTimeIntervalEndsTrue.exec(this.ctx).should.be.true();
-    this.dateTimeIntervalEndsFalse.exec(this.ctx).should.be.false();
-    this.dateTimeIntervalEndsDayOfTrue.exec(this.ctx).should.be.true();
-    this.dateTimeIntervalEndsStartsFalse.exec(this.ctx).should.be.false();
+  it('should calculate datetime intervals properly', async function () {
+    (await this.dateTimeIntervalEndsTrue.exec(this.ctx)).should.be.true();
+    (await this.dateTimeIntervalEndsFalse.exec(this.ctx)).should.be.false();
+    (await this.dateTimeIntervalEndsDayOfTrue.exec(this.ctx)).should.be.true();
+    (await this.dateTimeIntervalEndsStartsFalse.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1509,67 +1509,67 @@ describe('IntegerIntervalUnion', () => {
     setup(this, data);
   });
 
-  it('should properly calculate open and closed unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    let y = this.intClosedUnionClosed.exec(this.ctx);
+  it('should properly calculate open and closed unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    let y = await this.intClosedUnionClosed.exec(this.ctx);
     y.equals(x).should.be.true();
 
-    y = this.intClosedUnionOpen.exec(this.ctx);
+    y = await this.intClosedUnionOpen.exec(this.ctx);
     y.contains(0).should.be.true();
     y.contains(10).should.be.false();
 
-    y = this.intOpenUnionOpen.exec(this.ctx);
+    y = await this.intOpenUnionOpen.exec(this.ctx);
     y.contains(0).should.be.false();
     y.contains(10).should.be.false();
 
-    y = this.intOpenUnionClosed.exec(this.ctx);
+    y = await this.intOpenUnionClosed.exec(this.ctx);
     y.contains(0).should.be.false();
     y.contains(10).should.be.true();
   });
 
-  it('should properly calculate sameAs unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intSameAsUnion.exec(this.ctx);
+  it('should properly calculate sameAs unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intSameAsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate before/after unions', function () {
-    should(this.intBeforeUnion.exec(this.ctx)).be.null();
+  it('should properly calculate before/after unions', async function () {
+    should(await this.intBeforeUnion.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate meets unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intMeetsUnion.exec(this.ctx);
+  it('should properly calculate meets unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intMeetsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intOverlapsUnion.exec(this.ctx);
+  it('should properly calculate left/right overlapping unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intOverlapsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intBeginsUnion.exec(this.ctx);
+  it('should properly calculate begins/begun by unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intBeginsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate includes/included by unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intDuringUnion.exec(this.ctx);
+  it('should properly calculate includes/included by unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intDuringUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate ends/ended by unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intEndsUnion.exec(this.ctx);
+  it('should properly calculate ends/ended by unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intEndsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly handle null unions', function () {
-    should(this.nullUnion.exec(this.ctx)).be.null();
-    should(this.unionNull.exec(this.ctx)).be.null();
+  it('should properly handle null unions', async function () {
+    should(await this.nullUnion.exec(this.ctx)).be.null();
+    should(await this.unionNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -1581,64 +1581,64 @@ describe('DateTimeIntervalUnion', () => {
     setup(this, data);
   });
 
-  it('should properly calculate open and closed unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    let y = this.dateTimeClosedUnionClosed.exec(this.ctx);
+  it('should properly calculate open and closed unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    let y = await this.dateTimeClosedUnionClosed.exec(this.ctx);
     y.equals(x).should.be.true();
 
     const a = new DateTime(2012, 1, 1, 0, 0, 0, 0);
     const b = new DateTime(2013, 1, 1, 0, 0, 0, 0);
 
-    y = this.dateTimeClosedUnionOpen.exec(this.ctx);
+    y = await this.dateTimeClosedUnionOpen.exec(this.ctx);
     y.contains(a).should.be.true();
     y.contains(b).should.be.false();
 
-    y = this.dateTimeOpenUnionOpen.exec(this.ctx);
+    y = await this.dateTimeOpenUnionOpen.exec(this.ctx);
     y.contains(a).should.be.false();
     y.contains(b).should.be.false();
 
-    y = this.dateTimeOpenUnionClosed.exec(this.ctx);
+    y = await this.dateTimeOpenUnionClosed.exec(this.ctx);
     y.contains(a).should.be.false();
     y.contains(b).should.be.true();
   });
 
-  it('should properly calculate sameAs unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeSameAsUnion.exec(this.ctx);
+  it('should properly calculate sameAs unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeSameAsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate before/after unions', function () {
-    should(this.dateTimeBeforeUnion.exec(this.ctx)).be.null();
+  it('should properly calculate before/after unions', async function () {
+    should(await this.dateTimeBeforeUnion.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate meets unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeMeetsUnion.exec(this.ctx);
+  it('should properly calculate meets unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeMeetsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeOverlapsUnion.exec(this.ctx);
+  it('should properly calculate left/right overlapping unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeOverlapsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeBeginsUnion.exec(this.ctx);
+  it('should properly calculate begins/begun by unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeBeginsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate includes/included by unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeDuringUnion.exec(this.ctx);
+  it('should properly calculate includes/included by unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeDuringUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate ends/ended by unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeEndsUnion.exec(this.ctx);
+  it('should properly calculate ends/ended by unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeEndsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 });
@@ -1651,36 +1651,36 @@ describe('IntegerIntervalExcept', () => {
     setup(this, data);
   });
 
-  it('should properly calculate sameAs except', function () {
-    should(this.intSameAsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate sameAs except', async function () {
+    should(await this.intSameAsExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate before/after except', function () {
-    this.intBeforeExcept.exec(this.ctx).should.eql(new Interval(0, 4));
+  it('should properly calculate before/after except', async function () {
+    (await this.intBeforeExcept.exec(this.ctx)).should.eql(new Interval(0, 4));
   });
 
-  it('should properly calculate meets except', function () {
-    const x = this.intHalfInterval.exec(this.ctx);
-    const y = this.intMeetsExcept.exec(this.ctx);
+  it('should properly calculate meets except', async function () {
+    const x = await this.intHalfInterval.exec(this.ctx);
+    const y = await this.intMeetsExcept.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping except', function () {
-    const x = this.intHalfInterval.exec(this.ctx);
-    const y = this.intOverlapsExcept.exec(this.ctx);
+  it('should properly calculate left/right overlapping except', async function () {
+    const x = await this.intHalfInterval.exec(this.ctx);
+    const y = await this.intOverlapsExcept.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by except', function () {
-    should(this.intBeginsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate begins/begun by except', async function () {
+    should(await this.intBeginsExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate includes/included by except', function () {
-    should(this.intDuringExcept.exec(this.ctx)).be.null();
+  it('should properly calculate includes/included by except', async function () {
+    should(await this.intDuringExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate ends/ended by except', function () {
-    should(this.intEndsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate ends/ended by except', async function () {
+    should(await this.intEndsExcept.exec(this.ctx)).be.null();
   });
 });
 
@@ -1692,40 +1692,38 @@ describe('DateTimeIntervalExcept', () => {
     setup(this, data);
   });
 
-  it('should properly calculate sameAs except', function () {
-    should(this.dateTimeSameAsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate sameAs except', async function () {
+    should(await this.dateTimeSameAsExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate before/after except', function () {
-    this.dateTimeBeforeExcept
-      .exec(this.ctx)
-      .should.eql(
-        new Interval(new DateTime(2012, 1, 1, 0, 0, 0, 0), new DateTime(2012, 4, 1, 0, 0, 0, 0))
-      );
+  it('should properly calculate before/after except', async function () {
+    (await this.dateTimeBeforeExcept.exec(this.ctx)).should.eql(
+      new Interval(new DateTime(2012, 1, 1, 0, 0, 0, 0), new DateTime(2012, 4, 1, 0, 0, 0, 0))
+    );
   });
 
-  it('should properly calculate meets except', function () {
-    const x = this.dateTimeHalfInterval.exec(this.ctx);
-    const y = this.dateTimeMeetsExcept.exec(this.ctx);
+  it('should properly calculate meets except', async function () {
+    const x = await this.dateTimeHalfInterval.exec(this.ctx);
+    const y = await this.dateTimeMeetsExcept.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping except', function () {
-    const x = this.dateTimeHalfInterval.exec(this.ctx);
-    const y = this.dateTimeOverlapsExcept.exec(this.ctx);
+  it('should properly calculate left/right overlapping except', async function () {
+    const x = await this.dateTimeHalfInterval.exec(this.ctx);
+    const y = await this.dateTimeOverlapsExcept.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by except', function () {
-    should(this.dateTimeBeginsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate begins/begun by except', async function () {
+    should(await this.dateTimeBeginsExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate includes/included by except', function () {
-    should(this.dateTimeDuringExcept.exec(this.ctx)).be.null();
+  it('should properly calculate includes/included by except', async function () {
+    should(await this.dateTimeDuringExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate ends/ended by except', function () {
-    should(this.dateTimeEndsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate ends/ended by except', async function () {
+    should(await this.dateTimeEndsExcept.exec(this.ctx)).be.null();
   });
 });
 
@@ -1737,43 +1735,43 @@ describe('IntegerIntervalIntersect', () => {
     setup(this, data);
   });
 
-  it('should properly calculate sameAs intersect', function () {
-    const x = this.intSameAsIntersect.exec(this.ctx);
-    const y = this.intFullInterval.exec(this.ctx);
+  it('should properly calculate sameAs intersect', async function () {
+    const x = await this.intSameAsIntersect.exec(this.ctx);
+    const y = await this.intFullInterval.exec(this.ctx);
     x.equals(y).should.be.true();
   });
 
-  it('should properly calculate before/after intersect', function () {
-    should(this.intBeforeIntersect.exec(this.ctx)).be.null();
+  it('should properly calculate before/after intersect', async function () {
+    should(await this.intBeforeIntersect.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate meets intersect', function () {
-    const x = this.intMeetsInterval.exec(this.ctx);
-    const y = this.intMeetsIntersect.exec(this.ctx);
+  it('should properly calculate meets intersect', async function () {
+    const x = await this.intMeetsInterval.exec(this.ctx);
+    const y = await this.intMeetsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping intersect', function () {
-    const x = this.intOverlapsInterval.exec(this.ctx);
-    const y = this.intOverlapsIntersect.exec(this.ctx);
+  it('should properly calculate left/right overlapping intersect', async function () {
+    const x = await this.intOverlapsInterval.exec(this.ctx);
+    const y = await this.intOverlapsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by intersect', function () {
-    const x = this.intBeginsInterval.exec(this.ctx);
-    const y = this.intBeginsIntersect.exec(this.ctx);
+  it('should properly calculate begins/begun by intersect', async function () {
+    const x = await this.intBeginsInterval.exec(this.ctx);
+    const y = await this.intBeginsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate includes/included by intersect', function () {
-    const x = this.intDuringInterval.exec(this.ctx);
-    const y = this.intDuringIntersect.exec(this.ctx);
+  it('should properly calculate includes/included by intersect', async function () {
+    const x = await this.intDuringInterval.exec(this.ctx);
+    const y = await this.intDuringIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate ends/ended by intersect', function () {
-    const x = this.intEndsInterval.exec(this.ctx);
-    const y = this.intEndsIntersect.exec(this.ctx);
+  it('should properly calculate ends/ended by intersect', async function () {
+    const x = await this.intEndsInterval.exec(this.ctx);
+    const y = await this.intEndsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 });
@@ -1783,43 +1781,43 @@ describe('DateTimeIntervalIntersect', () => {
     setup(this, data);
   });
 
-  it('should properly calculate sameAs intersect', function () {
-    const x = this.dateTimeSameAsIntersect.exec(this.ctx);
-    const y = this.dateTimeFullInterval.exec(this.ctx);
+  it('should properly calculate sameAs intersect', async function () {
+    const x = await this.dateTimeSameAsIntersect.exec(this.ctx);
+    const y = await this.dateTimeFullInterval.exec(this.ctx);
     x.equals(y).should.be.true();
   });
 
-  it('should properly calculate before/after intersect', function () {
-    should(this.dateTimeBeforeIntersect.exec(this.ctx)).be.null();
+  it('should properly calculate before/after intersect', async function () {
+    should(await this.dateTimeBeforeIntersect.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate meets intersect', function () {
-    const x = this.dateTimeMeetsInterval.exec(this.ctx);
-    const y = this.dateTimeMeetsIntersect.exec(this.ctx);
+  it('should properly calculate meets intersect', async function () {
+    const x = await this.dateTimeMeetsInterval.exec(this.ctx);
+    const y = await this.dateTimeMeetsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping intersect', function () {
-    const x = this.dateTimeOverlapsInterval.exec(this.ctx);
-    const y = this.dateTimeOverlapsIntersect.exec(this.ctx);
+  it('should properly calculate left/right overlapping intersect', async function () {
+    const x = await this.dateTimeOverlapsInterval.exec(this.ctx);
+    const y = await this.dateTimeOverlapsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by intersect', function () {
-    const x = this.dateTimeBeginsInterval.exec(this.ctx);
-    const y = this.dateTimeBeginsIntersect.exec(this.ctx);
+  it('should properly calculate begins/begun by intersect', async function () {
+    const x = await this.dateTimeBeginsInterval.exec(this.ctx);
+    const y = await this.dateTimeBeginsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate includes/included by intersect', function () {
-    const x = this.dateTimeDuringInterval.exec(this.ctx);
-    const y = this.dateTimeDuringIntersect.exec(this.ctx);
+  it('should properly calculate includes/included by intersect', async function () {
+    const x = await this.dateTimeDuringInterval.exec(this.ctx);
+    const y = await this.dateTimeDuringIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate ends/ended by intersect', function () {
-    const x = this.dateTimeEndsInterval.exec(this.ctx);
-    const y = this.dateTimeEndsIntersect.exec(this.ctx);
+  it('should properly calculate ends/ended by intersect', async function () {
+    const x = await this.dateTimeEndsInterval.exec(this.ctx);
+    const y = await this.dateTimeEndsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 });
@@ -1832,41 +1830,49 @@ describe('IntegerIntervalCollapse', () => {
     setup(this, data);
   });
 
-  it('empty interval collapses to empty', function () {
-    this.intCollapseEmpty.exec(this.ctx).should.eql(this.intEmptyIntervalList.exec(this.ctx));
+  it('empty interval collapses to empty', async function () {
+    (await this.intCollapseEmpty.exec(this.ctx)).should.eql(
+      await this.intEmptyIntervalList.exec(this.ctx)
+    );
   });
 
-  it('single interval list collapse to self', function () {
-    this.intCollapseSingleInterval
-      .exec(this.ctx)
-      .should.eql(this.int1_10IntervalList.exec(this.ctx));
+  it('single interval list collapse to self', async function () {
+    (await this.intCollapseSingleInterval.exec(this.ctx)).should.eql(
+      await this.int1_10IntervalList.exec(this.ctx)
+    );
   });
 
-  it('disjoint intervals list collapses to ordered self', function () {
-    this.intCollapseDisjoint.exec(this.ctx).should.eql(this.intTwoItemDisjointList.exec(this.ctx));
-    this.intCollapseDisjointReversed
-      .exec(this.ctx)
-      .should.eql(this.intTwoItemDisjointList.exec(this.ctx));
+  it('disjoint intervals list collapses to ordered self', async function () {
+    (await this.intCollapseDisjoint.exec(this.ctx)).should.eql(
+      await this.intTwoItemDisjointList.exec(this.ctx)
+    );
+    (await this.intCollapseDisjointReversed.exec(this.ctx)).should.eql(
+      await this.intTwoItemDisjointList.exec(this.ctx)
+    );
   });
 
-  it('adjacent intervals list combines', function () {
-    this.intCollapseAdjacent.exec(this.ctx).should.eql(this.int1_15IntervalList.exec(this.ctx));
+  it('adjacent intervals list combines', async function () {
+    (await this.intCollapseAdjacent.exec(this.ctx)).should.eql(
+      await this.int1_15IntervalList.exec(this.ctx)
+    );
   });
 
-  it('overlapping intervals list combine', function () {
-    this.intCollapseOverlap.exec(this.ctx).should.eql(this.int1_12IntervalList.exec(this.ctx));
-    this.intCollapseOverlapContained
-      .exec(this.ctx)
-      .should.eql(this.int1_15IntervalList.exec(this.ctx));
-    this.intCollapseOverlapContainedEdge
-      .exec(this.ctx)
-      .should.eql(this.int1_10IntervalList.exec(this.ctx));
-    this.intCollapseOverlapContainedEdge2
-      .exec(this.ctx)
-      .should.eql(this.int1_15IntervalList.exec(this.ctx));
-    this.intCollapseOverlapMultipleCombine
-      .exec(this.ctx)
-      .should.eql(this.int1_15IntervalList.exec(this.ctx));
+  it('overlapping intervals list combine', async function () {
+    (await this.intCollapseOverlap.exec(this.ctx)).should.eql(
+      await this.int1_12IntervalList.exec(this.ctx)
+    );
+    (await this.intCollapseOverlapContained.exec(this.ctx)).should.eql(
+      await this.int1_15IntervalList.exec(this.ctx)
+    );
+    (await this.intCollapseOverlapContainedEdge.exec(this.ctx)).should.eql(
+      await this.int1_10IntervalList.exec(this.ctx)
+    );
+    (await this.intCollapseOverlapContainedEdge2.exec(this.ctx)).should.eql(
+      await this.int1_15IntervalList.exec(this.ctx)
+    );
+    (await this.intCollapseOverlapMultipleCombine.exec(this.ctx)).should.eql(
+      await this.int1_15IntervalList.exec(this.ctx)
+    );
   });
 });
 
@@ -1875,65 +1881,65 @@ describe('DateTimeIntervalCollapse', () => {
     setup(this, data);
   });
 
-  it('empty interval collapses to empty', function () {
-    this.dateTimeCollapseEmpty
-      .exec(this.ctx)
-      .should.eql(this.dateTimeEmptyIntervalList.exec(this.ctx));
+  it('empty interval collapses to empty', async function () {
+    (await this.dateTimeCollapseEmpty.exec(this.ctx)).should.eql(
+      await this.dateTimeEmptyIntervalList.exec(this.ctx)
+    );
   });
 
-  it('single interval list collapse to self', function () {
-    this.dateTimeCollapseSingleInterval
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_10IntervalList.exec(this.ctx));
+  it('single interval list collapse to self', async function () {
+    (await this.dateTimeCollapseSingleInterval.exec(this.ctx)).should.eql(
+      await this.dateTime1_10IntervalList.exec(this.ctx)
+    );
   });
 
-  it('disjoint intervals list collapses to ordered self', function () {
-    this.dateTimeCollapseDisjoint
-      .exec(this.ctx)
-      .should.eql(this.dateTimeTwoItemDisjointList.exec(this.ctx));
+  it('disjoint intervals list collapses to ordered self', async function () {
+    (await this.dateTimeCollapseDisjoint.exec(this.ctx)).should.eql(
+      await this.dateTimeTwoItemDisjointList.exec(this.ctx)
+    );
   });
 
-  it('reversed disjoint intervals list collapses to ordered self', function () {
-    this.dateTimeCollapseDisjointReversed
-      .exec(this.ctx)
-      .should.eql(this.dateTimeTwoItemDisjointList.exec(this.ctx));
+  it('reversed disjoint intervals list collapses to ordered self', async function () {
+    (await this.dateTimeCollapseDisjointReversed.exec(this.ctx)).should.eql(
+      await this.dateTimeTwoItemDisjointList.exec(this.ctx)
+    );
   });
 
-  it('adjacent intervals list combines', function () {
-    this.dateTimeCollapseAdjacent
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
+  it('adjacent intervals list combines', async function () {
+    (await this.dateTimeCollapseAdjacent.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
   });
 
-  it('overlapping intervals list combine', function () {
-    this.dateTimeCollapseOverlap
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_12IntervalList.exec(this.ctx));
-    this.dateTimeCollapseOverlapContained
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
-    this.dateTimeCollapseOverlapContainedEdge
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_10IntervalList.exec(this.ctx));
-    this.dateTimeCollapseOverlapContainedEdge2
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
-    this.dateTimeCollapseOverlapMultipleCombine
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
+  it('overlapping intervals list combine', async function () {
+    (await this.dateTimeCollapseOverlap.exec(this.ctx)).should.eql(
+      await this.dateTime1_12IntervalList.exec(this.ctx)
+    );
+    (await this.dateTimeCollapseOverlapContained.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
+    (await this.dateTimeCollapseOverlapContainedEdge.exec(this.ctx)).should.eql(
+      await this.dateTime1_10IntervalList.exec(this.ctx)
+    );
+    (await this.dateTimeCollapseOverlapContainedEdge2.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
+    (await this.dateTimeCollapseOverlapMultipleCombine.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
   });
 
-  it('throws collapsing imprecise interval', function () {
-    this.dateTimeCollapseImpreciseBoundary
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_10IntervalList.exec(this.ctx));
+  it('throws collapsing imprecise interval', async function () {
+    (await this.dateTimeCollapseImpreciseBoundary.exec(this.ctx)).should.eql(
+      await this.dateTime1_10IntervalList.exec(this.ctx)
+    );
   });
 
-  it('should not modify collapse parameters', function () {
+  it('should not modify collapse parameters', async function () {
     const interval1CopyString = this.dateTime1_6Interval.toString();
     const interval2CopyString = this.dateTime5_12Interval.toString();
     const interval3CopyString = this.dateTime10_15Interval.toString();
-    this.dateTimeCollapseOverlapMultipleCombine.exec(this.ctx);
+    await this.dateTimeCollapseOverlapMultipleCombine.exec(this.ctx);
     this.dateTime1_6Interval.toString().should.eql(interval1CopyString);
     this.dateTime5_12Interval.toString().should.eql(interval2CopyString);
     this.dateTime10_15Interval.toString().should.eql(interval3CopyString);
@@ -1945,203 +1951,219 @@ describe('Collapse', () => {
     setup(this, data);
   });
 
-  it('numeric collapse uses "1" as default per unit', function () {
-    this.intCollapseNoPer.exec(this.ctx).should.eql(this.intCollapsePerUnit1.exec(this.ctx));
+  it('numeric collapse uses "1" as default per unit', async function () {
+    (await this.intCollapseNoPer.exec(this.ctx)).should.eql(
+      await this.intCollapsePerUnit1.exec(this.ctx)
+    );
   });
 
-  it('combines intervals separated by less than per unit', function () {
-    this.intCollapseSeparatedListPer3
-      .exec(this.ctx)
-      .should.eql(this.expectedIntervalList.exec(this.ctx));
+  it('combines intervals separated by less than per unit', async function () {
+    (await this.intCollapseSeparatedListPer3.exec(this.ctx)).should.eql(
+      await this.expectedIntervalList.exec(this.ctx)
+    );
   });
 
-  it('DateTime collapse uses 1 ms as default per unit', function () {
+  it('DateTime collapse uses 1 ms as default per unit', async function () {
     // TODO: spec says to determine this based on width of successor, but Bonnie
     // will only ever have fully-defined dates. Implement successor way if time.
-    this.dateTimeCollapseNoPer.exec(this.ctx).should.eql(this.dateTimeCollapsePerMs.exec(this.ctx));
+    (await this.dateTimeCollapseNoPer.exec(this.ctx)).should.eql(
+      await this.dateTimeCollapsePerMs.exec(this.ctx)
+    );
   });
 
-  it('DateTime with null end collapse with no overlap', function () {
-    this.dateTimeNullEndCollapseNoOverlap
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullEndCollapseNoOverlapExpected.exec(this.ctx));
+  it('DateTime with null end collapse with no overlap', async function () {
+    (await this.dateTimeNullEndCollapseNoOverlap.exec(this.ctx)).should.eql(
+      await this.dateTimeNullEndCollapseNoOverlapExpected.exec(this.ctx)
+    );
   });
 
-  it('DateTime with null start collapse with no overlap', function () {
-    this.dateTimeNullStartCollapseNoOverlap
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullStartCollapseNoOverlapExpected.exec(this.ctx));
+  it('DateTime with null start collapse with no overlap', async function () {
+    (await this.dateTimeNullStartCollapseNoOverlap.exec(this.ctx)).should.eql(
+      await this.dateTimeNullStartCollapseNoOverlapExpected.exec(this.ctx)
+    );
   });
 
-  it('combines DateTime intervals separated by less than per unit', function () {
-    this.dateTimeCollapsePerDay
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
+  it('combines DateTime intervals separated by less than per unit', async function () {
+    (await this.dateTimeCollapsePerDay.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
   });
 
-  it('Date collapse overlapping intervals with no per', function () {
-    this.overlappingDateCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.date1_15Interval.exec(this.ctx)]);
+  it('Date collapse overlapping intervals with no per', async function () {
+    (await this.overlappingDateCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.date1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Date collapse adjacent intervals with no per', function () {
-    this.adjacentDateCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.date1_15Interval.exec(this.ctx)]);
+  it('Date collapse adjacent intervals with no per', async function () {
+    (await this.adjacentDateCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.date1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Date collapse disjoint intervals with no per', function () {
-    this.disjointDateCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.date1_2Interval.exec(this.ctx), this.date4_15Interval.exec(this.ctx)]);
+  it('Date collapse disjoint intervals with no per', async function () {
+    (await this.disjointDateCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.date1_2Interval.exec(this.ctx),
+      await this.date4_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Date collapse per day', function () {
-    this.dateCollapsePerDay
-      .exec(this.ctx)
-      .should.eql([this.date1_2Interval.exec(this.ctx), this.date4_15Interval.exec(this.ctx)]);
+  it('Date collapse per day', async function () {
+    (await this.dateCollapsePerDay.exec(this.ctx)).should.eql([
+      await this.date1_2Interval.exec(this.ctx),
+      await this.date4_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Date collapse per month', function () {
-    this.dateCollapsePerMonth.exec(this.ctx).should.eql([this.date1_15Interval.exec(this.ctx)]);
+  it('Date collapse per month', async function () {
+    (await this.dateCollapsePerMonth.exec(this.ctx)).should.eql([
+      await this.date1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse overlapping intervals with no per', function () {
-    this.overlappingTimeCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.time1_15Interval.exec(this.ctx)]);
+  it('Time collapse overlapping intervals with no per', async function () {
+    (await this.overlappingTimeCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.time1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse adjacent intervals with no per', function () {
-    this.adjacentTimeCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.time1_15Interval.exec(this.ctx)]);
+  it('Time collapse adjacent intervals with no per', async function () {
+    (await this.adjacentTimeCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.time1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse disjoint intervals with no per', function () {
-    this.disjointTimeCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.time1_2Interval.exec(this.ctx), this.time4_15Interval.exec(this.ctx)]);
+  it('Time collapse disjoint intervals with no per', async function () {
+    (await this.disjointTimeCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.time1_2Interval.exec(this.ctx),
+      await this.time4_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse per second', function () {
-    this.timeCollapsePerSecond
-      .exec(this.ctx)
-      .should.eql([this.time1_2Interval.exec(this.ctx), this.time4_15Interval.exec(this.ctx)]);
+  it('Time collapse per second', async function () {
+    (await this.timeCollapsePerSecond.exec(this.ctx)).should.eql([
+      await this.time1_2Interval.exec(this.ctx),
+      await this.time4_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse per minute', function () {
-    this.timeCollapsePerMinute.exec(this.ctx).should.eql([this.time1_15Interval.exec(this.ctx)]);
+  it('Time collapse per minute', async function () {
+    (await this.timeCollapsePerMinute.exec(this.ctx)).should.eql([
+      await this.time1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Quantity uses default per unit', function () {
-    const quantity_collapse = this.quantityIntervalCollapseNoPer.exec(this.ctx);
-    quantity_collapse.should.eql(this.expectedQuantityList.exec(this.ctx));
-    quantity_collapse.should.eql(this.quantityIntervalCollapsePerUnit1.exec(this.ctx));
+  it('Quantity uses default per unit', async function () {
+    const quantity_collapse = await this.quantityIntervalCollapseNoPer.exec(this.ctx);
+    quantity_collapse.should.eql(await this.expectedQuantityList.exec(this.ctx));
+    quantity_collapse.should.eql(await this.quantityIntervalCollapsePerUnit1.exec(this.ctx));
   });
 
-  it('Quantity with separated intervals', function () {
-    this.collapseSeparatedQuantity
-      .exec(this.ctx)
-      .should.eql(this.quantitySeparatedBy3.exec(this.ctx));
+  it('Quantity with separated intervals', async function () {
+    (await this.collapseSeparatedQuantity.exec(this.ctx)).should.eql(
+      await this.quantitySeparatedBy3.exec(this.ctx)
+    );
   });
 
-  it('Quantity combines disjoint intervals that are within per width', function () {
-    this.collapseSeparatedQuantityPer3
-      .exec(this.ctx)
-      .should.eql(this.expectedSeparatedQuantity.exec(this.ctx));
+  it('Quantity combines disjoint intervals that are within per width', async function () {
+    (await this.collapseSeparatedQuantityPer3.exec(this.ctx)).should.eql(
+      await this.expectedSeparatedQuantity.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units uses point type as default per value', function () {
-    this.collapseDisjointQuantityUnits
-      .exec(this.ctx)
-      .should.eql(this.expectedQuantityUnitsCollapse.exec(this.ctx));
+  it('Quantity with units uses point type as default per value', async function () {
+    (await this.collapseDisjointQuantityUnits.exec(this.ctx)).should.eql(
+      await this.expectedQuantityUnitsCollapse.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units disjoint but within per', function () {
-    this.collapseQuantityUnitsWithinPer
-      .exec(this.ctx)
-      .should.eql(this.expectedQuantityUnitsCollapse.exec(this.ctx));
+  it('Quantity with units disjoint but within per', async function () {
+    (await this.collapseQuantityUnitsWithinPer.exec(this.ctx)).should.eql(
+      await this.expectedQuantityUnitsCollapse.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units disjoint and not within per', function () {
-    this.collapseQuantityUnitsNotWithinPer
-      .exec(this.ctx)
-      .should.eql(this.quantityMeterIntervalList.exec(this.ctx));
+  it('Quantity with units disjoint and not within per', async function () {
+    (await this.collapseQuantityUnitsNotWithinPer.exec(this.ctx)).should.eql(
+      await this.quantityMeterIntervalList.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units with null low value', function () {
-    this.collapseQuantityNullLowUnitsWithinPer
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityNullLowUnitsWithinPerExpected.exec(this.ctx));
+  it('Quantity with units with null low value', async function () {
+    (await this.collapseQuantityNullLowUnitsWithinPer.exec(this.ctx)).should.eql(
+      await this.collapseQuantityNullLowUnitsWithinPerExpected.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units with null low and high values', function () {
-    this.collapseQuantityIntervalListWithNulls
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityIntervalListWithNullsExpected.exec(this.ctx));
+  it('Quantity with units with null low and high values', async function () {
+    (await this.collapseQuantityIntervalListWithNulls.exec(this.ctx)).should.eql(
+      await this.collapseQuantityIntervalListWithNullsExpected.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units with null high value', function () {
-    this.collapseQuantityNullHighUnitsWithinPer
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityNullHighUnitsWithinPerExpected.exec(this.ctx));
+  it('Quantity with units with null high value', async function () {
+    (await this.collapseQuantityNullHighUnitsWithinPer.exec(this.ctx)).should.eql(
+      await this.collapseQuantityNullHighUnitsWithinPerExpected.exec(this.ctx)
+    );
   });
 
-  it('Quantity Intervals no overlap with null low', function () {
-    this.collapseQuantityIntervalListWithNullLowNoOverlap
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityIntervalListWithNullLowNoOverlapExpected.exec(this.ctx));
+  it('Quantity Intervals no overlap with null low', async function () {
+    (await this.collapseQuantityIntervalListWithNullLowNoOverlap.exec(this.ctx)).should.eql(
+      await this.collapseQuantityIntervalListWithNullLowNoOverlapExpected.exec(this.ctx)
+    );
   });
 
-  it('Quantity Intervals no overlap with null high', function () {
-    this.collapseQuantityIntervalListWithNullHighNoOverlap
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityIntervalListWithNullHighNoOverlapExpected.exec(this.ctx));
+  it('Quantity Intervals no overlap with null high', async function () {
+    (await this.collapseQuantityIntervalListWithNullHighNoOverlap.exec(this.ctx)).should.eql(
+      await this.collapseQuantityIntervalListWithNullHighNoOverlapExpected.exec(this.ctx)
+    );
   });
 
-  it('with Interval that has null low values', function () {
-    this.collapseNullLowIntervalList
-      .exec(this.ctx)
-      .should.eql(this.expectedNullLowIntervalCollapse.exec(this.ctx));
+  it('with Interval that has null low values', async function () {
+    (await this.collapseNullLowIntervalList.exec(this.ctx)).should.eql(
+      await this.expectedNullLowIntervalCollapse.exec(this.ctx)
+    );
   });
 
-  it('with Interval that has null high values', function () {
-    this.collapseNullHighIntervalList
-      .exec(this.ctx)
-      .should.eql(this.expectedNullHighIntervalCollapse.exec(this.ctx));
+  it('with Interval that has null high values', async function () {
+    (await this.collapseNullHighIntervalList.exec(this.ctx)).should.eql(
+      await this.expectedNullHighIntervalCollapse.exec(this.ctx)
+    );
   });
 
-  it('with Date Interval that has null start values', function () {
-    this.dateTimeNullStartCollapse
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullStartCollapseExpected.exec(this.ctx));
+  it('with Date Interval that has null start values', async function () {
+    (await this.dateTimeNullStartCollapse.exec(this.ctx)).should.eql(
+      await this.dateTimeNullStartCollapseExpected.exec(this.ctx)
+    );
   });
 
-  it('with Date Interval that has null high values', function () {
-    this.dateTimeNullEndCollapse
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullEndCollapseExpected.exec(this.ctx));
+  it('with Date Interval that has null high values', async function () {
+    (await this.dateTimeNullEndCollapse.exec(this.ctx)).should.eql(
+      await this.dateTimeNullEndCollapseExpected.exec(this.ctx)
+    );
   });
 
-  it('with Date Interval that has null high and low values', function () {
-    this.dateTimeNullStartEndCollapse
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullStartEndCollapseExpected.exec(this.ctx));
+  it('with Date Interval that has null high and low values', async function () {
+    (await this.dateTimeNullStartEndCollapse.exec(this.ctx)).should.eql(
+      await this.dateTimeNullStartEndCollapseExpected.exec(this.ctx)
+    );
   });
 
-  it('should ignore nulls in list of Intervals', function () {
-    this.nullInCollapse.exec(this.ctx).should.eql(this.expectedResultWithNull.exec(this.ctx));
+  it('should ignore nulls in list of Intervals', async function () {
+    (await this.nullInCollapse.exec(this.ctx)).should.eql(
+      await this.expectedResultWithNull.exec(this.ctx)
+    );
   });
 
-  it.skip('should return null if list is null', function () {
+  it.skip('should return null if list is null', async function () {
     // TODO: Translation Error
-    should.not.exist(this.nullCollapse.exec(this.ctx));
+    should.not.exist(await this.nullCollapse.exec(this.ctx));
   });
 
-  it('should use default per unit if per is expicitly null', function () {
-    this.nullPerCollapse.exec(this.ctx).should.eql(this.expectedResultNullPer.exec(this.ctx));
+  it('should use default per unit if per is expicitly null', async function () {
+    (await this.nullPerCollapse.exec(this.ctx)).should.eql(
+      await this.expectedResultNullPer.exec(this.ctx)
+    );
   });
 });
 
@@ -2157,163 +2179,163 @@ describe('DateIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands a closed interval per day', function () {
+  it('expands a closed interval per day', async function () {
     // define ClosedSinglePerDay: expand { Interval[@2018-01-01, @2018-01-03] } per day
-    const a = this.closedSinglePerDay.exec(this.ctx);
+    const a = await this.closedSinglePerDay.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
   });
 
-  it('expands a closed interval per week', function () {
+  it('expands a closed interval per week', async function () {
     // define ClosedSinglePerWeek: expand { Interval[@2018-01-01, @2018-01-21] } per week
-    const a = this.closedSinglePerWeek.exec(this.ctx);
+    const a = await this.closedSinglePerWeek.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }'
     );
   });
 
-  it('expands a closed interval per month', function () {
+  it('expands a closed interval per month', async function () {
     // define ClosedSinglePerMonth: expand { Interval[@2018-01-01, @2018-03-31] } per month
     // define ClosedSinglePerMonthTrunc: expand { Interval[@2018-01-01, @2018-04-29] } per month
-    const a = this.closedSinglePerMonth.exec(this.ctx);
-    const b = this.closedSinglePerMonthTrunc.exec(this.ctx);
+    const a = await this.closedSinglePerMonth.exec(this.ctx);
+    const b = await this.closedSinglePerMonthTrunc.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }');
     prettyList(b).should.equal(
       '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03], [2018-04, 2018-04] }'
     );
   });
 
-  it('expands a closed interval per year', function () {
+  it('expands a closed interval per year', async function () {
     // define ClosedSinglePerYear: expand { Interval[@2016-01-01, @2018-12-32] } per year
     // define ClosedSinglePerYearTrunc: expand { Interval[@2016-01-01, @2019-12-30] } per year
-    const a = this.closedSinglePerYear.exec(this.ctx);
-    const b = this.closedSinglePerYearTrunc.exec(this.ctx);
+    const a = await this.closedSinglePerYear.exec(this.ctx);
+    const b = await this.closedSinglePerYearTrunc.exec(this.ctx);
     prettyList(a).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018] }');
     prettyList(b).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018], [2019, 2019] }');
   });
 
-  it('ignores null item in list', function () {
+  it('ignores null item in list', async function () {
     // define NullInList: expand { Interval[@2018-01-01, @2018-01-03], null } per day
-    const a = this.nullInList.exec(this.ctx);
+    const a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
   });
 
-  it('expands two overlapping intervals', function () {
+  it('expands two overlapping intervals', async function () {
     // define Overlapping: expand { Interval[@2018-01-01, @2018-01-03], Interval[@2018-01-02, @2018-01-04] } per day
-    const a = this.overlapping.exec(this.ctx);
+    const a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03], [2018-01-04, 2018-01-04] }'
     );
   });
 
-  it('expands two non overlapping intervals', function () {
+  it('expands two non overlapping intervals', async function () {
     // define NonOverlapping: expand { Interval[@2018-01-01, @2018-01-03], Interval[@2018-01-08, @2018-01-08] } per day
-    const a = this.nonOverlapping.exec(this.ctx);
+    const a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03], [2018-01-08, 2018-01-08] }'
     );
   });
 
-  it('expands an interval with mid boundaries per day', function () {
+  it('expands an interval with mid boundaries per day', async function () {
     // define MidBoundariesPerDay: expand { Interval[@2017-12-30, @2018-01-01] } per day
-    const a = this.midBoundariesPerDay.exec(this.ctx);
+    const a = await this.midBoundariesPerDay.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2017-12-30, 2017-12-30], [2017-12-31, 2017-12-31], [2018-01-01, 2018-01-01] }'
     );
   });
 
-  it('expands an interval with mid boundaries per month', function () {
+  it('expands an interval with mid boundaries per month', async function () {
     // define MidBoundariesPerMonth: expand { Interval[@2017-11-14, @2018-01-18] } per month
-    const a = this.midBoundariesPerMonth.exec(this.ctx);
+    const a = await this.midBoundariesPerMonth.exec(this.ctx);
     prettyList(a).should.equal('{ [2017-11, 2017-11], [2017-12, 2017-12], [2018-01, 2018-01] }');
   });
 
-  it('expands an interval with mid boundaries per year', function () {
+  it('expands an interval with mid boundaries per year', async function () {
     // define MidBoundariesPerYear: expand { Interval[@2016-04-06, @2018-04-06] } per year
-    const a = this.midBoundariesPerYear.exec(this.ctx);
+    const a = await this.midBoundariesPerYear.exec(this.ctx);
     prettyList(a).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018] }');
   });
 
-  it('expands an interval with default per', function () {
+  it('expands an interval with default per', async function () {
     // define NoPerDefaultDay: expand { Interval[@2018-01-01, @2018-01-03] }
-    let a = this.noPerDefaultDay.exec(this.ctx);
+    let a = await this.noPerDefaultDay.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
 
     // define NoPerDefaultMonth: expand { Interval[@2018-01, @2018-03] }
-    a = this.noPerDefaultMonth.exec(this.ctx);
+    a = await this.noPerDefaultMonth.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }');
 
     // define NoPerDefaultYear: expand { Interval[@2016, @2018] }
-    a = this.noPerDefaultYear.exec(this.ctx);
+    a = await this.noPerDefaultYear.exec(this.ctx);
     prettyList(a).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018] }');
 
     // define NoPerDefaultMonthWithMismatch: expand { Interval[@2016, @2018-03] }
-    a = this.noPerDefaultMonthWithMismatch.exec(this.ctx);
+    a = await this.noPerDefaultMonthWithMismatch.exec(this.ctx);
     prettyList(a).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018] }');
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(@2018-01-01, @2018-01-03] } per day
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }');
 
     // define OpenEnd: expand { Interval[@2018-01-01, @2018-01-03) } per day
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02] }');
 
     // define OpenBoth: expand { Interval(@2018-01-01, @2018-01-03) } per day
-    a = this.openBoth.exec(this.ctx);
+    a = await this.openBoth.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-02, 2018-01-02] }');
   });
 
-  it('handles ends with mismatched precision', function () {
+  it('handles ends with mismatched precision', async function () {
     // define MismatchPrecision: expand { Interval[@2018-01-01, @2018-03] } per month
     let e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.mismatchPrecision.exec(this.ctx)).should.equal(e);
+    prettyList(await this.mismatchPrecision.exec(this.ctx)).should.equal(e);
 
     // define MismatchPrecisionResultLongerThanInput: expand { Interval[@2018-01, @2018-02-28] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02] }';
-    prettyList(this.mismatchPrecisionResultLongerThanInput.exec(this.ctx)).should.equal(e);
+    prettyList(await this.mismatchPrecisionResultLongerThanInput.exec(this.ctx)).should.equal(e);
   });
 
-  it('returns an empty list if we get an empty list', function () {
+  it('returns an empty list if we get an empty list', async function () {
     // define EmptyList: List<Interval<Date>>{}
-    const a = this.emptyList.exec(this.ctx);
+    const a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullOpen: expand { Interval[null, @2018-01-03] } per day
-    let a = this.nullOpen.exec(this.ctx);
+    let a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
 
     // define NullClose: expand { Interval[@2018-01-01, null] } per day
-    a = this.nullClose.exec(this.ctx);
+    a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
 
     // define NullBoth: expand { Interval[null, null] } per day
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns empty list when per is more precise than the interval ends', function () {
+  it('returns empty list when per is more precise than the interval ends', async function () {
     // define MonthDayPer: expand { Interval[@2018-01, @2018-03] } per day
-    this.monthDayPer.exec(this.ctx).should.be.empty();
+    (await this.monthDayPer.exec(this.ctx)).should.be.empty();
   });
 
-  it('returns null when per not applicable', function () {
+  it('returns null when per not applicable', async function () {
     // define BadPerMinute: expand { Interval[@2018-01-01, @2018-01-04] } per minute
-    let a = this.badPerMinute.exec(this.ctx);
+    let a = await this.badPerMinute.exec(this.ctx);
     should.not.exist(a);
 
     // define BadPerGram: expand { Interval[@2018-01-01, @2018-01-04] } per 1 'g'
-    a = this.badPerGram.exec(this.ctx);
+    a = await this.badPerGram.exec(this.ctx);
     should.not.exist(a);
   });
 });
@@ -2323,303 +2345,303 @@ describe('DateTimeIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands a millisecond precision datetime', function () {
+  it('expands a millisecond precision datetime', async function () {
     // define MsPrecPerYear: expand { Interval[@2016-01-01T00:00:00.000+00:00, @2018-01-01T00:00:00.000+00:00] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.msPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMonth: expand { Interval[@2018-01-01T00:00:00.000+00:00, @2018-03-01T00:00:00.000+00:00] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.msPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerWeek: expand { Interval[@2018-01-01T00:00:00.000+00:00, @2018-01-21T00:00:00.000+00:00] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }';
-    prettyList(this.msPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerDay: expand { Interval[@2018-01-01T00:00:00.000+00:00, @2018-01-03T00:00:00.000+00:00] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }';
-    prettyList(this.msPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerDay.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerHour: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T03:00:00.000+00:00] } per hour
     e =
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T03+00:00, 2018-01-01T03+00:00] }';
-    prettyList(this.msPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMinute: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T01:02:00.000+00:00] } per minute
     e =
       '{ [2018-01-01T01:00+00:00, 2018-01-01T01:00+00:00], [2018-01-01T01:01+00:00, 2018-01-01T01:01+00:00], [2018-01-01T01:02+00:00, 2018-01-01T01:02+00:00] }';
-    prettyList(this.msPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMinute.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerSecond: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T01:00:02.000+00:00] } per second
     e =
       '{ [2018-01-01T01:00:00+00:00, 2018-01-01T01:00:00+00:00], [2018-01-01T01:00:01+00:00, 2018-01-01T01:00:01+00:00], [2018-01-01T01:00:02+00:00, 2018-01-01T01:00:02+00:00] }';
-    prettyList(this.msPrecPerSecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerSecond.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMillisecond: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T01:00:00.001+00:00] } per millisecond
     e =
       '{ [2018-01-01T01:00:00.000+00:00, 2018-01-01T01:00:00.000+00:00], [2018-01-01T01:00:00.001+00:00, 2018-01-01T01:00:00.001+00:00] }';
-    prettyList(this.msPrecPerMillisecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMillisecond.exec(this.ctx)).should.equal(e);
   });
 
-  it('expands a second precision datetime', function () {
+  it('expands a second precision datetime', async function () {
     // define SecPrecPerYear: expand { Interval[@2016-01-01T00:00:00+00:00, @2018-01-01T00:00:00+00:00] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.secPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerMonth: expand { Interval[@2018-01-01T00:00:00+00:00, @2018-03-01T00:00:00+00:00] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.secPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerWeek: expand { Interval[@2018-01-01T00:00:00+00:00, @2018-01-21T00:00:00+00:00] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }';
-    prettyList(this.secPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerDay: expand { Interval[@2018-01-01T00:00:00+00:00, @2018-01-03T00:00:00+00:00] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }';
-    prettyList(this.secPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerDay.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerHour: expand { Interval[@2018-01-01T01:00:00+00:00, @2018-01-01T03:00:00+00:00] } per hour
     e =
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T03+00:00, 2018-01-01T03+00:00] }';
-    prettyList(this.secPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerMinute: expand { Interval[@2018-01-01T01:00:00+00:00, @2018-01-01T01:02:00+00:00] } per minute
     e =
       '{ [2018-01-01T01:00+00:00, 2018-01-01T01:00+00:00], [2018-01-01T01:01+00:00, 2018-01-01T01:01+00:00], [2018-01-01T01:02+00:00, 2018-01-01T01:02+00:00] }';
-    prettyList(this.secPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerMinute.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerSecond: expand { Interval[@2018-01-01T01:00:00+00:00, @2018-01-01T01:00:01+00:00] } per second
     e =
       '{ [2018-01-01T01:00:00+00:00, 2018-01-01T01:00:00+00:00], [2018-01-01T01:00:01+00:00, 2018-01-01T01:00:01+00:00] }';
-    prettyList(this.secPrecPerSecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerSecond.exec(this.ctx)).should.equal(e);
 
-    this.secPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.secPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a minute precision datetime', function () {
+  it('expands a minute precision datetime', async function () {
     // define MinPrecPerYear: expand { Interval[@2016-01-01T00:00+00:00, @2018-01-01T00:00+00:00] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.minPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerMonth: expand { Interval[@2018-01-01T00:00+00:00, @2018-03-01T00:00+00:00] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.minPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerWeek: expand { Interval[@2018-01-01T00:00+00:00, @2018-01-21T00:00+00:00] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }';
-    prettyList(this.minPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerDay: expand { Interval[@2018-01-01T00:00+00:00, @2018-01-03T00:00+00:00] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }';
-    prettyList(this.minPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerDay.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerHour: expand { Interval[@2018-01-01T01:00+00:00, @2018-01-01T03:00+00:00] } per hour
     e =
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T03+00:00, 2018-01-01T03+00:00] }';
-    prettyList(this.minPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerMinute: expand { Interval[@2018-01-01T01:00+00:00, @2018-01-01T01:01+00:00] } per minute
     e =
       '{ [2018-01-01T01:00+00:00, 2018-01-01T01:00+00:00], [2018-01-01T01:01+00:00, 2018-01-01T01:01+00:00] }';
-    prettyList(this.minPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerMinute.exec(this.ctx)).should.equal(e);
 
-    this.minPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.minPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.minPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.minPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands an hour precision datetime', function () {
+  it('expands an hour precision datetime', async function () {
     // define HourPrecPerYear: expand { Interval[@2016-01-01T00+00:00, @2018-01-01T00+00:00] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.hourPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define HourPrecPerMonth: expand { Interval[@2018-01-01T00+00:00, @2018-03-01T00+00:00] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.hourPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define HourPrecPerWeek: expand { Interval[@2018-01-01T00+00:00, @2018-01-21T00+00:00] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }';
-    prettyList(this.hourPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define HourPrecPerDay: expand { Interval[@2018-01-01T00+00:00, @2018-01-03T00+00:00] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }';
-    prettyList(this.hourPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerDay.exec(this.ctx)).should.equal(e);
 
     // define HourPrecPerHour: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T02+00:00] } per hour
     e =
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00] }';
-    prettyList(this.hourPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerHour.exec(this.ctx)).should.equal(e);
 
-    this.hourPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.hourPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.hourPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.hourPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.hourPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.hourPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a day precision datetime', function () {
+  it('expands a day precision datetime', async function () {
     // define DayPrecPerYear: expand { Interval[DateTime(2016,01,01), DateTime(2018,01,01)] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.dayPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.dayPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define DayPrecPerMonth: expand { Interval[DateTime(2018,01,01), DateTime(2018,03,01)] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.dayPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.dayPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define DayPrecPerWeek: expand { Interval[DateTime(2018,01,01), DateTime(2018,01,14)] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14] }';
-    prettyList(this.dayPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.dayPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define DayPrecPerDay: expand { Interval[DateTime(2018,01,01), DateTime(2018,01,02)] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02] }';
-    prettyList(this.dayPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.dayPrecPerDay.exec(this.ctx)).should.equal(e);
 
-    this.dayPrecPerHour.exec(this.ctx).should.be.empty();
-    this.dayPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.dayPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.dayPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.dayPrecPerHour.exec(this.ctx)).should.be.empty();
+    (await this.dayPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.dayPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.dayPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a month precision datetime', function () {
+  it('expands a month precision datetime', async function () {
     // define MonthPrecPerYear: expand { Interval[DateTime(2016,01), DateTime(2018,01)] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.monthPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.monthPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define MonthPrecPerMonth: expand { Interval[DateTime(2018,01), DateTime(2018,02)] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02] }';
-    prettyList(this.monthPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.monthPrecPerMonth.exec(this.ctx)).should.equal(e);
 
-    this.monthPrecPerWeek.exec(this.ctx).should.be.empty();
-    this.monthPrecPerDay.exec(this.ctx).should.be.empty();
-    this.monthPrecPerHour.exec(this.ctx).should.be.empty();
-    this.monthPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.monthPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.monthPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.monthPrecPerWeek.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerDay.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerHour.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a year precision datetime', function () {
+  it('expands a year precision datetime', async function () {
     // define YearPrecPerYear: expand { Interval[DateTime(2016), DateTime(2018)] } per year
     const e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.yearPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.yearPrecPerYear.exec(this.ctx)).should.equal(e);
 
-    this.yearPrecPerMonth.exec(this.ctx).should.be.empty();
-    this.yearPrecPerWeek.exec(this.ctx).should.be.empty();
-    this.yearPrecPerDay.exec(this.ctx).should.be.empty();
-    this.yearPrecPerHour.exec(this.ctx).should.be.empty();
-    this.yearPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.yearPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.yearPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.yearPrecPerMonth.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerWeek.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerDay.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerHour.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('ignores null item in list', function () {
+  it('ignores null item in list', async function () {
     // define NullInList: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T01+00:00], null } per hour
-    const a = this.nullInList.exec(this.ctx);
+    const a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-01T01+00:00, 2018-01-01T01+00:00] }');
   });
 
-  it('expands two overlapping intervals', function () {
+  it('expands two overlapping intervals', async function () {
     // define Overlapping: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T03+00:00], Interval[@2018-01-01T02+00:00, @2018-01-01T04+00:00] } per hour
-    const a = this.overlapping.exec(this.ctx);
+    const a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T03+00:00, 2018-01-01T03+00:00], [2018-01-01T04+00:00, 2018-01-01T04+00:00] }'
     );
   });
 
-  it('expands two non overlapping intervals', function () {
+  it('expands two non overlapping intervals', async function () {
     // define NonOverlapping: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T02+00:00], Interval[@2018-01-01T05+00:00, @2018-01-01T05+00:00] } per hour
-    const a = this.nonOverlapping.exec(this.ctx);
+    const a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T05+00:00, 2018-01-01T05+00:00] }'
     );
   });
 
-  it('expands an interval with default per', function () {
+  it('expands an interval with default per', async function () {
     // # define NoPerDefaultMS: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T01:00:00.001+00:00] }
-    let a = this.noPerDefaultMS.exec(this.ctx);
+    let a = await this.noPerDefaultMS.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01:00:00.000+00:00, 2018-01-01T01:00:00.000+00:00], [2018-01-01T01:00:00.001+00:00, 2018-01-01T01:00:00.001+00:00] }'
     );
 
     // # define NoPerDefaultSec: expand { Interval[@2018-01-01T01:00:00+00:00, @2018-01-01T01:00:01+00:00] }
-    a = this.noPerDefaultSec.exec(this.ctx);
+    a = await this.noPerDefaultSec.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01:00:00+00:00, 2018-01-01T01:00:00+00:00], [2018-01-01T01:00:01+00:00, 2018-01-01T01:00:01+00:00] }'
     );
 
     // # define NoPerDefaultMin: expand { Interval[@2018-01-01T01:00+00:00, @2018-01-01T01:01+00:00] }
-    a = this.noPerDefaultMin.exec(this.ctx);
+    a = await this.noPerDefaultMin.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01:00+00:00, 2018-01-01T01:00+00:00], [2018-01-01T01:01+00:00, 2018-01-01T01:01+00:00] }'
     );
 
     // define NoPerDefaultHour: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T01+00:00] }
-    a = this.noPerDefaultHour.exec(this.ctx);
+    a = await this.noPerDefaultHour.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-01T01+00:00, 2018-01-01T01+00:00] }');
 
     // define NoPerDefaultDay: expand { Interval[DateTime(2018,01,01), DateTime(2018,01,01)] }
-    a = this.noPerDefaultDay.exec(this.ctx);
+    a = await this.noPerDefaultDay.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-01, 2018-01-01] }');
 
     // define NoPerDefaultMonth: expand { Interval[DateTime(2018,01), DateTime(2018,01)]  }
-    a = this.noPerDefaultMonth.exec(this.ctx);
+    a = await this.noPerDefaultMonth.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01, 2018-01] }');
 
     // define NoPerDefaultYear: expand { Interval[DateTime(2018), DateTime(2018)]  }
-    a = this.noPerDefaultYear.exec(this.ctx);
+    a = await this.noPerDefaultYear.exec(this.ctx);
     prettyList(a).should.equal('{ [2018, 2018] }');
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(@2018-01-01T01+00:00, @2018-01-03T01+00:00] } per day
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
 
     // define OpenEnd: expand { Interval[@2018-01-01T01+00:00, @2018-01-03T01+00:00) } per day
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
 
     // define OpenBoth: expand { Interval(@2018-01-01T01+00:00, @2018-01-03T01+00:00) } per day
-    a = this.openBoth.exec(this.ctx);
+    a = await this.openBoth.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
   });
 
-  it('handles ends with mismatched precision', function () {
+  it('handles ends with mismatched precision', async function () {
     // define MismatchPrecision: expand { Interval[@2012-01-01T12:00+00:00, @2012-01-02T12:00:00+00:00] } per day
     let e = '{ [2012-01-01, 2012-01-01], [2012-01-02, 2012-01-02] }';
-    prettyList(this.mismatchPrecision.exec(this.ctx)).should.equal(e);
+    prettyList(await this.mismatchPrecision.exec(this.ctx)).should.equal(e);
 
     // define MismatchPrecisionResultLongerThanInput: expand { Interval[@2012-01-01T13:00:00+00:00, @2012-01-02T12:59+00:00] } per day
     e = '{ [2012-01-01, 2012-01-01], [2012-01-02, 2012-01-02] }';
-    prettyList(this.mismatchPrecisionResultLongerThanInput.exec(this.ctx)).should.equal(e);
+    prettyList(await this.mismatchPrecisionResultLongerThanInput.exec(this.ctx)).should.equal(e);
   });
 
-  it('returns an empty list if we get an empty list', function () {
+  it('returns an empty list if we get an empty list', async function () {
     // define EmptyList: List<Interval<Date>>{}
-    const a = this.emptyList.exec(this.ctx);
+    const a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullOpen: expand { Interval[null, @2018-01-03T01+00:00] } per day
-    let a = this.nullOpen.exec(this.ctx);
+    let a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
 
     // define NullClose: expand { Interval[@2018-01-01T01+00:00, null] } per day
-    a = this.nullClose.exec(this.ctx);
+    a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
 
     // define NullBoth: expand { Interval[null, null] } per day
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns null when per not applicable', function () {
+  it('returns null when per not applicable', async function () {
     // define BadPerGram: expand { Interval[@2018-01-01T01+00:00, @2018-01-04T01+00:00] } per 1 'g'
-    const a = this.badPerGram.exec(this.ctx);
+    const a = await this.badPerGram.exec(this.ctx);
     should.not.exist(a);
   });
 });
@@ -2629,61 +2651,61 @@ describe('TimeIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands a millisecond precision time', function () {
+  it('expands a millisecond precision time', async function () {
     // define MsPrecPerHour: expand { Interval[@T01:00:00.000, @T03:00:00.000] } per hour
     let e = '{ [01, 01], [02, 02], [03, 03] }';
-    prettyList(this.msPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMinute: expand { Interval[@T01:00:00.000, @T01:02:00.000] } per minute
     e = '{ [01:00, 01:00], [01:01, 01:01], [01:02, 01:02] }';
-    prettyList(this.msPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMinute.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerSecond: expand { Interval[@T01:00:00.000, @T01:00:02.000] } per second
     e = '{ [01:00:00, 01:00:00], [01:00:01, 01:00:01], [01:00:02, 01:00:02] }';
-    prettyList(this.msPrecPerSecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerSecond.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMillisecond: expand { Interval[@T01:00:00.000, @T01:00:00.001] } per millisecond
     e = '{ [01:00:00.000, 01:00:00.000], [01:00:00.001, 01:00:00.001] }';
-    prettyList(this.msPrecPerMillisecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMillisecond.exec(this.ctx)).should.equal(e);
   });
 
-  it('expands a second precision datetime', function () {
+  it('expands a second precision datetime', async function () {
     // define SecPrecPerHour: expand { Interval[@T01:00:00, @T03:00:00] } per hour
     let e = '{ [01, 01], [02, 02], [03, 03] }';
-    prettyList(this.secPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerMinute: expand { Interval[@T01:00:00, @T01:02:00] } per minute
     e = '{ [01:00, 01:00], [01:01, 01:01], [01:02, 01:02] }';
-    prettyList(this.secPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerMinute.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerSecond: expand { Interval[@T01:00:00, @T01:00:01] } per second
     e = '{ [01:00:00, 01:00:00], [01:00:01, 01:00:01] }';
-    prettyList(this.secPrecPerSecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerSecond.exec(this.ctx)).should.equal(e);
 
-    this.secPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.secPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a minute precision datetime', function () {
+  it('expands a minute precision datetime', async function () {
     // define MinPrecPerHour: expand { Interval[@T01:00, @T03:00] } per hour
     let e = '{ [01, 01], [02, 02], [03, 03] }';
-    prettyList(this.minPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerMinute: expand { Interval[@T01:00, @T01:01] } per minute
     e = '{ [01:00, 01:00], [01:01, 01:01] }';
-    prettyList(this.minPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerMinute.exec(this.ctx)).should.equal(e);
 
-    this.minPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.minPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.minPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.minPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands an hour precision datetime', function () {
+  it('expands an hour precision datetime', async function () {
     // define HourPrecPerHour: expand { Interval[@T01, @T02] } per hour
     const e = '{ [01, 01], [02, 02] }';
-    prettyList(this.hourPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerHour.exec(this.ctx)).should.equal(e);
 
-    this.hourPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.hourPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.hourPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.hourPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.hourPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.hourPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 });
 
@@ -2692,119 +2714,119 @@ describe('QuantityIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands single intervals', function () {
+  it('expands single intervals', async function () {
     // define ClosedSingleGPerG: expand { Interval[2 'g', 4 'g'] } per 1 'g'
-    let a = this.closedSingleGPerG.exec(this.ctx);
+    let a = await this.closedSingleGPerG.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define ClosedSingleGPerGDecimal: expand { Interval[2.1 'g', 4.1 'g'] } per 1 'g'
-    a = this.closedSingleGPerGDecimal.exec(this.ctx);
+    a = await this.closedSingleGPerGDecimal.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define ClosedSingleGPerMG: expand { Interval[2 'g', 2.003 'g'] } per 1 'mg'
-    a = this.closedSingleGPerMG.exec(this.ctx);
+    a = await this.closedSingleGPerMG.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2000 'mg', 2000 'mg'], [2001 'mg', 2001 'mg'], [2002 'mg', 2002 'mg'], [2003 'mg', 2003 'mg'] }"
     );
 
     // define ClosedSingleMGPerGTrunc: expand { Interval[2999 'mg', 4200 'mg'] } per 1 'g'
-    a = this.closedSingleMGPerGTrunc.exec(this.ctx);
+    a = await this.closedSingleMGPerGTrunc.exec(this.ctx);
     prettyList(a).should.equal("{ [2999 'mg', 3998 'mg'] }");
 
     // define ClosedSingleMGPerMGTrunc: expand { Interval[2000 'mg', 4500 'mg'] } per 800 'mg'
-    a = this.closedSingleMGPerMGTrunc.exec(this.ctx);
+    a = await this.closedSingleMGPerMGTrunc.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2000 'mg', 2799 'mg'], [2800 'mg', 3599 'mg'], [3600 'mg', 4399 'mg'] }"
     );
 
     // define ClosedSingleMGPerMGDecimal: expand { Interval[2000.01 'mg', 4500 'mg'] } per 800 'mg'
-    a = this.closedSingleMGPerMGDecimal.exec(this.ctx);
+    a = await this.closedSingleMGPerMGDecimal.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2000 'mg', 2799 'mg'], [2800 'mg', 3599 'mg'], [3600 'mg', 4399 'mg'] }"
     );
   });
 
-  it('expands lists of multiple intervals', function () {
+  it('expands lists of multiple intervals', async function () {
     // define NullInList: expand { Interval[2 'g', 4 'g'], null } per 1 'g'
-    let a = this.nullInList.exec(this.ctx);
+    let a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define Overlapping: expand { Interval[2 'g', 4 'g'], Interval[3 'g', 5 'g'] } per 1 'g'
-    a = this.overlapping.exec(this.ctx);
+    a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'], [5 'g', 5 'g'] }"
     );
 
     // define NonOverlapping: expand { Interval[2 'g', 4 'g'], Interval[6 'g', 6 'g'] } per 1 'g'
-    a = this.nonOverlapping.exec(this.ctx);
+    a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'], [6 'g', 6 'g'] }"
     );
   });
 
-  it('expands interval using the first items units if no per provided', function () {
+  it('expands interval using the first items units if no per provided', async function () {
     // define NoPerDefaultM: expand { Interval[2 'm', 400 'cm'] }
-    let a = this.noPerDefaultM.exec(this.ctx);
+    let a = await this.noPerDefaultM.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'm', 2 'm'], [3 'm', 3 'm'], [4 'm', 4 'm'] }");
 
     // define NoPerDefaultG: expand { Interval[2 'g', 4 'g'] }
-    a = this.noPerDefaultG.exec(this.ctx);
+    a = await this.noPerDefaultG.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(2 'g', 4 'g'] } per 1 'g'
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal("{ [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define OpenEnd: expand { Interval[2 'g', 4 'g') } per 1 'g'
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'] }");
 
     // define OpenBoth: expand { Interval(2 'g', 4 'g') } per 1 'g'
-    a = this.openBoth.exec(this.ctx);
+    a = await this.openBoth.exec(this.ctx);
     prettyList(a).should.equal("{ [3 'g', 3 'g'] }");
 
     // define OpenBothDecimal: expand { Interval(2.1 'g', 4.1 'g') } per 1 'g'
-    a = this.openBothDecimal.exec(this.ctx);
+    a = await this.openBothDecimal.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define OpenBothDecimalTrunc: expand { Interval(2.1 'g', 4.101 'g') } per 1 'g'
-    a = this.openBothDecimalTrunc.exec(this.ctx);
+    a = await this.openBothDecimalTrunc.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
   });
 
-  it('returns an empty list if we get an empty list or if there are no results', function () {
+  it('returns an empty list if we get an empty list or if there are no results', async function () {
     // define EmptyList: List<Interval<Date>>{}
-    let a = this.emptyList.exec(this.ctx);
+    let a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
 
     // define PerTooBig: expand { Interval[2 'g', 4 'g'], null } per 5 'g'
-    a = this.perTooBig.exec(this.ctx);
+    a = await this.perTooBig.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullClose: expand { Interval[2 'g', null] } per 1 'g'
-    let a = this.nullClose.exec(this.ctx);
+    let a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
     // define NullOpen: expand { Interval[null, 4 'g'] } per 1 'g'
-    a = this.nullOpen.exec(this.ctx);
+    a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
     // define NullBoth: expand { Interval[null, null] } per 1 'g'
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns null when per not applicable or mismatch interval', function () {
+  it('returns null when per not applicable or mismatch interval', async function () {
     // define BadPerMinute: expand { Interval(2 'g', 4 'g'] } per 1 minute
-    let a = this.badPerMinute.exec(this.ctx);
+    let a = await this.badPerMinute.exec(this.ctx);
     should.not.exist(a);
 
     // define BadPerGram: expand { Interval(2 'km', 4 'km'] }  per 1 'g'
-    a = this.badPerGram.exec(this.ctx);
+    a = await this.badPerGram.exec(this.ctx);
     should.not.exist(a);
   });
 });
@@ -2814,87 +2836,87 @@ describe('IntegerIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands single intervals', function () {
+  it('expands single intervals', async function () {
     // define ClosedSinglePer1: expand { Interval[2, 4] } per 1 '1'
-    let a = this.closedSinglePer1.exec(this.ctx);
+    let a = await this.closedSinglePer1.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4] }');
 
     // define ClosedSinglePer3: expand { Interval[2, 10] } per 3 '1'
-    a = this.closedSinglePer3.exec(this.ctx);
+    a = await this.closedSinglePer3.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 4], [5, 7], [8, 10] }');
 
     // define ClosedSinglePer3NoteTheWidth: expand { Interval[2, 4] } per 3 '1'
-    a = this.closedSinglePer3NoteTheWidth.exec(this.ctx);
+    a = await this.closedSinglePer3NoteTheWidth.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 4] }');
   });
 
-  it('expands lists of multiple intervals', function () {
+  it('expands lists of multiple intervals', async function () {
     // define NullInList: expand { Interval[2, 4], null } per 1 '1'
-    let a = this.nullInList.exec(this.ctx);
+    let a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4] }');
 
     // define Overlapping: expand { Interval[2, 4], Interval[3, 5] } per 1 '1'
-    a = this.overlapping.exec(this.ctx);
+    a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4], [5, 5] }');
 
     // define NonOverlapping: expand { Interval[2, 4], Interval[6, 6] } per 1 '1'
-    a = this.nonOverlapping.exec(this.ctx);
+    a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4], [6, 6] }');
   });
 
-  it('expands interval using default per of 1', function () {
+  it('expands interval using default per of 1', async function () {
     // define NoPer: expand { Interval[2, 4] }
-    const a = this.noPer.exec(this.ctx);
+    const a = await this.noPer.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4] }');
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(2, 4] } per 1 '1'
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal('{ [3, 3], [4, 4] }');
 
     // define OpenEnd: expand { Interval[2, 4) } per 1 '1'
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3] }');
 
     // define OpenBoth: expand { Interval(2, 4) } per 1 '1'
-    a = this.openBoth.exec(this.ctx);
+    a = await this.openBoth.exec(this.ctx);
     prettyList(a).should.equal('{ [3, 3] }');
   });
 
-  it('returns an empty list if we get an empty list or if there are no results', function () {
+  it('returns an empty list if we get an empty list or if there are no results', async function () {
     // define EmptyList: List<Interval<Integer>>{}
-    let a = this.emptyList.exec(this.ctx);
+    let a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
 
     // define PerTooBig: expand { Interval[2, 4], null } per 5 '1'
-    a = this.perTooBig.exec(this.ctx);
+    a = await this.perTooBig.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullClose: expand { Interval[2, null] } per 1 '1'
-    let a = this.nullClose.exec(this.ctx);
+    let a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
     // define NullOpen: expand { Interval[null, 4] } per 1 '1'
-    a = this.nullOpen.exec(this.ctx);
+    a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
     // define NullBoth: expand { Interval[null, null] } per 1 '1'
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns null when per not applicable or mismatch interval', function () {
+  it('returns null when per not applicable or mismatch interval', async function () {
     // define BadPerMinute: expand { Interval(2, 4] } per 1 minute
-    const a = this.badPerMinute.exec(this.ctx);
+    const a = await this.badPerMinute.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('produces a more precise value for output intervals', function () {
+  it('produces a more precise value for output intervals', async function () {
     // define PerDecimalMorePrecise: expand { Interval[10, 10] } per 0.1
-    const a = this.perDecimalMorePrecise.exec(this.ctx);
+    const a = await this.perDecimalMorePrecise.exec(this.ctx);
     // JavaScript truncates 10.0 to 10.
     prettyList(a).should.equal(
       '{ [10, 10.09999999], [10.1, 10.19999999], [10.2, 10.29999999], [10.3, 10.39999999], [10.4, 10.49999999], [10.5, 10.59999999], [10.6, 10.69999999], [10.7, 10.79999999], [10.8, 10.89999999], [10.9, 10.99999999] }'
@@ -2907,84 +2929,84 @@ describe('DecimalIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands single intervals', function () {
+  it('expands single intervals', async function () {
     // define ClosedSingle: expand { Interval[2, 5] } per 1.5 '1'
-    let a = this.closedSingle.exec(this.ctx);
+    let a = await this.closedSingle.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999], [3.5, 4.99999999] }');
 
     // define ClosedSingle1: expand { Interval[2.5, 10] } per 2 '1'
-    a = this.closedSingle1.exec(this.ctx);
+    a = await this.closedSingle1.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3], [4, 5], [6, 7], [8, 9] }');
 
     // define ClosedSingle2: expand { Interval[2, 4.5] } per 0.5 '1'
-    a = this.closedSingle2.exec(this.ctx);
+    a = await this.closedSingle2.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2, 2.49999999], [2.5, 2.99999999], [3, 3.49999999], [3.5, 3.99999999], [4, 4.49999999] }'
     );
   });
 
-  it('expands lists of multiple intervals', function () {
+  it('expands lists of multiple intervals', async function () {
     // define NullInList: expand { Interval[2, 5], null } per 1.5 '1'
-    let a = this.nullInList.exec(this.ctx);
+    let a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999], [3.5, 4.99999999] }');
 
     // define Overlapping: expand { Interval[2, 5], Interval[4, 7] } per 1.5 '1'
-    a = this.overlapping.exec(this.ctx);
+    a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999], [3.5, 4.99999999], [5, 6.49999999] }');
 
     // define NonOverlapping: expand { Interval[2, 4], Interval[6, 8] } per 1.5 '1'
-    a = this.nonOverlapping.exec(this.ctx);
+    a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999], [6, 7.49999999] }');
   });
 
-  it('expands interval using default per of 1', function () {
+  it('expands interval using default per of 1', async function () {
     // define NoPer: expand { Interval[2.5, 4.5] }
-    const a = this.noPer.exec(this.ctx);
+    const a = await this.noPer.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4] }');
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(2, 5] } per 1.5 '1'
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal('{ [3, 4.49999999] }');
 
     // define OpenEnd: expand { Interval[2, 5) } per 1.5 '1'
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999] }');
 
     // define OpenBoth: expand { Interval(2, 5) } per 1.5 '1'
-    this.openBoth.exec(this.ctx).should.be.empty();
+    (await this.openBoth.exec(this.ctx)).should.be.empty();
   });
 
-  it('returns an empty list if we get an empty list', function () {
+  it('returns an empty list if we get an empty list', async function () {
     // define EmptyList: List<Interval<Decimal>>{}
-    const a = this.emptyList.exec(this.ctx);
+    const a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.should.be.empty();
   });
 
-  it('returns an empty list if we get an interval with a null boundary', function () {
+  it('returns an empty list if we get an interval with a null boundary', async function () {
     // define PerTooBig: expand { Interval[2, 4], null } per 5.5 '1'
-    const a = this.perTooBig.exec(this.ctx);
+    const a = await this.perTooBig.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.should.be.empty();
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullClose: expand { Interval[2, null] } per 1.5 '1'
-    let a = this.nullClose.exec(this.ctx);
+    let a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
     // define NullOpen: expand { Interval[null, 4] } per 1.5 '1'
-    a = this.nullOpen.exec(this.ctx);
+    a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
     // define NullBoth: expand { Interval[null, null] } per 1.5 '1'
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns null when per not applicable or mismatch interval', function () {
+  it('returns null when per not applicable or mismatch interval', async function () {
     // define BadPerMinute: expand { Interval(2.1, 4.1] } per 0.5 minute
-    const a = this.badPerMinute.exec(this.ctx);
+    const a = await this.badPerMinute.exec(this.ctx);
     should.not.exist(a);
   });
 });
@@ -2994,240 +3016,240 @@ describe('SameAs', () => {
     setup(this, data);
   });
 
-  it('returns true when both intervals values are null and closed', function () {
+  it('returns true when both intervals values are null and closed', async function () {
     // define NullBoth: Interval[null,null] same as Interval[null,null]
-    this.nullBoth.exec(this.ctx).should.be.true();
+    (await this.nullBoth.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when one intervals low and high are null', function () {
+  it('returns false when one intervals low and high are null', async function () {
     // define NullOne: Interval[DateTime(2018,01,01), DateTime(2018,02,02)] same as Interval[null,null]
-    this.nullOne.exec(this.ctx).should.be.false();
+    (await this.nullOne.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when both intervals are the same', function () {
+  it('returns true when both intervals are the same', async function () {
     // define Equal: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[DateTime(2018,01,01), DateTime(2018,01,01)]
-    this.equal.exec(this.ctx).should.be.true();
+    (await this.equal.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when both intervals are not the same', function () {
+  it('returns false when both intervals are not the same', async function () {
     // define NotEqual: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[DateTime(2018,02,01), DateTime(2018,05,01)]
-    this.notEqual.exec(this.ctx).should.be.false();
+    (await this.notEqual.exec(this.ctx)).should.be.false();
   });
 
-  it('returns null when comparing date and datetime because precision is changed when converting date to datetime', function () {
+  it('returns null when comparing date and datetime because precision is changed when converting date to datetime', async function () {
     // define DateTimeAndDateComparisonEqual: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[Date(2018,01,01), Date(2018,01,01)]
-    const a = this.dateTimeAndDateComparisonEqual.exec(this.ctx);
+    const a = await this.dateTimeAndDateComparisonEqual.exec(this.ctx);
     should(a).be.null();
   });
 
-  it('returns null when both intervals are null', function () {
+  it('returns null when both intervals are null', async function () {
     // define NullIntervals: (null as Interval<DateTime>) same as (null as Interval<DateTime>)
-    const a = this.nullIntervals.exec(this.ctx);
+    const a = await this.nullIntervals.exec(this.ctx);
     should(a).be.null();
   });
 
-  it('returns true when comparing a closed interval and open interval after it is converted', function () {
+  it('returns true when comparing a closed interval and open interval after it is converted', async function () {
     // define OpenAndClosed: Interval[DateTime(2018,01,01,00,00,00,0), DateTime(2019,01,01,00,00,00,0)) same as Interval[DateTime(2018,01,01,00,00,00,0), DateTime(2018,12,31,23,59,59,999)]
-    this.openAndClosed.exec(this.ctx).should.be.true();
+    (await this.openAndClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when both intervals are open ended', function () {
+  it('returns true when both intervals are open ended', async function () {
     // define OpenEnded: Interval[DateTime(2018,01,01), null] same day as Interval[DateTime(2018,01,01), null]
-    this.openEnded.exec(this.ctx).should.be.true();
+    (await this.openEnded.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when the first interval is open ended and the second is not', function () {
+  it('returns false when the first interval is open ended and the second is not', async function () {
     // define OpenEndedNotSame: Interval[DateTime(2018,01,01), null] same day as Interval[DateTime(2018,01,01), DateTime(2019,01,01)]
-    this.openEndedNotSame.exec(this.ctx).should.be.false();
+    (await this.openEndedNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns false when the second interval is open and the first is not', function () {
+  it('returns false when the second interval is open and the first is not', async function () {
     // define OpenEndedNotSame2: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same day as Interval[DateTime(2018,01,01), null]
-    this.openEndedNotSame2.exec(this.ctx).should.be.false();
+    (await this.openEndedNotSame2.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when both intervals start at null and end at the same time', function () {
+  it('returns true when both intervals start at null and end at the same time', async function () {
     // define OpenBeginningSame: Interval[null,DateTime(2018,01,01)] same as Interval[null,DateTime(2018,01,01)]
-    this.openBeginningSame.exec(this.ctx).should.be.true();
+    (await this.openBeginningSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when one interval starts at null and the other does not', function () {
+  it('returns false when one interval starts at null and the other does not', async function () {
     // define OpenBeginningNotSame: Interval[DateTime(2017,01,01),DateTime(2018,01,01)] same as Interval[null,DateTime(2018,01,01)]
-    this.openBeginningNotSame.exec(this.ctx).should.be.false();
+    (await this.openBeginningNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when comparing a closed interval of Dates to an open interval after it is converted', function () {
+  it('returns true when comparing a closed interval of Dates to an open interval after it is converted', async function () {
     // define DateOpenAndClosed: Interval[Date(2018,01,01), Date(2018,02,02)] same as Interval[Date(2018,01,01), Date(2018,02,03))
-    this.dateOpenAndClosed.exec(this.ctx).should.be.true();
+    (await this.dateOpenAndClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when both Date intervals are open ended', function () {
+  it('returns true when both Date intervals are open ended', async function () {
     // define DateOpenEnded: Interval[Date(2018,01,01), null] same as Interval[Date(2018,01,01), null)]
-    this.dateOpenEnded.exec(this.ctx).should.be.true();
+    (await this.dateOpenEnded.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when comparing a closed interval of Times to an open interval after it is converted', function () {
+  it('returns true when comparing a closed interval of Times to an open interval after it is converted', async function () {
     // define TimeOpenAndClosed: Interval[Time(01,01), Time(02,02)] same as Interval[Time(01,01), Time(02,03))
-    this.timeOpenAndClosed.exec(this.ctx).should.be.true();
+    (await this.timeOpenAndClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when both Time intervals are open ended', function () {
+  it('returns true when both Time intervals are open ended', async function () {
     // define TimeOpenEnded: Interval[Time(01,01), null] same as Interval[Time(01,01), null)]
-    this.timeOpenEnded.exec(this.ctx).should.be.true();
+    (await this.timeOpenEnded.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when both Date intervals are the same', function () {
+  it('returns true when both Date intervals are the same', async function () {
     // define DateIntervalComparisonSame: Interval[Date(2018,01,01), Date(2018,02,02)] same as Interval[Date(2018,01,01), Date(2018,02,02)]
-    this.dateIntervalComparisonSame.exec(this.ctx).should.be.true();
+    (await this.dateIntervalComparisonSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when Date intervals are not the same', function () {
+  it('returns false when Date intervals are not the same', async function () {
     // define DateIntervalComparisonNotSame: Interval[Date(2018,01,01), Date(2018,02,02)] same as Interval[Date(2018,01,01), Date(2018,02,01)]
-    this.dateIntervalComparisonNotSame.exec(this.ctx).should.be.false();
+    (await this.dateIntervalComparisonNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when both Time intervals are the same', function () {
+  it('returns true when both Time intervals are the same', async function () {
     // define TimeIntervalComparisonSame: Interval[Time(01,01), Time(02,02)] same as Interval[Time(01,01), Time(02,02)]
-    this.timeIntervalComparisonSame.exec(this.ctx).should.be.true();
+    (await this.timeIntervalComparisonSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when Time intervals are not the same', function () {
+  it('returns false when Time intervals are not the same', async function () {
     // define TimeIntervalComparisonNotSame: Interval[Time(01,01), Time(02,02)] same as Interval[Time(01,01), Time(08,01)]
-    this.timeIntervalComparisonNotSame.exec(this.ctx).should.be.false();
+    (await this.timeIntervalComparisonNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the year precision', function () {
+  it('returns true when DateTime intervals are same on the year precision', async function () {
     // define DateTimeYearPrecisionSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same year as Interval[DateTime(2018,02,01), DateTime(2019,05,01)]
-    this.dateTimeYearPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeYearPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested year precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested year precision', async function () {
     // define DateTimeYearPrecisionNotSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same year as Interval[DateTime(2018,02,01), DateTime(2020,05,01)]
-    this.dateTimeYearPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeYearPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the year precision', function () {
+  it('returns true when DateTime intervals are same on the year precision', async function () {
     // define DateYearPrecisionSame: Interval[Date(2018,01,01), Date(2019,01,01)] same year as Interval[Date(2018,02,01), Date(2019,05,01)]
-    this.dateYearPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateYearPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested year precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested year precision', async function () {
     // define DateYearPrecisionNotSame: Interval[Date(2018,01,01), Date(2019,01,01)] same year as Interval[Date(2018,02,01), Date(2020,05,01)]
-    this.dateYearPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateYearPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the month precision', function () {
+  it('returns true when DateTime intervals are same on the month precision', async function () {
     // define DateTimeMonthPrecisionSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same month as Interval[DateTime(2018,01,01), DateTime(2019,01,03)]
-    this.dateTimeMonthPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeMonthPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested month precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested month precision', async function () {
     // define DateTimeMonthPrecisionNotSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same month as Interval[DateTime(2018,02,01), DateTime(2019,01,01)]
-    this.dateTimeMonthPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeMonthPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the day precision', function () {
+  it('returns true when DateTime intervals are same on the day precision', async function () {
     // define DateTimeDayPrecisionSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same day as Interval[DateTime(2018,01,01,05), DateTime(2019,01,01,09)]
-    this.dateTimeDayPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeDayPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested day precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested day precision', async function () {
     // define DateTimeDayPrecisionNotSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same day as Interval[DateTime(2018,01,01), DateTime(2019,01,02,06)]
-    this.dateTimeDayPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeDayPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the hour precision', function () {
+  it('returns true when DateTime intervals are same on the hour precision', async function () {
     // define DateTimeHourPrecisionSame: Interval[DateTime(2018,01,01,01), DateTime(2019,01,01,01)] same hour as Interval[DateTime(2018,01,01,01), DateTime(2019,01,01,01,05)]
-    this.dateTimeHourPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeHourPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested hour precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested hour precision', async function () {
     // define DateTimeHourPrecisionNotSame: Interval[DateTime(2018,01,01,01), DateTime(2019,01,01,01)] same hour as Interval[DateTime(2018,01,01,06), DateTime(2019,01,01,01)]
-    this.dateTimeHourPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeHourPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the minute precision', function () {
+  it('returns true when DateTime intervals are same on the minute precision', async function () {
     // define DateTimeMinutePrecisionSame: Interval[DateTime(2018,01,01,01,01), DateTime(2019,01,01,01,01)] same minute as Interval[DateTime(2018,01,01,01,01,09), DateTime(2019,01,01,01,01,06)]
-    this.dateTimeMinutePrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeMinutePrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested minute precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested minute precision', async function () {
     // define DateTimeMinutePrecisionNotSame: Interval[DateTime(2018,01,01,01,01), DateTime(2019,01,01,01,01)] same minute as Interval[DateTime(2018,01,01,06,03), DateTime(2019,01,01,01,06)]
-    this.dateTimeMinutePrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeMinutePrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the second precision', function () {
+  it('returns true when DateTime intervals are same on the second precision', async function () {
     // define DateTimeSecondPrecisionSame: Interval[DateTime(2018,01,01,01,01,01), DateTime(2019,01,01,01,01,01)] same second as Interval[DateTime(2018,01,01,01,01,01), DateTime(2019,01,01,01,01,01,07)]
-    this.dateTimeSecondPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeSecondPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested second precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested second precision', async function () {
     // define DateTimeSecondPrecisionNotSame: Interval[DateTime(2018,01,01,01,01,01), DateTime(2019,01,01,01,01,01)] same second as Interval[DateTime(2018,01,01,01,01,01), DateTime(2019,01,01,01,07,55)]
-    this.dateTimeSecondPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeSecondPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the millisecond precision', function () {
+  it('returns true when DateTime intervals are same on the millisecond precision', async function () {
     // define DateTimeMillisecondPrecisionSame: Interval[DateTime(2018,01,01,01,01,01,01), DateTime(2019,01,01,01,01,01,01)] same millisecond as Interval[DateTime(2018,01,01,01,01,01,01), DateTime(2019,01,01,01,01,01,01)]
-    this.dateTimeMillisecondPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeMillisecondPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested millisecond precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested millisecond precision', async function () {
     // define DateTimeMillisecondPrecisionNotSame: Interval[DateTime(2018,01,01,01,01,01,01), DateTime(2019,01,01,01,01,01,01)] same millisecond as Interval[DateTime(2018,01,01,01,01,01,01), DateTime(2019,01,01,01,01,01,09)]
-    this.dateTimeMillisecondPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeMillisecondPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when integer interval is the same', function () {
+  it('returns true when integer interval is the same', async function () {
     // define IntegerIntervalSame: Interval[2,5] same as Interval[2,5]
-    this.integerIntervalSame.exec(this.ctx).should.be.true();
+    (await this.integerIntervalSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when integer interval is not the same', function () {
+  it('returns false when integer interval is not the same', async function () {
     // define IntegerIntervalNotSame: Interval[2,5] same as Interval[2,4]
-    this.integerIntervalNotSame.exec(this.ctx).should.be.false();
+    (await this.integerIntervalNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when integer interval is same after the open interval is closed', function () {
+  it('returns true when integer interval is same after the open interval is closed', async function () {
     // define IntegerIntervalSameOpen: Interval[2,5] same as Interval[2,6)
-    this.integerIntervalSameOpen.exec(this.ctx).should.be.true();
+    (await this.integerIntervalSameOpen.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false even with an open ended null because the lows are not null and not same', function () {
+  it('returns false even with an open ended null because the lows are not null and not same', async function () {
     // define OpenNullHighLowDifferent: Interval(3,null) same as Interval(2,4)
-    this.openNullHighLowDifferent.exec(this.ctx).should.be.false();
+    (await this.openNullHighLowDifferent.exec(this.ctx)).should.be.false();
   });
 
-  it('returns false even with an open ended null because the highs are not null and not same', function () {
+  it('returns false even with an open ended null because the highs are not null and not same', async function () {
     // define OpenNullLowHighDifferent: Interval(1,5) same as Interval(null,4)
-    this.openNullLowHighDifferent.exec(this.ctx).should.be.false();
+    (await this.openNullLowHighDifferent.exec(this.ctx)).should.be.false();
   });
 
-  it('returns null if lows are same and highs have an open null', function () {
+  it('returns null if lows are same and highs have an open null', async function () {
     // OpenNullHighLowSame: Interval(2,null) same as Interval(2,4)
-    should(this.openNullHighLowSame.exec(this.ctx)).be.null();
+    should(await this.openNullHighLowSame.exec(this.ctx)).be.null();
   });
 
-  it('returns null if lows have an open null and highs are same', function () {
+  it('returns null if lows have an open null and highs are same', async function () {
     // OpenNullLowHighSame: Interval(1,4) same as Interval(null,4)
-    should(this.openNullLowHighSame.exec(this.ctx)).be.null();
+    should(await this.openNullLowHighSame.exec(this.ctx)).be.null();
   });
 
-  it('returns null if both lows and highs have open null', function () {
+  it('returns null if both lows and highs have open null', async function () {
     // OpenNullLowOpenNullHigh: Interval(1,null) same as Interval(null,4)
-    should(this.openNullLowOpenNullHigh.exec(this.ctx)).be.null();
+    should(await this.openNullLowOpenNullHigh.exec(this.ctx)).be.null();
   });
 
-  it('returns false if lows are different and highs have open null', function () {
+  it('returns false if lows are different and highs have open null', async function () {
     // OpenNullHighsLowsDifferent: Interval(1,null) same as Interval(2,null)
-    this.openNullHighsLowsDifferent.exec(this.ctx).should.be.false();
+    (await this.openNullHighsLowsDifferent.exec(this.ctx)).should.be.false();
   });
 
-  it('returns null if lows are same and highs have open null', function () {
+  it('returns null if lows are same and highs have open null', async function () {
     // OpenNullHighsLowsSame: Interval(1,null) same as Interval(1,null)
-    should(this.openNullHighsLowsSame.exec(this.ctx)).be.null();
+    should(await this.openNullHighsLowsSame.exec(this.ctx)).be.null();
   });
 
-  it('returns null if lows have open null and highs are same', function () {
+  it('returns null if lows have open null and highs are same', async function () {
     // OpenNullLowsHighsSame: Interval(null,3) same as Interval(null,3)
-    should(this.openNullLowsHighsSame.exec(this.ctx)).be.null();
+    should(await this.openNullLowsHighsSame.exec(this.ctx)).be.null();
   });
 });

--- a/test/elm/library/library-test.ts
+++ b/test/elm/library/library-test.ts
@@ -8,9 +8,11 @@ import { Repository, Code } from '../../../src/cql';
 const { p1, p2 } = require('./patients');
 
 describe('In Age Demographic', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, data, [p1, p2]);
-    this.results = this.executor.withLibrary(this.lib).exec_patient_context(this.patientSource);
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
   });
 
   it('should have correct patient results', function () {
@@ -43,18 +45,20 @@ describe('Using CommonLib', () => {
     this.lib.includes.should.not.be.empty();
   });
 
-  it('should be able to execute expression from included library', function () {
-    this.results = this.executor.withLibrary(this.lib).exec_patient_context(this.patientSource);
+  it('should be able to execute expression from included library', async function () {
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
     this.results.patientResults['1'].ID.should.equal(false);
     this.results.patientResults['2'].ID.should.equal(true);
     this.results.patientResults['2'].FuncTest.should.equal(7);
     this.results.patientResults['1'].FuncTest.should.equal(7);
   });
 
-  it('should find the code defined in the included library', function () {
-    should.exist(this.supportLibCode.exec(this.ctx));
+  it('should find the code defined in the included library', async function () {
+    should.exist(await this.supportLibCode.exec(this.ctx));
     equivalent(
-      this.supportLibCode.exec(this.ctx),
+      await this.supportLibCode.exec(this.ctx),
       new Code('428371000124100', '2.16.840.1.113883.6.96', 'foo', 'directReferenceCode')
     ).should.be.true();
   });
@@ -65,71 +69,81 @@ describe('Using CommonLib2', () => {
     setup(this, data, [], {}, { AnotherNumber: 50 }, new Repository(data));
   });
 
-  it('should execute expression from included library that uses parameter', function () {
-    this.exprUsesParam.exec(this.ctx).should.equal(17);
+  it('should execute expression from included library that uses parameter', async function () {
+    (await this.exprUsesParam.exec(this.ctx)).should.equal(17);
   });
 
-  it('should execute expression from included library that uses sent-in parameter', function () {
-    this.exprUsesParam.exec(this.ctx.withParameters({ SomeNumber: 42 })).should.equal(42);
+  it('should execute expression from included library that uses sent-in parameter', async function () {
+    (await this.exprUsesParam.exec(this.ctx.withParameters({ SomeNumber: 42 }))).should.equal(42);
   });
 
-  it('should execute parameter from included library', function () {
-    this.exprUsesParamDirectly.exec(this.ctx).should.equal(17);
+  it('should execute parameter from included library', async function () {
+    (await this.exprUsesParamDirectly.exec(this.ctx)).should.equal(17);
   });
 
-  it('should execute sent-in parameter from included library', function () {
-    this.exprUsesParamDirectly.exec(this.ctx.withParameters({ SomeNumber: 73 })).should.equal(73);
+  it('should execute sent-in parameter from included library', async function () {
+    (
+      await this.exprUsesParamDirectly.exec(this.ctx.withParameters({ SomeNumber: 73 }))
+    ).should.equal(73);
   });
 
-  it('should execute expression from included library that uses parameter', function () {
-    this.exprUsesAnotherParam.exec(this.ctx).should.equal(50);
+  it('should execute expression from included library that uses parameter', async function () {
+    (await this.exprUsesAnotherParam.exec(this.ctx)).should.equal(50);
   });
 
-  it('should execute expression from included library that uses sent-in parameter', function () {
-    this.exprUsesAnotherParam.exec(this.ctx.withParameters({ AnotherNumber: 66 })).should.equal(66);
+  it('should execute expression from included library that uses sent-in parameter', async function () {
+    (
+      await this.exprUsesAnotherParam.exec(this.ctx.withParameters({ AnotherNumber: 66 }))
+    ).should.equal(66);
   });
 
-  it('should execute parameter from included library', function () {
-    this.exprUsesAnotherParamDirectly.exec(this.ctx).should.equal(50);
+  it('should execute parameter from included library', async function () {
+    (await this.exprUsesAnotherParamDirectly.exec(this.ctx)).should.equal(50);
   });
 
-  it('should execute sent-in parameter from included library', function () {
-    this.exprUsesAnotherParamDirectly
-      .exec(this.ctx.withParameters({ AnotherNumber: 73 }))
-      .should.equal(73);
+  it('should execute sent-in parameter from included library', async function () {
+    (
+      await this.exprUsesAnotherParamDirectly.exec(this.ctx.withParameters({ AnotherNumber: 73 }))
+    ).should.equal(73);
   });
 
-  it('should execute function from included library that uses parameter', function () {
-    this.funcUsesParam.exec(this.ctx).should.equal(22);
+  it('should execute function from included library that uses parameter', async function () {
+    (await this.funcUsesParam.exec(this.ctx)).should.equal(22);
   });
 
-  it('should execute expression from included library that calls function', function () {
-    this.exprCallsFunc.exec(this.ctx).should.equal(6);
+  it('should execute expression from included library that calls function', async function () {
+    (await this.exprCallsFunc.exec(this.ctx)).should.equal(6);
   });
 
-  it('should execute function from included library that calls function', function () {
-    this.funcCallsFunc.exec(this.ctx).should.equal(25);
+  it('should execute function from included library that calls function', async function () {
+    (await this.funcCallsFunc.exec(this.ctx)).should.equal(25);
   });
 
-  it('should execute expression from included library that uses expression', function () {
-    this.exprUsesExpr.exec(this.ctx).should.equal(3);
+  it('should execute expression from included library that uses expression', async function () {
+    (await this.exprUsesExpr.exec(this.ctx)).should.equal(3);
   });
 
-  it('should execute function from included library that uses expression', function () {
-    this.funcUsesExpr.exec(this.ctx).should.equal(7);
+  it('should execute function from included library that uses expression', async function () {
+    (await this.funcUsesExpr.exec(this.ctx)).should.equal(7);
   });
 
-  it('should execute function from included library that uses expression', function () {
-    this.exprSortsOnFunc
-      .exec(this.ctx)
-      .should.eql([{ N: 1 }, { N: 2 }, { N: 3 }, { N: 4 }, { N: 5 }]);
+  it('should execute function from included library that uses expression', async function () {
+    (await this.exprSortsOnFunc.exec(this.ctx)).should.eql([
+      { N: 1 },
+      { N: 2 },
+      { N: 3 },
+      { N: 4 },
+      { N: 5 }
+    ]);
   });
 });
 
 describe('Using CommonLib and CommonLib2', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, data, [p1], {}, {}, new Repository(data));
-    this.results = this.executor.withLibrary(this.lib).exec_patient_context(this.patientSource);
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
     this.commonLocalIdObject = this.results.localIdPatientResultsMap['1'].Common;
     this.common2LocalIdObject = this.results.localIdPatientResultsMap['1'].Common2;
   });
@@ -164,9 +178,11 @@ describe('Using CommonLib and CommonLib2', () => {
 // NOTE: These all use the manually maintained fixture, see
 //       https://github.com/cqframework/cql-execution/pull/251
 describe('Using CommonLib and CommonLib2 with namespace support', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, dataWithNamespace, [p1], {}, {}, new Repository(dataWithNamespace));
-    this.results = this.executor.withLibrary(this.lib).exec_patient_context(this.patientSource);
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
     this.commonLocalIdObject = this.results.localIdPatientResultsMap['1'].Common;
     this.common2LocalIdObject = this.results.localIdPatientResultsMap['1'].Common2;
   });

--- a/test/elm/list/list-test.ts
+++ b/test/elm/list/list-test.ts
@@ -7,20 +7,20 @@ describe('List', () => {
     setup(this, data);
   });
 
-  it('should execute to an array (ints)', function () {
-    this.intList.exec(this.ctx).should.eql([9, 7, 8]);
+  it('should execute to an array (ints)', async function () {
+    (await this.intList.exec(this.ctx)).should.eql([9, 7, 8]);
   });
 
-  it('should execute to an array (strings)', function () {
-    this.stringList.exec(this.ctx).should.eql(['a', 'bee', 'see']);
+  it('should execute to an array (strings)', async function () {
+    (await this.stringList.exec(this.ctx)).should.eql(['a', 'bee', 'see']);
   });
 
-  it('should execute to an array (mixed)', function () {
-    this.mixedList.exec(this.ctx).should.eql([1, 'two', 3]);
+  it('should execute to an array (mixed)', async function () {
+    (await this.mixedList.exec(this.ctx)).should.eql([1, 'two', 3]);
   });
 
-  it('should execute to an empty array', function () {
-    this.emptyList.exec(this.ctx).should.eql([]);
+  it('should execute to an empty array', async function () {
+    (await this.emptyList.exec(this.ctx)).should.eql([]);
   });
 });
 
@@ -29,35 +29,35 @@ describe('Exists', () => {
     setup(this, data);
   });
 
-  it('should return false for empty list', function () {
-    this.emptyList.exec(this.ctx).should.be.false();
+  it('should return false for empty list', async function () {
+    (await this.emptyList.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true for full list', function () {
-    this.fullList.exec(this.ctx).should.be.true();
+  it('should return true for full list', async function () {
+    (await this.fullList.exec(this.ctx)).should.be.true();
   });
 
-  it('should return false for list with only one null', function () {
-    this.listWithOneNull.exec(this.ctx).should.be.false();
+  it('should return false for list with only one null', async function () {
+    (await this.listWithOneNull.exec(this.ctx)).should.be.false();
   });
 
-  it('should return false for list with only two nulls', function () {
-    this.listWithTwoNulls.exec(this.ctx).should.be.false();
+  it('should return false for list with only two nulls', async function () {
+    (await this.listWithTwoNulls.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true for list starting with null and with non-null elements', function () {
-    this.listStartingWithNull.exec(this.ctx).should.be.true();
+  it('should return true for list starting with null and with non-null elements', async function () {
+    (await this.listStartingWithNull.exec(this.ctx)).should.be.true();
   });
 
-  it('should return true for list with null and non-null elements', function () {
-    this.listWithNull.exec(this.ctx).should.be.true();
+  it('should return true for list with null and non-null elements', async function () {
+    (await this.listWithNull.exec(this.ctx)).should.be.true();
   });
 
   // NOTE: This test is misleading due to list promotion of the null to a list with null.
   // Test will remain as it still tests a different list creation method. Additionally, it
   // will be useful if list promotion is disabled.
-  it('should return false for null argument', function () {
-    this.nullExists.exec(this.ctx).should.be.false();
+  it('should return false for null argument', async function () {
+    (await this.nullExists.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -66,45 +66,45 @@ describe('Equal', () => {
     setup(this, data);
   });
 
-  it('should identify equal lists of integers', function () {
-    this.equalIntList.exec(this.ctx).should.be.true();
+  it('should identify equal lists of integers', async function () {
+    (await this.equalIntList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify unequal lists of integers', function () {
-    this.unequalIntList.exec(this.ctx).should.be.false();
+  it('should identify unequal lists of integers', async function () {
+    (await this.unequalIntList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify re-ordered lists of integers as unequal', function () {
-    this.reverseIntList.exec(this.ctx).should.be.false();
+  it('should identify re-ordered lists of integers as unequal', async function () {
+    (await this.reverseIntList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify equal lists of strings', function () {
-    this.equalStringList.exec(this.ctx).should.be.true();
+  it('should identify equal lists of strings', async function () {
+    (await this.equalStringList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify unequal lists of strings', function () {
-    this.unequalStringList.exec(this.ctx).should.be.false();
+  it('should identify unequal lists of strings', async function () {
+    (await this.unequalStringList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify equal lists of tuples', function () {
-    this.equalTupleList.exec(this.ctx).should.be.true();
+  it('should identify equal lists of tuples', async function () {
+    (await this.equalTupleList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify unequal lists of tuples', function () {
-    this.unequalTupleList.exec(this.ctx).should.be.false();
+  it('should identify unequal lists of tuples', async function () {
+    (await this.unequalTupleList.exec(this.ctx)).should.be.false();
   });
 
   describe('should return null', () => {
-    it('when first list has a null element', function () {
-      should(this.firstListHasNull.exec(this.ctx)).be.null();
+    it('when first list has a null element', async function () {
+      should(await this.firstListHasNull.exec(this.ctx)).be.null();
     });
 
-    it('when second list has a null element', function () {
-      should(this.secondListHasNull.exec(this.ctx)).be.null();
+    it('when second list has a null element', async function () {
+      should(await this.secondListHasNull.exec(this.ctx)).be.null();
     });
 
-    it('when both lists have only null elements', function () {
-      should(this.bothListsHaveNull.exec(this.ctx)).be.null();
+    it('when both lists have only null elements', async function () {
+      should(await this.bothListsHaveNull.exec(this.ctx)).be.null();
     });
   });
 });
@@ -114,32 +114,32 @@ describe('NotEqual', () => {
     setup(this, data);
   });
 
-  it('should identify equal lists of integers', function () {
-    this.equalIntList.exec(this.ctx).should.be.false();
+  it('should identify equal lists of integers', async function () {
+    (await this.equalIntList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify unequal lists of integers', function () {
-    this.unequalIntList.exec(this.ctx).should.be.true();
+  it('should identify unequal lists of integers', async function () {
+    (await this.unequalIntList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify re-ordered lists of integers as unequal', function () {
-    this.reverseIntList.exec(this.ctx).should.be.true();
+  it('should identify re-ordered lists of integers as unequal', async function () {
+    (await this.reverseIntList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify equal lists of strings', function () {
-    this.equalStringList.exec(this.ctx).should.be.false();
+  it('should identify equal lists of strings', async function () {
+    (await this.equalStringList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify unequal lists of strings', function () {
-    this.unequalStringList.exec(this.ctx).should.be.true();
+  it('should identify unequal lists of strings', async function () {
+    (await this.unequalStringList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify equal lists of tuples', function () {
-    this.equalTupleList.exec(this.ctx).should.be.false();
+  it('should identify equal lists of tuples', async function () {
+    (await this.equalTupleList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify unequal lists of tuples', function () {
-    this.unequalTupleList.exec(this.ctx).should.be.true();
+  it('should identify unequal lists of tuples', async function () {
+    (await this.unequalTupleList.exec(this.ctx)).should.be.true();
   });
 });
 
@@ -148,35 +148,49 @@ describe('Union', () => {
     setup(this, data);
   });
 
-  it('should union two lists to a single list', function () {
-    this.oneToTen.exec(this.ctx).should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  it('should union two lists to a single list', async function () {
+    (await this.oneToTen.exec(this.ctx)).should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   });
 
-  it('should remove duplicate elements (according to CQL 1.2 spec)', function () {
-    this.oneToFiveOverlapped.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should remove duplicate elements (according to CQL 1.2 spec)', async function () {
+    (await this.oneToFiveOverlapped.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should remove duplicate null elements', function () {
-    this.oneToFiveOverlappedWithNulls.exec(this.ctx).should.eql([1, null, 2, 3, 4, 5]);
+  it('should remove duplicate null elements', async function () {
+    (await this.oneToFiveOverlappedWithNulls.exec(this.ctx)).should.eql([1, null, 2, 3, 4, 5]);
   });
 
-  it('should not fill in values in a disjoint union', function () {
-    this.disjoint.exec(this.ctx).should.eql([1, 2, 4, 5]);
+  it('should not fill in values in a disjoint union', async function () {
+    (await this.disjoint.exec(this.ctx)).should.eql([1, 2, 4, 5]);
   });
 
-  it('should return one list for multiple nested unions', function () {
-    this.nestedToFifteen
-      .exec(this.ctx)
-      .should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+  it('should return one list for multiple nested unions', async function () {
+    (await this.nestedToFifteen.exec(this.ctx)).should.eql([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ]);
   });
 
-  it('should return other list if either arg is null', function () {
-    should(this.unionNull.exec(this.ctx)).be.eql([1, 2, 3]);
-    should(this.nullUnion.exec(this.ctx)).be.eql([1, 2, 3]);
+  it('should return other list if either arg is null', async function () {
+    should(await this.unionNull.exec(this.ctx)).be.eql([1, 2, 3]);
+    should(await this.nullUnion.exec(this.ctx)).be.eql([1, 2, 3]);
   });
 
-  it('should return an empty list if both args are null but expected to be lists', function () {
-    this.nullUnionNull.exec(this.ctx).should.be.eql([]);
+  it('should return an empty list if both args are null but expected to be lists', async function () {
+    (await this.nullUnionNull.exec(this.ctx)).should.be.eql([]);
   });
 });
 
@@ -185,48 +199,48 @@ describe('Except', () => {
     setup(this, data);
   });
 
-  it('should remove items in second list', function () {
-    this.exceptThreeFour.exec(this.ctx).should.eql([1, 2, 5]);
+  it('should remove items in second list', async function () {
+    (await this.exceptThreeFour.exec(this.ctx)).should.eql([1, 2, 5]);
   });
 
-  it('should not be commutative', function () {
-    this.threeFourExcept.exec(this.ctx).should.eql([]);
+  it('should not be commutative', async function () {
+    (await this.threeFourExcept.exec(this.ctx)).should.eql([]);
   });
 
-  it('should remove items in second list regardless of order', function () {
-    this.exceptFiveThree.exec(this.ctx).should.eql([1, 2, 4]);
+  it('should remove items in second list regardless of order', async function () {
+    (await this.exceptFiveThree.exec(this.ctx)).should.eql([1, 2, 4]);
   });
 
-  it('should be a no-op when lists have no common items', function () {
-    this.exceptNoOp.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should be a no-op when lists have no common items', async function () {
+    (await this.exceptNoOp.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should remove all items when lists are the same', function () {
-    this.exceptEverything.exec(this.ctx).should.eql([]);
+  it('should remove all items when lists are the same', async function () {
+    (await this.exceptEverything.exec(this.ctx)).should.eql([]);
   });
 
-  it('should return items in first list without 3 and null', function () {
-    this.multipleNullExcept.exec(this.ctx).should.eql([1, 5, 7]);
+  it('should return items in first list without 3 and null', async function () {
+    (await this.multipleNullExcept.exec(this.ctx)).should.eql([1, 5, 7]);
   });
 
-  it('should be a no-op when second list is empty', function () {
-    this.somethingExceptNothing.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should be a no-op when second list is empty', async function () {
+    (await this.somethingExceptNothing.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should be a no-op when first list is already empty', function () {
-    this.nothingExceptSomething.exec(this.ctx).should.eql([]);
+  it('should be a no-op when first list is already empty', async function () {
+    (await this.nothingExceptSomething.exec(this.ctx)).should.eql([]);
   });
 
-  it('should except lists of tuples', function () {
-    this.exceptTuples.exec(this.ctx).should.eql([{ a: 1 }, { a: 3 }]);
+  it('should except lists of tuples', async function () {
+    (await this.exceptTuples.exec(this.ctx)).should.eql([{ a: 1 }, { a: 3 }]);
   });
 
-  it('should return null if first arg is null', function () {
-    should(this.nullExcept.exec(this.ctx)).be.null();
+  it('should return null if first arg is null', async function () {
+    should(await this.nullExcept.exec(this.ctx)).be.null();
   });
 
-  it('should return first arg if second arg is null', function () {
-    this.exceptNull.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should return first arg if second arg is null', async function () {
+    (await this.exceptNull.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 });
 
@@ -235,44 +249,44 @@ describe('Intersect', () => {
     setup(this, data);
   });
 
-  it('should intersect two disjoint lists  to an empty list', function () {
-    this.noIntersection.exec(this.ctx).should.eql([]);
+  it('should intersect two disjoint lists  to an empty list', async function () {
+    (await this.noIntersection.exec(this.ctx)).should.eql([]);
   });
 
-  it('should intersect two lists with a single common element', function () {
-    this.intersectOnFive.exec(this.ctx).should.eql([5]);
+  it('should intersect two lists with a single common element', async function () {
+    (await this.intersectOnFive.exec(this.ctx)).should.eql([5]);
   });
 
-  it('should intersect two lists with a single common element even with duplicates', function () {
-    this.intersectionOnFourDuplicates.exec(this.ctx).should.eql([4]);
+  it('should intersect two lists with a single common element even with duplicates', async function () {
+    (await this.intersectionOnFourDuplicates.exec(this.ctx)).should.eql([4]);
   });
 
-  it('should intersect two lists with several common elements', function () {
-    this.intersectOnEvens.exec(this.ctx).should.eql([2, 4, 6, 8, 10]);
+  it('should intersect two lists with several common elements', async function () {
+    (await this.intersectOnEvens.exec(this.ctx)).should.eql([2, 4, 6, 8, 10]);
   });
 
-  it('should intersect two identical lists to the same list', function () {
-    this.intersectOnAll.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should intersect two identical lists to the same list', async function () {
+    (await this.intersectOnAll.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should intersect multiple lists to only those elements common across all', function () {
-    this.nestedIntersects.exec(this.ctx).should.eql([4, 5]);
+  it('should intersect multiple lists to only those elements common across all', async function () {
+    (await this.nestedIntersects.exec(this.ctx)).should.eql([4, 5]);
   });
 
-  it('should intersect lists of tuples', function () {
-    this.intersectTuples.exec(this.ctx).should.eql([
+  it('should intersect lists of tuples', async function () {
+    (await this.intersectTuples.exec(this.ctx)).should.eql([
       { a: 1, b: 'c' },
       { a: 2, b: 'c' }
     ]);
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.intersectNull.exec(this.ctx)).be.null();
-    should(this.nullIntersect.exec(this.ctx)).be.null();
+  it('should return null if either arg is null', async function () {
+    should(await this.intersectNull.exec(this.ctx)).be.null();
+    should(await this.nullIntersect.exec(this.ctx)).be.null();
   });
 
-  it('should intersect two lists that contain null', function () {
-    this.multipleNullInListIntersect.exec(this.ctx).should.eql([3, null]);
+  it('should intersect two lists that contain null', async function () {
+    (await this.multipleNullInListIntersect.exec(this.ctx)).should.eql([3, null]);
   });
 });
 
@@ -281,44 +295,44 @@ describe('IndexOf', () => {
     setup(this, data);
   });
 
-  it('should return the correct 0-based index when an item is in the list', function () {
-    this.indexOfSecond.exec(this.ctx).should.equal(1);
+  it('should return the correct 0-based index when an item is in the list', async function () {
+    (await this.indexOfSecond.exec(this.ctx)).should.equal(1);
     this.ctx.rootContext().localId_context[this.indexOfSecond.source.localId].should.not.be.null();
     this.ctx.rootContext().localId_context[this.indexOfSecond.element.localId].should.not.be.null();
   });
 
-  it('should work with complex types like tuples', function () {
-    this.indexOfThirdTuple.exec(this.ctx).should.equal(2);
+  it('should work with complex types like tuples', async function () {
+    (await this.indexOfThirdTuple.exec(this.ctx)).should.equal(2);
   });
 
-  it('should return the first index when there are multiple matches', function () {
-    this.multipleMatches.exec(this.ctx).should.equal(3);
+  it('should return the first index when there are multiple matches', async function () {
+    (await this.multipleMatches.exec(this.ctx)).should.equal(3);
   });
 
-  it('should return -1 when the item is not in the list', function () {
-    this.itemNotFound.exec(this.ctx).should.equal(-1);
+  it('should return -1 when the item is not in the list', async function () {
+    (await this.itemNotFound.exec(this.ctx)).should.equal(-1);
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.nullList.exec(this.ctx)).be.null();
-    should(this.nullItem.exec(this.ctx)).be.null();
+  it('should return null if either arg is null', async function () {
+    should(await this.nullList.exec(this.ctx)).be.null();
+    should(await this.nullItem.exec(this.ctx)).be.null();
   });
 
   describe('should use equality to determine presence in List', () => {
-    it('when code is in list but have undefined displays', function () {
-      this.listCodeUndefined.exec(this.ctx).should.equal(0);
+    it('when code is in list but have undefined displays', async function () {
+      (await this.listCodeUndefined.exec(this.ctx)).should.equal(0);
     });
 
-    it('when code is in list', function () {
-      this.listCode.exec(this.ctx).should.equal(0);
+    it('when code is in list', async function () {
+      (await this.listCode.exec(this.ctx)).should.equal(0);
     });
 
-    it('when code is not in list', function () {
-      this.listWrongCode.exec(this.ctx).should.equal(-1);
+    it('when code is not in list', async function () {
+      (await this.listWrongCode.exec(this.ctx)).should.equal(-1);
     });
 
-    it('when code system is not in list', function () {
-      this.listWrongCodeSystem.exec(this.ctx).should.equal(-1);
+    it('when code system is not in list', async function () {
+      (await this.listWrongCodeSystem.exec(this.ctx)).should.equal(-1);
     });
   });
 });
@@ -328,21 +342,21 @@ describe('Indexer', () => {
     setup(this, data);
   });
 
-  it('should return the correct item based on the 0-based index', function () {
-    this.secondItem.exec(this.ctx).should.equal('b');
+  it('should return the correct item based on the 0-based index', async function () {
+    (await this.secondItem.exec(this.ctx)).should.equal('b');
   });
 
-  it('should NOT return null when accessing index 0', function () {
-    should(this.zeroIndex.exec(this.ctx)).not.be.null();
+  it('should NOT return null when accessing index 0', async function () {
+    should(await this.zeroIndex.exec(this.ctx)).not.be.null();
   });
 
-  it('should return null when accessing out of bounds index', function () {
-    should(this.outOfBounds.exec(this.ctx)).be.null();
+  it('should return null when accessing out of bounds index', async function () {
+    should(await this.outOfBounds.exec(this.ctx)).be.null();
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.nullList.exec(this.ctx)).be.null();
-    should(this.nullIndexer.exec(this.ctx)).be.null();
+  it('should return null if either arg is null', async function () {
+    should(await this.nullList.exec(this.ctx)).be.null();
+    should(await this.nullIndexer.exec(this.ctx)).be.null();
   });
 });
 
@@ -351,32 +365,32 @@ describe('In', () => {
     setup(this, data);
   });
 
-  it('should execute to true when item is in list', function () {
-    this.isIn.exec(this.ctx).should.be.true();
+  it('should execute to true when item is in list', async function () {
+    (await this.isIn.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when item is not in list', function () {
-    this.isNotIn.exec(this.ctx).should.be.false();
+  it('should execute to false when item is not in list', async function () {
+    (await this.isNotIn.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple is in list', function () {
-    this.tupleIsIn.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple is in list', async function () {
+    (await this.tupleIsIn.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple is not in list', function () {
-    this.tupleIsNotIn.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple is not in list', async function () {
+    (await this.tupleIsNotIn.exec(this.ctx)).should.be.false();
   });
 
-  it('should return false if list is null', function () {
-    this.inNull.exec(this.ctx).should.be.false();
+  it('should return false if list is null', async function () {
+    (await this.inNull.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null if null is in list', function () {
-    should(this.nullIn.exec(this.ctx)).be.null();
+  it('should return null if null is in list', async function () {
+    should(await this.nullIn.exec(this.ctx)).be.null();
   });
 
-  it('should return null if null is not in list', function () {
-    should(this.nullNotIn.exec(this.ctx)).be.null();
+  it('should return null if null is not in list', async function () {
+    should(await this.nullNotIn.exec(this.ctx)).be.null();
   });
 });
 
@@ -385,32 +399,32 @@ describe('Contains', () => {
     setup(this, data);
   });
 
-  it('should execute to true when item is in list', function () {
-    this.isIn.exec(this.ctx).should.be.true();
+  it('should execute to true when item is in list', async function () {
+    (await this.isIn.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when item is not in list', function () {
-    this.isNotIn.exec(this.ctx).should.be.false();
+  it('should execute to false when item is not in list', async function () {
+    (await this.isNotIn.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple is in list', function () {
-    this.tupleIsIn.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple is in list', async function () {
+    (await this.tupleIsIn.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple is not in list', function () {
-    this.tupleIsNotIn.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple is not in list', async function () {
+    (await this.tupleIsNotIn.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null if null is contained in the list', function () {
-    should(this.nullIn.exec(this.ctx)).be.null();
+  it('should return null if null is contained in the list', async function () {
+    should(await this.nullIn.exec(this.ctx)).be.null();
   });
 
-  it('should return null if null is not contained in the list', function () {
-    should(this.nullNotIn.exec(this.ctx)).be.null();
+  it('should return null if null is not contained in the list', async function () {
+    should(await this.nullNotIn.exec(this.ctx)).be.null();
   });
 
-  it('should return false if list is null', function () {
-    this.inNull.exec(this.ctx).should.be.false();
+  it('should return false if list is null', async function () {
+    (await this.inNull.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -419,47 +433,47 @@ describe('Includes', () => {
     setup(this, data);
   });
 
-  it('should execute to true when sublist is in list', function () {
-    this.isIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list', async function () {
+    (await this.isIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when sublist is in list in different order', function () {
-    this.isIncludedReversed.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list in different order', async function () {
+    (await this.isIncludedReversed.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when lists are the same', function () {
-    this.isSame.exec(this.ctx).should.be.true();
+  it('should execute to true when lists are the same', async function () {
+    (await this.isSame.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when sublist is not in list', function () {
-    this.isNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when sublist is not in list', async function () {
+    (await this.isNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple sublist is in list', function () {
-    this.tuplesIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple sublist is in list', async function () {
+    (await this.tuplesIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple sublist is not in list', function () {
-    this.tuplesNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple sublist is not in list', async function () {
+    (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it.skip('should return true if right arg is null', function () {
+  it.skip('should return true if right arg is null', async function () {
     // TODO: currently returns false
-    should(this.nullIncluded.exec(this.ctx)).be.true();
+    should(await this.nullIncluded.exec(this.ctx)).be.true();
   });
 
-  it.skip('should return false if left arg is null', function () {
+  it.skip('should return false if left arg is null', async function () {
     // TODO: currently returns null
-    should(this.nullIncludes.exec(this.ctx)).be.false();
+    should(await this.nullIncludes.exec(this.ctx)).be.false();
   });
 
-  it('should correctly handle point comparisons', function () {
-    this.dayIncluded.exec(this.ctx).should.be.true();
-    this.dayNotIncluded.exec(this.ctx).should.be.false();
-    this.integerIncluded.exec(this.ctx).should.be.true();
-    this.integerNotIncluded.exec(this.ctx).should.be.false();
-    this.quantityInList.exec(this.ctx).should.be.true();
-    this.quantityNotInList.exec(this.ctx).should.be.false();
+  it('should correctly handle point comparisons', async function () {
+    (await this.dayIncluded.exec(this.ctx)).should.be.true();
+    (await this.dayNotIncluded.exec(this.ctx)).should.be.false();
+    (await this.integerIncluded.exec(this.ctx)).should.be.true();
+    (await this.integerNotIncluded.exec(this.ctx)).should.be.false();
+    (await this.quantityInList.exec(this.ctx)).should.be.true();
+    (await this.quantityNotInList.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -468,47 +482,47 @@ describe('IncludedIn', () => {
     setup(this, data);
   });
 
-  it('should execute to true when sublist is in list', function () {
-    this.isIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list', async function () {
+    (await this.isIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when sublist is in list in different order', function () {
-    this.isIncludedReversed.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list in different order', async function () {
+    (await this.isIncludedReversed.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when lists are the same', function () {
-    this.isSame.exec(this.ctx).should.be.true();
+  it('should execute to true when lists are the same', async function () {
+    (await this.isSame.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when sublist is not in list', function () {
-    this.isNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when sublist is not in list', async function () {
+    (await this.isNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple sublist is in list', function () {
-    this.tuplesIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple sublist is in list', async function () {
+    (await this.tuplesIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple sublist is not in list', function () {
-    this.tuplesNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple sublist is not in list', async function () {
+    (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it.skip('should return true if left arg is null', function () {
+  it.skip('should return true if left arg is null', async function () {
     // TODO: currently returns false
-    should(this.nullIncluded.exec(this.ctx)).be.true();
+    should(await this.nullIncluded.exec(this.ctx)).be.true();
   });
 
-  it.skip('should return false if right arg is null', function () {
+  it.skip('should return false if right arg is null', async function () {
     // TODO: currently returns null
-    should(this.nullIncludes.exec(this.ctx)).be.false();
+    should(await this.nullIncludes.exec(this.ctx)).be.false();
   });
 
-  it('should correctly handle point comparisons', function () {
-    this.dayIncluded.exec(this.ctx).should.be.true();
-    this.dayNotIncluded.exec(this.ctx).should.be.false();
-    this.integerIncluded.exec(this.ctx).should.be.true();
-    this.integerNotIncluded.exec(this.ctx).should.be.false();
-    this.quantityInList.exec(this.ctx).should.be.true();
-    this.quantityNotInList.exec(this.ctx).should.be.false();
+  it('should correctly handle point comparisons', async function () {
+    (await this.dayIncluded.exec(this.ctx)).should.be.true();
+    (await this.dayNotIncluded.exec(this.ctx)).should.be.false();
+    (await this.integerIncluded.exec(this.ctx)).should.be.true();
+    (await this.integerNotIncluded.exec(this.ctx)).should.be.false();
+    (await this.quantityInList.exec(this.ctx)).should.be.true();
+    (await this.quantityNotInList.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -517,34 +531,34 @@ describe('ProperIncludes', () => {
     setup(this, data);
   });
 
-  it('should execute to true when sublist is in list', function () {
-    this.isIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list', async function () {
+    (await this.isIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when sublist is in list in different order', function () {
-    this.isIncludedReversed.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list in different order', async function () {
+    (await this.isIncludedReversed.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when lists are the same', function () {
-    this.isSame.exec(this.ctx).should.be.false();
+  it('should execute to false when lists are the same', async function () {
+    (await this.isSame.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to false when sublist is not in list', function () {
-    this.isNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when sublist is not in list', async function () {
+    (await this.isNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple sublist is in list', function () {
-    this.tuplesIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple sublist is in list', async function () {
+    (await this.tuplesIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple sublist is not in list', function () {
-    this.tuplesNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple sublist is not in list', async function () {
+    (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
   // TODO: Support for ProperContains
-  it.skip('should return null if either arg is null', function () {
-    should(this.nullIncluded.exec(this.ctx)).be.null();
-    should(this.nullIncludes.exec(this.ctx)).be.null();
+  it.skip('should return null if either arg is null', async function () {
+    should(await this.nullIncluded.exec(this.ctx)).be.null();
+    should(await this.nullIncludes.exec(this.ctx)).be.null();
   });
 });
 
@@ -553,33 +567,33 @@ describe('ProperIncludedIn', () => {
     setup(this, data);
   });
 
-  it('should execute to true when sublist is in list', function () {
-    this.isIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list', async function () {
+    (await this.isIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when sublist is in list in different order', function () {
-    this.isIncludedReversed.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list in different order', async function () {
+    (await this.isIncludedReversed.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when lists are the same', function () {
-    this.isSame.exec(this.ctx).should.be.false();
+  it('should execute to false when lists are the same', async function () {
+    (await this.isSame.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to false when sublist is not in list', function () {
-    this.isNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when sublist is not in list', async function () {
+    (await this.isNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple sublist is in list', function () {
-    this.tuplesIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple sublist is in list', async function () {
+    (await this.tuplesIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple sublist is not in list', function () {
-    this.tuplesNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple sublist is not in list', async function () {
+    (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.nullIncluded.exec(this.ctx)).be.null();
-    should(this.nullIncludes.exec(this.ctx)).be.null();
+  it('should return null if either arg is null', async function () {
+    should(await this.nullIncluded.exec(this.ctx)).be.null();
+    should(await this.nullIncludes.exec(this.ctx)).be.null();
   });
 });
 
@@ -588,14 +602,31 @@ describe('Flatten', () => {
     setup(this, data);
   });
 
-  it('should flatten a list of lists', function () {
-    this.listOfLists
-      .exec(this.ctx)
-      .should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+  it('should flatten a list of lists', async function () {
+    (await this.listOfLists.exec(this.ctx)).should.eql([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      9,
+      8,
+      7,
+      6,
+      5,
+      4,
+      3,
+      2,
+      1
+    ]);
   });
 
-  it('should return null for a null list', function () {
-    should(this.nullValue.exec(this.ctx)).be.null();
+  it('should return null for a null list', async function () {
+    should(await this.nullValue.exec(this.ctx)).be.null();
   });
 });
 
@@ -604,27 +635,32 @@ describe('Distinct', () => {
     setup(this, data);
   });
 
-  it('should remove duplicates', function () {
-    this.lotsOfDups.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should remove duplicates', async function () {
+    (await this.lotsOfDups.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should do nothing to an already distinct array', function () {
-    this.noDups.exec(this.ctx).should.eql([2, 4, 6, 8, 10]);
+  it('should do nothing to an already distinct array', async function () {
+    (await this.noDups.exec(this.ctx)).should.eql([2, 4, 6, 8, 10]);
   });
 
-  it('should remove duplicate tuples', function () {
-    this.dupsTuples
-      .exec(this.ctx)
-      .should.eql([{ hello: 'world' }, { hello: 'cleveland' }, { hello: 'dolly' }]);
+  it('should remove duplicate tuples', async function () {
+    (await this.dupsTuples.exec(this.ctx)).should.eql([
+      { hello: 'world' },
+      { hello: 'cleveland' },
+      { hello: 'dolly' }
+    ]);
   });
 
-  it('should do nothing to an array of distinct tuples', function () {
-    this.noDupsTuples.exec(this.ctx).should.eql([{ hello: 'world' }, { hello: 'cleveland' }]);
+  it('should do nothing to an array of distinct tuples', async function () {
+    (await this.noDupsTuples.exec(this.ctx)).should.eql([
+      { hello: 'world' },
+      { hello: 'cleveland' }
+    ]);
   });
 
-  it('should remove duplicate null values', function () {
+  it('should remove duplicate null values', async function () {
     // define DuplicateNulls: distinct {null, 1, 2, null, 3, 4, 5, null}
-    this.duplicateNulls.exec(this.ctx).should.eql([null, 1, 2, 3, 4, 5]);
+    (await this.duplicateNulls.exec(this.ctx)).should.eql([null, 1, 2, 3, 4, 5]);
   });
 });
 
@@ -633,32 +669,32 @@ describe('First', () => {
     setup(this, data);
   });
 
-  it('should get first of a list of numbers', function () {
-    this.numbers.exec(this.ctx).should.equal(1);
+  it('should get first of a list of numbers', async function () {
+    (await this.numbers.exec(this.ctx)).should.equal(1);
   });
 
-  it('should get first of a list of letters', function () {
-    this.letters.exec(this.ctx).should.equal('a');
+  it('should get first of a list of letters', async function () {
+    (await this.letters.exec(this.ctx)).should.equal('a');
   });
 
-  it('should get first of a list of lists', function () {
-    this.lists.exec(this.ctx).should.eql(['a', 'b', 'c']);
+  it('should get first of a list of lists', async function () {
+    (await this.lists.exec(this.ctx)).should.eql(['a', 'b', 'c']);
   });
 
-  it('should get first of a list of tuples', function () {
-    this.tuples.exec(this.ctx).should.eql({ a: 1, b: 2, c: 3 });
+  it('should get first of a list of tuples', async function () {
+    (await this.tuples.exec(this.ctx)).should.eql({ a: 1, b: 2, c: 3 });
   });
 
-  it('should get first of a list of unordered numbers', function () {
-    this.unordered.exec(this.ctx).should.equal(3);
+  it('should get first of a list of unordered numbers', async function () {
+    (await this.unordered.exec(this.ctx)).should.equal(3);
   });
 
-  it('should return null for an empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for an empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
 
-  it('should return null for a null list', function () {
-    should(this.nullValue.exec(this.ctx)).be.null();
+  it('should return null for a null list', async function () {
+    should(await this.nullValue.exec(this.ctx)).be.null();
   });
 });
 
@@ -667,32 +703,32 @@ describe('Last', () => {
     setup(this, data);
   });
 
-  it('should get last of a list of numbers', function () {
-    this.numbers.exec(this.ctx).should.equal(4);
+  it('should get last of a list of numbers', async function () {
+    (await this.numbers.exec(this.ctx)).should.equal(4);
   });
 
-  it('should get last of a list of letters', function () {
-    this.letters.exec(this.ctx).should.equal('c');
+  it('should get last of a list of letters', async function () {
+    (await this.letters.exec(this.ctx)).should.equal('c');
   });
 
-  it('should get last of a list of lists', function () {
-    this.lists.exec(this.ctx).should.eql(['d', 'e', 'f']);
+  it('should get last of a list of lists', async function () {
+    (await this.lists.exec(this.ctx)).should.eql(['d', 'e', 'f']);
   });
 
-  it('should get last of a list of tuples', function () {
-    this.tuples.exec(this.ctx).should.eql({ a: 24, b: 25, c: 26 });
+  it('should get last of a list of tuples', async function () {
+    (await this.tuples.exec(this.ctx)).should.eql({ a: 24, b: 25, c: 26 });
   });
 
-  it('should get last of a list of unordered numbers', function () {
-    this.unordered.exec(this.ctx).should.equal(2);
+  it('should get last of a list of unordered numbers', async function () {
+    (await this.unordered.exec(this.ctx)).should.equal(2);
   });
 
-  it('should return null for an empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for an empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
 
-  it('should return null for a null list', function () {
-    should(this.nullValue.exec(this.ctx)).be.null();
+  it('should return null for a null list', async function () {
+    should(await this.nullValue.exec(this.ctx)).be.null();
   });
 });
 
@@ -701,24 +737,24 @@ describe('Length', () => {
     setup(this, data);
   });
 
-  it('should get length of a list of numbers', function () {
-    this.numbers.exec(this.ctx).should.equal(5);
+  it('should get length of a list of numbers', async function () {
+    (await this.numbers.exec(this.ctx)).should.equal(5);
   });
 
-  it('should get length of a list of lists', function () {
-    this.lists.exec(this.ctx).should.equal(4);
+  it('should get length of a list of lists', async function () {
+    (await this.lists.exec(this.ctx)).should.equal(4);
   });
 
-  it('should get length of a list of tuples', function () {
-    this.tuples.exec(this.ctx).should.equal(2);
+  it('should get length of a list of tuples', async function () {
+    (await this.tuples.exec(this.ctx)).should.equal(2);
   });
 
-  it('should get length of an empty list', function () {
-    this.empty.exec(this.ctx).should.equal(0);
+  it('should get length of an empty list', async function () {
+    (await this.empty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should return zero for a null list', function () {
-    this.nullValue.exec(this.ctx).should.equal(0);
+  it('should return zero for a null list', async function () {
+    (await this.nullValue.exec(this.ctx)).should.equal(0);
   });
 });
 
@@ -727,16 +763,16 @@ describe('ToList', () => {
     setup(this, data);
   });
 
-  it('should return true that 5 is in 5', function () {
-    this.fiveInFive.exec(this.ctx).should.be.true();
+  it('should return true that 5 is in 5', async function () {
+    (await this.fiveInFive.exec(this.ctx)).should.be.true();
   });
 
-  it('should return false that 4 is in 5', function () {
-    this.fourInFive.exec(this.ctx).should.be.false();
+  it('should return false that 4 is in 5', async function () {
+    (await this.fourInFive.exec(this.ctx)).should.be.false();
   });
 
-  it('should make null into an empty list', function () {
-    this.lengthOfNull.exec(this.ctx).should.equal(0);
+  it('should make null into an empty list', async function () {
+    (await this.lengthOfNull.exec(this.ctx)).should.equal(0);
   });
 });
 
@@ -745,20 +781,20 @@ describe('Skip', () => {
     setup(this, data);
   });
 
-  it('should skip two elements', function () {
-    this.skip2.exec(this.ctx).should.eql([3, 4, 5]);
+  it('should skip two elements', async function () {
+    (await this.skip2.exec(this.ctx)).should.eql([3, 4, 5]);
   });
 
-  it('should not skip when using null', function () {
-    this.skipNull.exec(this.ctx).should.eql([1, 3, 5]);
+  it('should not skip when using null', async function () {
+    (await this.skipNull.exec(this.ctx)).should.eql([1, 3, 5]);
   });
 
-  it('should return empty list when using negative number', function () {
-    this.skipEmpty.exec(this.ctx).should.eql([]);
+  it('should return empty list when using negative number', async function () {
+    (await this.skipEmpty.exec(this.ctx)).should.eql([]);
   });
 
-  it('should return null when given null', function () {
-    should(this.skipIsNull.exec(this.ctx)).be.null();
+  it('should return null when given null', async function () {
+    should(await this.skipIsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -767,16 +803,16 @@ describe('Tail', () => {
     setup(this, data);
   });
 
-  it('should get tail of list', function () {
-    this.tail234.exec(this.ctx).should.eql([2, 3, 4]);
+  it('should get tail of list', async function () {
+    (await this.tail234.exec(this.ctx)).should.eql([2, 3, 4]);
   });
 
-  it('should return empty list when given empty list', function () {
-    this.tailEmpty.exec(this.ctx).should.eql([]);
+  it('should return empty list when given empty list', async function () {
+    (await this.tailEmpty.exec(this.ctx)).should.eql([]);
   });
 
-  it('should return null when given null', function () {
-    should(this.tailIsNull.exec(this.ctx)).be.null();
+  it('should return null when given null', async function () {
+    should(await this.tailIsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -785,19 +821,19 @@ describe('Take', () => {
     setup(this, data);
   });
 
-  it('should take two elements', function () {
-    this.take2.exec(this.ctx).should.eql([1, 2]);
+  it('should take two elements', async function () {
+    (await this.take2.exec(this.ctx)).should.eql([1, 2]);
   });
 
-  it('should return full list when asked for too many elements', function () {
-    this.takeTooMany.exec(this.ctx).should.eql([1, 2]);
+  it('should return full list when asked for too many elements', async function () {
+    (await this.takeTooMany.exec(this.ctx)).should.eql([1, 2]);
   });
 
-  it('should return empty list when using null', function () {
-    this.takeEmpty.exec(this.ctx).should.eql([]);
+  it('should return empty list when using null', async function () {
+    (await this.takeEmpty.exec(this.ctx)).should.eql([]);
   });
 
-  it('should return null when given null', function () {
-    should(this.takeIsNull.exec(this.ctx)).be.null();
+  it('should return null when given null', async function () {
+    should(await this.takeIsNull.exec(this.ctx)).be.null();
   });
 });

--- a/test/elm/message/message-test.ts
+++ b/test/elm/message/message-test.ts
@@ -11,18 +11,18 @@ describe('Message', () => {
     this.ctx.messageListener = messageCollector;
   });
 
-  it('should always return the first argument as-is', function () {
-    this.oneOverTwo.exec(this.ctx).should.equal(0.5);
-    should(this.oneOverZero.exec(this.ctx)).be.null();
+  it('should always return the first argument as-is', async function () {
+    (await this.oneOverTwo.exec(this.ctx)).should.equal(0.5);
+    should(await this.oneOverZero.exec(this.ctx)).be.null();
   });
 
-  it('should not log a message when the condition is false', function () {
-    this.oneOverTwo.exec(this.ctx);
+  it('should not log a message when the condition is false', async function () {
+    await this.oneOverTwo.exec(this.ctx);
     messageCollector.messages.length.should.equal(0);
   });
 
-  it('should log a message when the condition is true', function () {
-    this.oneOverZero.exec(this.ctx);
+  it('should log a message when the condition is true', async function () {
+    await this.oneOverZero.exec(this.ctx);
     messageCollector.messages.length.should.equal(1);
     messageCollector.messages[0].should.equal('Error: [DivideByZero] Cannot divide by zero (null)');
   });

--- a/test/elm/nullological/nullological-test.ts
+++ b/test/elm/nullological/nullological-test.ts
@@ -7,8 +7,8 @@ describe('Nil', () => {
     setup(this, data);
   });
 
-  it('should execute as null', function () {
-    should(this.nil.exec(this.ctx)).be.null();
+  it('should execute as null', async function () {
+    should(await this.nil.exec(this.ctx)).be.null();
   });
 });
 
@@ -17,20 +17,20 @@ describe('IsNull', () => {
     setup(this, data);
   });
 
-  it('should detect that null is null', function () {
-    this.nullIsNull.exec(this.ctx).should.be.true();
+  it('should detect that null is null', async function () {
+    (await this.nullIsNull.exec(this.ctx)).should.be.true();
   });
 
-  it('should detect that null variable is null', function () {
-    this.nullVarIsNull.exec(this.ctx).should.be.true();
+  it('should detect that null variable is null', async function () {
+    (await this.nullVarIsNull.exec(this.ctx)).should.be.true();
   });
 
-  it('should detect that string is not null', function () {
-    this.stringIsNull.exec(this.ctx).should.be.false();
+  it('should detect that string is not null', async function () {
+    (await this.stringIsNull.exec(this.ctx)).should.be.false();
   });
 
-  it('should detect that non-null variable is not null', function () {
-    this.nonNullVarIsNull.exec(this.ctx).should.be.false();
+  it('should detect that non-null variable is not null', async function () {
+    (await this.nonNullVarIsNull.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -39,35 +39,35 @@ describe('Coalesce', () => {
     setup(this, data);
   });
 
-  it('should return first non-null when leading args are null', function () {
-    this.nullNullHelloNullWorld.exec(this.ctx).should.equal('Hello');
+  it('should return first non-null when leading args are null', async function () {
+    (await this.nullNullHelloNullWorld.exec(this.ctx)).should.equal('Hello');
   });
 
-  it('should return first arg when it is non-null', function () {
-    this.fooNullNullBar.exec(this.ctx).should.equal('Foo');
+  it('should return first arg when it is non-null', async function () {
+    (await this.fooNullNullBar.exec(this.ctx)).should.equal('Foo');
   });
 
-  it('should return null when they are all null', function () {
-    should(this.allNull.exec(this.ctx)).be.null();
+  it('should return null when they are all null', async function () {
+    should(await this.allNull.exec(this.ctx)).be.null();
   });
 
-  it('should return first non-null in array', function () {
-    this.listArgStartsWithNull.exec(this.ctx).should.equal('One');
+  it('should return first non-null in array', async function () {
+    (await this.listArgStartsWithNull.exec(this.ctx)).should.equal('One');
   });
 
-  it('should return null for all-null array', function () {
-    should(this.listArgAllNull.exec(this.ctx)).be.null();
+  it('should return null for all-null array', async function () {
+    should(await this.listArgAllNull.exec(this.ctx)).be.null();
   });
 
-  it('should be able to handle ExpressionRef with list', function () {
-    this.listExpressionRef.exec(this.ctx).should.equal('One');
+  it('should be able to handle ExpressionRef with list', async function () {
+    (await this.listExpressionRef.exec(this.ctx)).should.equal('One');
   });
 
-  it('should be able to handle Retrieve as list', function () {
-    should(this.retrieveAsList.exec(this.ctx)).be.null();
+  it('should be able to handle Retrieve as list', async function () {
+    should(await this.retrieveAsList.exec(this.ctx)).be.null();
   });
 
-  it('should be able to handle Union as list', function () {
-    this.unionAsList.exec(this.ctx).should.equal(3);
+  it('should be able to handle Union as list', async function () {
+    (await this.unionAsList.exec(this.ctx)).should.equal(3);
   });
 });

--- a/test/elm/parameters/parameters-test.ts
+++ b/test/elm/parameters/parameters-test.ts
@@ -12,34 +12,36 @@ describe('ParameterDef', () => {
     this.param = this.lib.parameters.MeasureYear;
   });
 
-  it('should have a name', function () {
+  it('should have a name', async function () {
     this.param.name.should.equal('MeasureYear');
   });
 
-  it('should execute to default value', function () {
-    this.param.exec(this.ctx).should.equal(2012);
+  it('should execute to default value', async function () {
+    (await this.param.exec(this.ctx)).should.equal(2012);
   });
 
-  it('should execute to provided value', function () {
-    this.param.exec(this.ctx.withParameters({ MeasureYear: 2013 })).should.equal(2013);
+  it('should execute to provided value', async function () {
+    (await this.param.exec(this.ctx.withParameters({ MeasureYear: 2013 }))).should.equal(2013);
   });
 
-  it('should work with typed int parameters', function () {
+  it('should work with typed int parameters', async function () {
     const intParam = this.lib.parameters.IntParameter;
-    intParam.exec(this.ctx.withParameters({ IntParameter: 17 })).should.equal(17);
+    (await intParam.exec(this.ctx.withParameters({ IntParameter: 17 }))).should.equal(17);
   });
 
-  it('should work with typed list parameters', function () {
+  it('should work with typed list parameters', async function () {
     const listParam = this.lib.parameters.ListParameter;
-    listParam
-      .exec(this.ctx.withParameters({ ListParameter: ['a', 'b', 'c'] }))
-      .should.eql(['a', 'b', 'c']);
+    (await listParam.exec(this.ctx.withParameters({ ListParameter: ['a', 'b', 'c'] }))).should.eql([
+      'a',
+      'b',
+      'c'
+    ]);
   });
 
-  it('should work with typed tuple parameters', function () {
+  it('should work with typed tuple parameters', async function () {
     const tupleParam = this.lib.parameters.TupleParameter;
     const v = { a: 1, b: 'bee', c: true, d: [10, 9, 8], e: { f: 'eff', g: false } };
-    tupleParam.exec(this.ctx.withParameters({ TupleParameter: v })).should.eql(v);
+    (await tupleParam.exec(this.ctx.withParameters({ TupleParameter: v }))).should.eql(v);
   });
 });
 
@@ -48,16 +50,16 @@ describe('ParameterRef', () => {
     setup(this, data);
   });
 
-  it('should have a name', function () {
+  it('should have a name', async function () {
     this.foo.name.should.equal('FooP');
   });
 
-  it('should execute to default value', function () {
-    this.foo.exec(this.ctx).should.equal('Bar');
+  it('should execute to default value', async function () {
+    (await this.foo.exec(this.ctx)).should.equal('Bar');
   });
 
-  it('should execute to provided value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: 'Bah' })).should.equal('Bah');
+  it('should execute to provided value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: 'Bah' }))).should.equal('Bah');
   });
 
   it('should fail when provided value is wrong type', function () {
@@ -70,20 +72,20 @@ describe('BooleanParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: true })).should.equal(true);
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: true }))).should.equal(true);
   });
 
   it('should throw when provided value is wrong type', function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 12 }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.equal(true);
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.equal(true);
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2.exec(this.ctx.withParameters({ FooDP: false })).should.equal(false);
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: false }))).should.equal(false);
   });
 
   it('should throw when overriding value is wrong type', function () {
@@ -96,20 +98,20 @@ describe('DecimalParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: 3.0 })).should.equal(3.0);
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: 3.0 }))).should.equal(3.0);
   });
 
   it('should throw when provided value is wrong type', function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: '3' }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.equal(1.5);
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.equal(1.5);
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2.exec(this.ctx.withParameters({ FooDP: 3.0 })).should.equal(3.0);
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: 3.0 }))).should.equal(3.0);
   });
 
   it('should throw when overriding value is wrong type', function () {
@@ -122,20 +124,20 @@ describe('IntegerParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: 3 })).should.equal(3);
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: 3 }))).should.equal(3);
   });
 
   it('should throw when provided value is wrong type', function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 3.5 }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.equal(2);
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.equal(2);
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2.exec(this.ctx.withParameters({ FooDP: 3 })).should.equal(3);
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: 3 }))).should.equal(3);
   });
 
   it('should throw when overriding value is wrong type', function () {
@@ -148,20 +150,24 @@ describe('StringParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: 'Hello World' })).should.equal('Hello World');
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).should.equal(
+      'Hello World'
+    );
   });
 
   it('should throw when provided value is wrong type', function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 42 }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.equal('Hello');
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.equal('Hello');
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2.exec(this.ctx.withParameters({ FooDP: 'Hello World' })).should.equal('Hello World');
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: 'Hello World' }))).should.equal(
+      'Hello World'
+    );
   });
 
   it('should throw when overriding value is wrong type', function () {
@@ -174,28 +180,28 @@ describe('CodeParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const c = new Code('foo', 'http://foo.org', null, 'Foo');
-    this.foo.exec(this.ctx.withParameters({ FooP: c })).should.equal(c);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: c }))).should.equal(c);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const c = new Concept([new Code('foo', 'http://foo.org')], 'Foo');
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: c }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2
-      .exec(this.ctx)
-      .should.eql(new Code('FooTest', 'http://footest.org', undefined, 'Foo Test'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(
+      new Code('FooTest', 'http://footest.org', undefined, 'Foo Test')
+    );
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const c = new Code('foo', 'http://foo.org', null, 'Foo');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: c })).should.equal(c);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: c }))).should.equal(c);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const c = new Concept([new Code('foo', 'http://foo.org')], 'Foo');
     should(() => this.foo2.exec(this.ctx.withParameters({ FooDP: c }))).throw(/.*wrong type.*/);
   });
@@ -206,28 +212,28 @@ describe('ConceptParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const c = new Concept([new Code('foo', 'http://foo.org')], 'Foo');
-    this.foo.exec(this.ctx.withParameters({ FooP: c })).should.equal(c);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: c }))).should.equal(c);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const c = new Code('foo', 'http://foo.org');
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: c }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2
-      .exec(this.ctx)
-      .should.eql(new Concept([new Code('FooTest', 'http://footest.org')], 'Foo Test'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(
+      new Concept([new Code('FooTest', 'http://footest.org')], 'Foo Test')
+    );
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const c = new Concept([new Code('foo', 'http://foo.org')], 'Foo');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: c })).should.equal(c);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: c }))).should.equal(c);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const c = new Code('foo', 'http://foo.org');
     should(() => this.foo2.exec(this.ctx.withParameters({ FooDP: c }))).throw(/.*wrong type.*/);
   });
@@ -238,26 +244,26 @@ describe('DateTimeParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const d = DateTime.parse('2012-10-25T12:55:14.456+00');
-    this.foo.exec(this.ctx.withParameters({ FooP: d })).should.equal(d);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: d }))).should.equal(d);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const d = '2012-10-25T12:55:14.456+00';
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: d }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(DateTime.parse('2012-04-01T12:11:10'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(DateTime.parse('2012-04-01T12:11:10'));
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const d = DateTime.parse('2012-10-25T12:55:14.456+00');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: d })).should.equal(d);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: d }))).should.equal(d);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const d = '2012-10-25T12:55:14.456+00';
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: d }))).throw(/.*wrong type.*/);
   });
@@ -268,26 +274,26 @@ describe('DateParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const d = Date.parse('2012-10-25');
-    this.foo.exec(this.ctx.withParameters({ FooP: d })).should.equal(d);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: d }))).should.equal(d);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const d = '2012-10-25';
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: d }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(Date.parse('2012-04-01'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(Date.parse('2012-04-01'));
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const d = Date.parse('2012-10-25');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: d })).should.equal(d);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: d }))).should.equal(d);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const d = '2012-10-25';
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: d }))).throw(/.*wrong type.*/);
   });
@@ -298,26 +304,26 @@ describe('QuantityParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const q = new Quantity(5, 'mg');
-    this.foo.exec(this.ctx.withParameters({ FooP: q })).should.equal(q);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: q }))).should.equal(q);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const q = 5;
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: q }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(new Quantity(10, 'dL'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(new Quantity(10, 'dL'));
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const q = new Quantity(5, 'mg');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: q })).should.equal(q);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: q }))).should.equal(q);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const q = 5;
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: q }))).throw(/.*wrong type.*/);
   });
@@ -328,26 +334,26 @@ describe('TimeParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const t = DateTime.parse('2012-10-25T12:55:14.456+00').getTime();
-    this.foo.exec(this.ctx.withParameters({ FooP: t })).should.equal(t);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: t }))).should.equal(t);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const t = DateTime.parse('2012-10-25T12:55:14.456+00');
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: t }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(DateTime.parse('2012-10-25T12:00:00').getTime());
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(DateTime.parse('2012-10-25T12:00:00').getTime());
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const t = DateTime.parse('2012-10-25T12:55:14.456+00').getTime();
-    this.foo2.exec(this.ctx.withParameters({ FooDP: t })).should.equal(t);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: t }))).should.equal(t);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const t = DateTime.parse('2012-10-25T12:55:14.456+00');
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: t }))).throw(/.*wrong type.*/);
   });
@@ -358,41 +364,43 @@ describe('ListParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo
-      .exec(this.ctx.withParameters({ FooP: ['Hello', 'World'] }))
-      .should.eql(['Hello', 'World']);
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: ['Hello', 'World'] }))).should.eql([
+      'Hello',
+      'World'
+    ]);
   });
 
-  it('should throw when provided value is not a list', function () {
+  it('should throw when provided value is not a list', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should throw when list contains a wrong type', function () {
+  it('should throw when list contains a wrong type', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: ['Hello', 2468] }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(['a', 'b', 'c']);
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(['a', 'b', 'c']);
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2
-      .exec(this.ctx.withParameters({ FooDP: ['Hello', 'World'] }))
-      .should.eql(['Hello', 'World']);
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: ['Hello', 'World'] }))).should.eql([
+      'Hello',
+      'World'
+    ]);
   });
 
-  it('should throw when overriding value is not a list', function () {
+  it('should throw when overriding value is not a list', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should throw when overriding list contains a wrong type', function () {
+  it('should throw when overriding list contains a wrong type', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: ['Hello', 2468] }))).throw(
       /.*wrong type.*/
     );
@@ -404,37 +412,37 @@ describe('IntervalParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo
-      .exec(this.ctx.withParameters({ FooP: new Interval(1, 5) }))
-      .should.eql(new Interval(1, 5));
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: new Interval(1, 5) }))).should.eql(
+      new Interval(1, 5)
+    );
   });
 
-  it('should throw when provided value is not an interval', function () {
+  it('should throw when provided value is not an interval', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: [1, 5] }))).throw(/.*wrong type.*/);
   });
 
-  it('should throw when interval contains a wrong point type', function () {
+  it('should throw when interval contains a wrong point type', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: new Interval(1.5, 5.5) }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(new Interval(2, 6));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(new Interval(2, 6));
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2
-      .exec(this.ctx.withParameters({ FooDP: new Interval(1, 5) }))
-      .should.eql(new Interval(1, 5));
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: new Interval(1, 5) }))).should.eql(
+      new Interval(1, 5)
+    );
   });
 
-  it('should throw when overriding value is not an interval', function () {
+  it('should throw when overriding value is not an interval', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: [1, 5] }))).throw(/.*wrong type.*/);
   });
 
-  it('should throw when overriding interval contains a wrong point type', function () {
+  it('should throw when overriding interval contains a wrong point type', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: new Interval(1.5, 5.5) }))).throw(
       /.*wrong type.*/
     );
@@ -446,23 +454,23 @@ describe('TupleParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const t = { Hello: 'World', MeaningOfLife: 42 };
-    this.foo.exec(this.ctx.withParameters({ FooP: t })).should.eql(t);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: t }))).should.eql(t);
   });
 
-  it('should allow missing tuple properties', function () {
+  it('should allow missing tuple properties', async function () {
     const t = { MeaningOfLife: 42 };
-    this.foo.exec(this.ctx.withParameters({ FooP: t })).should.eql(t);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: t }))).should.eql(t);
   });
 
-  it('should throw when provided value is not a tuple', function () {
+  it('should throw when provided value is not a tuple', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should throw when tuple contains a wrong property type', function () {
+  it('should throw when tuple contains a wrong property type', async function () {
     should(() =>
       this.foo.exec(
         this.ctx.withParameters({ FooP: { Hello: 'World', MeaningOfLife: 'Forty-Two' } })
@@ -470,27 +478,27 @@ describe('TupleParameterTypes', () => {
     ).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql({ Hello: 'Universe', MeaningOfLife: 24 });
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql({ Hello: 'Universe', MeaningOfLife: 24 });
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const t = { Hello: 'World', MeaningOfLife: 42 };
-    this.foo2.exec(this.ctx.withParameters({ FooDP: t })).should.eql(t);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: t }))).should.eql(t);
   });
 
-  it('should allow missing tuple properties in overriding tuple', function () {
+  it('should allow missing tuple properties in overriding tuple', async function () {
     const t = { MeaningOfLife: 42 };
-    this.foo2.exec(this.ctx.withParameters({ FooDP: t })).should.eql(t);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: t }))).should.eql(t);
   });
 
-  it('should throw when overriding value is not a tuple', function () {
+  it('should throw when overriding value is not a tuple', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should throw when overriding tuple contains a wrong property type', function () {
+  it('should throw when overriding tuple contains a wrong property type', async function () {
     should(() =>
       this.foo2.exec(
         this.ctx.withParameters({ FooP: { Hello: 'World', MeaningOfLife: 'Forty-Two' } })
@@ -504,9 +512,9 @@ describe('DefaultAndNoDefault', () => {
     setup(this, data);
   });
 
-  it('should be able to retrieve a provided value and a default value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooWithNoDefault: 1 })).should.eql(1);
-    this.foo2.exec(this.ctx.withParameters({ FooWithNoDefault: 1 })).should.eql(5);
+  it('should be able to retrieve a provided value and a default value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooWithNoDefault: 1 }))).should.eql(1);
+    (await this.foo2.exec(this.ctx.withParameters({ FooWithNoDefault: 1 }))).should.eql(5);
   });
 });
 
@@ -515,7 +523,7 @@ describe('MeasurementPeriodParameter', () => {
     setup(this, data);
   });
 
-  it('should execute expression with a passed in measurement period in a child context', function () {
+  it('should execute expression with a passed in measurement period in a child context', async function () {
     this.ctx = this.ctx.withParameters({
       'Measurement Period': new Interval(
         new DateTime(2012, 1, 1, 0, 0, 0, 0),
@@ -523,10 +531,10 @@ describe('MeasurementPeriodParameter', () => {
       )
     });
     const rctx = this.ctx.childContext();
-    this.measurementPeriod.exec(rctx).should.equal(true);
+    (await this.measurementPeriod.exec(rctx)).should.equal(true);
   });
 
-  it('should execute expression with a passed in measurement period in a child context', function () {
+  it('should execute expression with a passed in measurement period in a child context', async function () {
     this.ctx = this.ctx.withParameters({
       'Measurement Period': new Interval(
         new DateTime(2012, 1, 1, 0, 0, 0, 0),
@@ -536,6 +544,6 @@ describe('MeasurementPeriodParameter', () => {
     const r1ctx = this.ctx.childContext();
     const r2ctx = r1ctx.childContext();
     const r3ctx = r2ctx.childContext();
-    this.measurementPeriod.exec(r3ctx).should.equal(true);
+    (await this.measurementPeriod.exec(r3ctx)).should.equal(true);
   });
 });

--- a/test/elm/structured/structured-test.ts
+++ b/test/elm/structured/structured-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 import 'should';
@@ -7,14 +8,14 @@ describe('Tuple', () => {
     setup(this, data);
   });
 
-  it('should be able to define a tuple', function () {
-    const e = this.tup.exec(this.ctx);
-    e['a'].should.equal(1);
-    e['b'].should.equal(2);
+  it('should be able to define a tuple', async function () {
+    const e = await this.tup.exec(this.ctx);
+    should(e['a']).equal(1);
+    should(e['b']).equal(2);
   });
 
-  it('should be able to define an empty tuple', function () {
-    const e = this.emptyTup.exec(this.ctx);
+  it('should be able to define an empty tuple', async function () {
+    const e = await this.emptyTup.exec(this.ctx);
     Object.keys(e).length.should.equal(0);
   });
 });

--- a/test/spec-tests/spec-test.ts
+++ b/test/spec-tests/spec-test.ts
@@ -51,9 +51,9 @@ describe('CQL Spec Tests (from XML)', () => {
               if (testCaseMap.has('expression') && testCaseMap.has('output')) {
                 const ctx = new PatientContext(library);
                 ctx.getExecutionDateTime().timezoneOffset = 0;
-                const actualExp = build(testCaseMap.get('expression'));
+                const actualExp = build(testCaseMap.get('expression')) as any;
                 let actual = actualExp.execute(ctx);
-                const expectedExp = build(testCaseMap.get('output'));
+                const expectedExp = build(testCaseMap.get('output')) as any;
                 let expected = expectedExp.execute(ctx);
                 if (expectedExp.json && expectedExp.json.type === 'Null') {
                   should(actual).be.null();


### PR DESCRIPTION
Asyncified handful of elm tests:

- list-test
- interval-test (done by @mgramigna)
- parameters-test
- external-test (also fixed issues with 'should' import which most of the other test files also needed the same fix)
- library-test (shows issue with sorting)
- instance-test
- structured-test
- nullological-test
- message-test
- executor-test

Adds a missing Promise.all in List expression. Replaced some `any`s while trying to track down the issue, mainly in the base Expression class and builder.