### PR TITLE
Async

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,15 +315,15 @@ describe('And', () => {
   });
 
   it('should execute allTrue as true', async function () {
-    (await this.allTrue.exec(this.ctx)).should.be.true();
+    should(await this.allTrue.exec(this.ctx)).be.true();
   });
 
   it('should execute someTrue as false', async function () {
-    (await this.someTrue.exec(this.ctx)).should.be.false();
+    should(await this.someTrue.exec(this.ctx)).be.false();
   });
 
   it('should execute allFalse as false', async function () {
-    (await this.allFalse.exec(this.ctx)).should.be.false();
+    should(await this.allFalse.exec(this.ctx)).be.false();
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -187,8 +187,14 @@ const psource = new cql.PatientSource([ {
   'birthDate' : '2007-08-02T11:47'
 } ]);
 
-const result = executor.exec(psource);
-console.log(JSON.stringify(result, undefined, 2));
+executor
+  .exec(psource)
+  .then(result => {
+    console.log(JSON.stringify(result, undefined, 2));
+  })
+  .catch(err => {
+    console.error(err);
+  });
 
 ```
 
@@ -308,16 +314,16 @@ describe('And', () => {
     setup(this, data);
   });
 
-  it('should execute allTrue as true', function () {
-    this.allTrue.exec(this.ctx).should.be.true();
+  it('should execute allTrue as true', async function () {
+    (await this.allTrue.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute someTrue as false', function () {
-    this.someTrue.exec(this.ctx).should.be.false();
+  it('should execute someTrue as false', async function () {
+    (await this.someTrue.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute allFalse as false', function () {
-    this.allFalse.exec(this.ctx).should.be.false();
+  it('should execute allFalse as false', async function () {
+    (await this.allFalse.exec(this.ctx)).should.be.false();
   });
 });
 ```

--- a/examples/browser/cql4browsers.html
+++ b/examples/browser/cql4browsers.html
@@ -2,7 +2,7 @@
   <head>
     <script src="cql4browsers.js"></script>
     <script>
-      function exec() {
+      async function exec() {
         f = document.getElementById('form');
         eval('elm = ' + f.elm.value)
         if (f.parameters.value.trim()) {
@@ -10,7 +10,7 @@
         } else {
           params = {}
         }
-        f.results.value = JSON.stringify(executeSimpleELM(elm, new cql.PatientSource([]), [], 'Math', '1', null, params), null, 2)
+        f.results.value = JSON.stringify(await executeSimpleELM(elm, new cql.PatientSource([]), [], 'Math', '1', null, params), null, 2)
       }
     </script>
   </head>

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -13609,7 +13609,7 @@ function asyncMergeSort(arr, compareFn) {
 exports.asyncMergeSort = asyncMergeSort;
 function merge(left, right, compareFn) {
     return __awaiter(this, void 0, void 0, function () {
-        var sorted;
+        var sorted, sortedElem, sortedElem;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
@@ -13620,10 +13620,16 @@ function merge(left, right, compareFn) {
                     return [4 /*yield*/, compareFn(left[0], right[0])];
                 case 2:
                     if ((_a.sent()) < 0) {
-                        sorted.push(left.shift());
+                        sortedElem = left.shift();
+                        if (sortedElem !== undefined) {
+                            sorted.push(sortedElem);
+                        }
                     }
                     else {
-                        sorted.push(right.shift());
+                        sortedElem = right.shift();
+                        if (sortedElem !== undefined) {
+                            sorted.push(sortedElem);
+                        }
                     }
                     return [3 /*break*/, 1];
                 case 3: return [2 /*return*/, __spreadArray(__spreadArray(__spreadArray([], sorted, true), left, true), right, true)];

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -2850,6 +2850,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AnyTrue = exports.AllTrue = exports.PopulationVariance = exports.Variance = exports.PopulationStdDev = exports.GeometricMean = exports.Product = exports.StdDev = exports.Mode = exports.Median = exports.Avg = exports.Max = exports.Min = exports.Sum = exports.Count = void 0;
 var expression_1 = require("./expression");
@@ -2873,11 +2909,20 @@ var Count = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Count.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if ((0, util_1.typeIsArray)(items)) {
-            return (0, util_1.removeNulls)(items).length;
-        }
-        return 0;
+        return __awaiter(this, void 0, void 0, function () {
+            var items;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if ((0, util_1.typeIsArray)(items)) {
+                            return [2 /*return*/, (0, util_1.removeNulls)(items).length];
+                        }
+                        return [2 /*return*/, 0];
+                }
+            });
+        });
     };
     return Count;
 }(AggregateExpression));
@@ -2888,27 +2933,37 @@ var Sum = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Sum.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if (!(0, util_1.typeIsArray)(items)) {
-            return null;
-        }
-        try {
-            items = processQuantities(items);
-        }
-        catch (e) {
-            return null;
-        }
-        if (items.length === 0) {
-            return null;
-        }
-        if (hasOnlyQuantities(items)) {
-            var values = getValuesFromQuantities(items);
-            var sum = values.reduce(function (x, y) { return x + y; });
-            return new datatypes_1.Quantity(sum, items[0].unit);
-        }
-        else {
-            return items.reduce(function (x, y) { return x + y; });
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var items, values, sum;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if (!(0, util_1.typeIsArray)(items)) {
+                            return [2 /*return*/, null];
+                        }
+                        try {
+                            items = processQuantities(items);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (items.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        if (hasOnlyQuantities(items)) {
+                            values = getValuesFromQuantities(items);
+                            sum = values.reduce(function (x, y) { return x + y; });
+                            return [2 /*return*/, new datatypes_1.Quantity(sum, items[0].unit)];
+                        }
+                        else {
+                            return [2 /*return*/, items.reduce(function (x, y) { return x + y; })];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Sum;
 }(AggregateExpression));
@@ -2919,31 +2974,39 @@ var Min = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Min.prototype.exec = function (ctx) {
-        var list = this.source.execute(ctx);
-        if (list == null) {
-            return null;
-        }
-        var listWithoutNulls = (0, util_1.removeNulls)(list);
-        // Check for incompatible units and return null. We don't want to convert
-        // the units for Min/Max, so we throw away the converted array if it succeeds
-        try {
-            processQuantities(list);
-        }
-        catch (e) {
-            return null;
-        }
-        if (listWithoutNulls.length === 0) {
-            return null;
-        }
-        // We assume the list is an array of all the same type.
-        var minimum = listWithoutNulls[0];
-        for (var _i = 0, listWithoutNulls_1 = listWithoutNulls; _i < listWithoutNulls_1.length; _i++) {
-            var element = listWithoutNulls_1[_i];
-            if ((0, comparison_1.lessThan)(element, minimum)) {
-                minimum = element;
-            }
-        }
-        return minimum;
+        return __awaiter(this, void 0, void 0, function () {
+            var list, listWithoutNulls, minimum, _i, listWithoutNulls_1, element;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        list = _a.sent();
+                        if (list == null) {
+                            return [2 /*return*/, null];
+                        }
+                        listWithoutNulls = (0, util_1.removeNulls)(list);
+                        // Check for incompatible units and return null. We don't want to convert
+                        // the units for Min/Max, so we throw away the converted array if it succeeds
+                        try {
+                            processQuantities(list);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (listWithoutNulls.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        minimum = listWithoutNulls[0];
+                        for (_i = 0, listWithoutNulls_1 = listWithoutNulls; _i < listWithoutNulls_1.length; _i++) {
+                            element = listWithoutNulls_1[_i];
+                            if ((0, comparison_1.lessThan)(element, minimum)) {
+                                minimum = element;
+                            }
+                        }
+                        return [2 /*return*/, minimum];
+                }
+            });
+        });
     };
     return Min;
 }(AggregateExpression));
@@ -2954,31 +3017,39 @@ var Max = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Max.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if (items == null) {
-            return null;
-        }
-        var listWithoutNulls = (0, util_1.removeNulls)(items);
-        // Check for incompatible units and return null. We don't want to convert
-        // the units for Min/Max, so we throw away the converted array if it succeeds
-        try {
-            processQuantities(items);
-        }
-        catch (e) {
-            return null;
-        }
-        if (listWithoutNulls.length === 0) {
-            return null;
-        }
-        // We assume the list is an array of all the same type.
-        var maximum = listWithoutNulls[0];
-        for (var _i = 0, listWithoutNulls_2 = listWithoutNulls; _i < listWithoutNulls_2.length; _i++) {
-            var element = listWithoutNulls_2[_i];
-            if ((0, comparison_1.greaterThan)(element, maximum)) {
-                maximum = element;
-            }
-        }
-        return maximum;
+        return __awaiter(this, void 0, void 0, function () {
+            var items, listWithoutNulls, maximum, _i, listWithoutNulls_2, element;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if (items == null) {
+                            return [2 /*return*/, null];
+                        }
+                        listWithoutNulls = (0, util_1.removeNulls)(items);
+                        // Check for incompatible units and return null. We don't want to convert
+                        // the units for Min/Max, so we throw away the converted array if it succeeds
+                        try {
+                            processQuantities(items);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (listWithoutNulls.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        maximum = listWithoutNulls[0];
+                        for (_i = 0, listWithoutNulls_2 = listWithoutNulls; _i < listWithoutNulls_2.length; _i++) {
+                            element = listWithoutNulls_2[_i];
+                            if ((0, comparison_1.greaterThan)(element, maximum)) {
+                                maximum = element;
+                            }
+                        }
+                        return [2 /*return*/, maximum];
+                }
+            });
+        });
     };
     return Max;
 }(AggregateExpression));
@@ -2989,28 +3060,38 @@ var Avg = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Avg.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if (!(0, util_1.typeIsArray)(items)) {
-            return null;
-        }
-        try {
-            items = processQuantities(items);
-        }
-        catch (e) {
-            return null;
-        }
-        if (items.length === 0) {
-            return null;
-        }
-        if (hasOnlyQuantities(items)) {
-            var values = getValuesFromQuantities(items);
-            var sum = values.reduce(function (x, y) { return x + y; });
-            return new datatypes_1.Quantity(sum / values.length, items[0].unit);
-        }
-        else {
-            var sum = items.reduce(function (x, y) { return x + y; });
-            return sum / items.length;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var items, values, sum, sum;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if (!(0, util_1.typeIsArray)(items)) {
+                            return [2 /*return*/, null];
+                        }
+                        try {
+                            items = processQuantities(items);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (items.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        if (hasOnlyQuantities(items)) {
+                            values = getValuesFromQuantities(items);
+                            sum = values.reduce(function (x, y) { return x + y; });
+                            return [2 /*return*/, new datatypes_1.Quantity(sum / values.length, items[0].unit)];
+                        }
+                        else {
+                            sum = items.reduce(function (x, y) { return x + y; });
+                            return [2 /*return*/, sum / items.length];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Avg;
 }(AggregateExpression));
@@ -3021,25 +3102,34 @@ var Median = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Median.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if (!(0, util_1.typeIsArray)(items)) {
-            return null;
-        }
-        if (items.length === 0) {
-            return null;
-        }
-        try {
-            items = processQuantities(items);
-        }
-        catch (e) {
-            return null;
-        }
-        if (!hasOnlyQuantities(items)) {
-            return medianOfNumbers(items);
-        }
-        var values = getValuesFromQuantities(items);
-        var median = medianOfNumbers(values);
-        return new datatypes_1.Quantity(median, items[0].unit);
+        return __awaiter(this, void 0, void 0, function () {
+            var items, values, median;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if (!(0, util_1.typeIsArray)(items)) {
+                            return [2 /*return*/, null];
+                        }
+                        if (items.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        try {
+                            items = processQuantities(items);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (!hasOnlyQuantities(items)) {
+                            return [2 /*return*/, medianOfNumbers(items)];
+                        }
+                        values = getValuesFromQuantities(items);
+                        median = medianOfNumbers(values);
+                        return [2 /*return*/, new datatypes_1.Quantity(median, items[0].unit)];
+                }
+            });
+        });
     };
     return Median;
 }(AggregateExpression));
@@ -3050,37 +3140,46 @@ var Mode = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Mode.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if (!(0, util_1.typeIsArray)(items)) {
-            return null;
-        }
-        if (items.length === 0) {
-            return null;
-        }
-        var filtered;
-        try {
-            filtered = processQuantities(items);
-        }
-        catch (e) {
-            return null;
-        }
-        if (hasOnlyQuantities(filtered)) {
-            var values = getValuesFromQuantities(filtered);
-            var mode = this.mode(values);
-            if (mode.length === 1) {
-                mode = mode[0];
-            }
-            return new datatypes_1.Quantity(mode, items[0].unit);
-        }
-        else {
-            var mode = this.mode(filtered);
-            if (mode.length === 1) {
-                return mode[0];
-            }
-            else {
-                return mode;
-            }
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var items, filtered, values, mode, mode;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if (!(0, util_1.typeIsArray)(items)) {
+                            return [2 /*return*/, null];
+                        }
+                        if (items.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        try {
+                            filtered = processQuantities(items);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (hasOnlyQuantities(filtered)) {
+                            values = getValuesFromQuantities(filtered);
+                            mode = this.mode(values);
+                            if (mode.length === 1) {
+                                mode = mode[0];
+                            }
+                            return [2 /*return*/, new datatypes_1.Quantity(mode, items[0].unit)];
+                        }
+                        else {
+                            mode = this.mode(filtered);
+                            if (mode.length === 1) {
+                                return [2 /*return*/, mode[0]];
+                            }
+                            else {
+                                return [2 /*return*/, mode];
+                            }
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     Mode.prototype.mode = function (arr) {
         var max = 0;
@@ -3110,27 +3209,37 @@ var StdDev = /** @class */ (function (_super) {
         return _this;
     }
     StdDev.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if (!(0, util_1.typeIsArray)(items)) {
-            return null;
-        }
-        try {
-            items = processQuantities(items);
-        }
-        catch (e) {
-            return null;
-        }
-        if (items.length === 0) {
-            return null;
-        }
-        if (hasOnlyQuantities(items)) {
-            var values = getValuesFromQuantities(items);
-            var stdDev = this.standardDeviation(values);
-            return new datatypes_1.Quantity(stdDev, items[0].unit);
-        }
-        else {
-            return this.standardDeviation(items);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var items, values, stdDev;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if (!(0, util_1.typeIsArray)(items)) {
+                            return [2 /*return*/, null];
+                        }
+                        try {
+                            items = processQuantities(items);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (items.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        if (hasOnlyQuantities(items)) {
+                            values = getValuesFromQuantities(items);
+                            stdDev = this.standardDeviation(values);
+                            return [2 /*return*/, new datatypes_1.Quantity(stdDev, items[0].unit)];
+                        }
+                        else {
+                            return [2 /*return*/, this.standardDeviation(items)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     StdDev.prototype.standardDeviation = function (list) {
         var val = this.stats(list);
@@ -3166,28 +3275,38 @@ var Product = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Product.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if (!(0, util_1.typeIsArray)(items)) {
-            return null;
-        }
-        try {
-            items = processQuantities(items);
-        }
-        catch (e) {
-            return null;
-        }
-        if (items.length === 0) {
-            return null;
-        }
-        if (hasOnlyQuantities(items)) {
-            var values = getValuesFromQuantities(items);
-            var product = values.reduce(function (x, y) { return x * y; });
-            // Units are not multiplied for the geometric product
-            return new datatypes_1.Quantity(product, items[0].unit);
-        }
-        else {
-            return items.reduce(function (x, y) { return x * y; });
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var items, values, product;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if (!(0, util_1.typeIsArray)(items)) {
+                            return [2 /*return*/, null];
+                        }
+                        try {
+                            items = processQuantities(items);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (items.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        if (hasOnlyQuantities(items)) {
+                            values = getValuesFromQuantities(items);
+                            product = values.reduce(function (x, y) { return x * y; });
+                            // Units are not multiplied for the geometric product
+                            return [2 /*return*/, new datatypes_1.Quantity(product, items[0].unit)];
+                        }
+                        else {
+                            return [2 /*return*/, items.reduce(function (x, y) { return x * y; })];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Product;
 }(AggregateExpression));
@@ -3198,29 +3317,39 @@ var GeometricMean = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     GeometricMean.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        if (!(0, util_1.typeIsArray)(items)) {
-            return null;
-        }
-        try {
-            items = processQuantities(items);
-        }
-        catch (e) {
-            return null;
-        }
-        if (items.length === 0) {
-            return null;
-        }
-        if (hasOnlyQuantities(items)) {
-            var values = getValuesFromQuantities(items);
-            var product = values.reduce(function (x, y) { return x * y; });
-            var geoMean = Math.pow(product, 1.0 / items.length);
-            return new datatypes_1.Quantity(geoMean, items[0].unit);
-        }
-        else {
-            var product = items.reduce(function (x, y) { return x * y; });
-            return Math.pow(product, 1.0 / items.length);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var items, values, product, geoMean, product;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        if (!(0, util_1.typeIsArray)(items)) {
+                            return [2 /*return*/, null];
+                        }
+                        try {
+                            items = processQuantities(items);
+                        }
+                        catch (e) {
+                            return [2 /*return*/, null];
+                        }
+                        if (items.length === 0) {
+                            return [2 /*return*/, null];
+                        }
+                        if (hasOnlyQuantities(items)) {
+                            values = getValuesFromQuantities(items);
+                            product = values.reduce(function (x, y) { return x * y; });
+                            geoMean = Math.pow(product, 1.0 / items.length);
+                            return [2 /*return*/, new datatypes_1.Quantity(geoMean, items[0].unit)];
+                        }
+                        else {
+                            product = items.reduce(function (x, y) { return x * y; });
+                            return [2 /*return*/, Math.pow(product, 1.0 / items.length)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return GeometricMean;
 }(AggregateExpression));
@@ -3261,8 +3390,17 @@ var AllTrue = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     AllTrue.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        return (0, util_1.allTrue)((0, util_1.removeNulls)(items));
+        return __awaiter(this, void 0, void 0, function () {
+            var items;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        return [2 /*return*/, (0, util_1.allTrue)((0, util_1.removeNulls)(items))];
+                }
+            });
+        });
     };
     return AllTrue;
 }(AggregateExpression));
@@ -3273,8 +3411,17 @@ var AnyTrue = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     AnyTrue.prototype.exec = function (ctx) {
-        var items = this.source.execute(ctx);
-        return (0, util_1.anyTrue)(items);
+        return __awaiter(this, void 0, void 0, function () {
+            var items;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        items = _a.sent();
+                        return [2 /*return*/, (0, util_1.anyTrue)(items)];
+                }
+            });
+        });
     };
     return AnyTrue;
 }(AggregateExpression));
@@ -3352,6 +3499,42 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Predecessor = exports.Successor = exports.MaxValue = exports.MinValue = exports.Power = exports.Log = exports.Exp = exports.Ln = exports.Round = exports.Negate = exports.Abs = exports.Truncate = exports.Floor = exports.Ceiling = exports.Modulo = exports.TruncatedDivide = exports.Divide = exports.Multiply = exports.Subtract = exports.Add = void 0;
 var expression_1 = require("./expression");
@@ -3365,39 +3548,48 @@ var Add = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Add.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args == null || args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        var sum = args.reduce(function (x, y) {
-            if (x.isUncertainty && !y.isUncertainty) {
-                y = new uncertainty_1.Uncertainty(y, y);
-            }
-            else if (y.isUncertainty && !x.isUncertainty) {
-                x = new uncertainty_1.Uncertainty(x, x);
-            }
-            if (x.isQuantity || x.isDateTime || x.isDate || (x.isTime && x.isTime())) {
-                return (0, quantity_1.doAddition)(x, y);
-            }
-            else if (x.isUncertainty && y.isUncertainty) {
-                if (x.low.isQuantity ||
-                    x.low.isDateTime ||
-                    x.low.isDate ||
-                    (x.low.isTime && x.low.isTime())) {
-                    return new uncertainty_1.Uncertainty((0, quantity_1.doAddition)(x.low, y.low), (0, quantity_1.doAddition)(x.high, y.high));
+        return __awaiter(this, void 0, void 0, function () {
+            var args, sum;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args == null || args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        sum = args.reduce(function (x, y) {
+                            if (x.isUncertainty && !y.isUncertainty) {
+                                y = new uncertainty_1.Uncertainty(y, y);
+                            }
+                            else if (y.isUncertainty && !x.isUncertainty) {
+                                x = new uncertainty_1.Uncertainty(x, x);
+                            }
+                            if (x.isQuantity || x.isDateTime || x.isDate || (x.isTime && x.isTime())) {
+                                return (0, quantity_1.doAddition)(x, y);
+                            }
+                            else if (x.isUncertainty && y.isUncertainty) {
+                                if (x.low.isQuantity ||
+                                    x.low.isDateTime ||
+                                    x.low.isDate ||
+                                    (x.low.isTime && x.low.isTime())) {
+                                    return new uncertainty_1.Uncertainty((0, quantity_1.doAddition)(x.low, y.low), (0, quantity_1.doAddition)(x.high, y.high));
+                                }
+                                else {
+                                    return new uncertainty_1.Uncertainty(x.low + y.low, x.high + y.high);
+                                }
+                            }
+                            else {
+                                return x + y;
+                            }
+                        });
+                        if (MathUtil.overflowsOrUnderflows(sum)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, sum];
                 }
-                else {
-                    return new uncertainty_1.Uncertainty(x.low + y.low, x.high + y.high);
-                }
-            }
-            else {
-                return x + y;
-            }
+            });
         });
-        if (MathUtil.overflowsOrUnderflows(sum)) {
-            return null;
-        }
-        return sum;
     };
     return Add;
 }(expression_1.Expression));
@@ -3408,36 +3600,45 @@ var Subtract = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Subtract.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args == null || args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        var difference = args.reduce(function (x, y) {
-            if (x.isUncertainty && !y.isUncertainty) {
-                y = new uncertainty_1.Uncertainty(y, y);
-            }
-            else if (y.isUncertainty && !x.isUncertainty) {
-                x = new uncertainty_1.Uncertainty(x, x);
-            }
-            if (x.isQuantity || x.isDateTime || x.isDate) {
-                return (0, quantity_1.doSubtraction)(x, y);
-            }
-            else if (x.isUncertainty && y.isUncertainty) {
-                if (x.low.isQuantity || x.low.isDateTime || x.low.isDate) {
-                    return new uncertainty_1.Uncertainty((0, quantity_1.doSubtraction)(x.low, y.high), (0, quantity_1.doSubtraction)(x.high, y.low));
+        return __awaiter(this, void 0, void 0, function () {
+            var args, difference;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args == null || args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        difference = args.reduce(function (x, y) {
+                            if (x.isUncertainty && !y.isUncertainty) {
+                                y = new uncertainty_1.Uncertainty(y, y);
+                            }
+                            else if (y.isUncertainty && !x.isUncertainty) {
+                                x = new uncertainty_1.Uncertainty(x, x);
+                            }
+                            if (x.isQuantity || x.isDateTime || x.isDate) {
+                                return (0, quantity_1.doSubtraction)(x, y);
+                            }
+                            else if (x.isUncertainty && y.isUncertainty) {
+                                if (x.low.isQuantity || x.low.isDateTime || x.low.isDate) {
+                                    return new uncertainty_1.Uncertainty((0, quantity_1.doSubtraction)(x.low, y.high), (0, quantity_1.doSubtraction)(x.high, y.low));
+                                }
+                                else {
+                                    return new uncertainty_1.Uncertainty(x.low - y.high, x.high - y.low);
+                                }
+                            }
+                            else {
+                                return x - y;
+                            }
+                        });
+                        if (MathUtil.overflowsOrUnderflows(difference)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, difference];
                 }
-                else {
-                    return new uncertainty_1.Uncertainty(x.low - y.high, x.high - y.low);
-                }
-            }
-            else {
-                return x - y;
-            }
+            });
         });
-        if (MathUtil.overflowsOrUnderflows(difference)) {
-            return null;
-        }
-        return difference;
     };
     return Subtract;
 }(expression_1.Expression));
@@ -3448,36 +3649,45 @@ var Multiply = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Multiply.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args == null || args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        var product = args.reduce(function (x, y) {
-            if (x.isUncertainty && !y.isUncertainty) {
-                y = new uncertainty_1.Uncertainty(y, y);
-            }
-            else if (y.isUncertainty && !x.isUncertainty) {
-                x = new uncertainty_1.Uncertainty(x, x);
-            }
-            if (x.isQuantity || y.isQuantity) {
-                return (0, quantity_1.doMultiplication)(x, y);
-            }
-            else if (x.isUncertainty && y.isUncertainty) {
-                if (x.low.isQuantity) {
-                    return new uncertainty_1.Uncertainty((0, quantity_1.doMultiplication)(x.low, y.low), (0, quantity_1.doMultiplication)(x.high, y.high));
+        return __awaiter(this, void 0, void 0, function () {
+            var args, product;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args == null || args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        product = args.reduce(function (x, y) {
+                            if (x.isUncertainty && !y.isUncertainty) {
+                                y = new uncertainty_1.Uncertainty(y, y);
+                            }
+                            else if (y.isUncertainty && !x.isUncertainty) {
+                                x = new uncertainty_1.Uncertainty(x, x);
+                            }
+                            if (x.isQuantity || y.isQuantity) {
+                                return (0, quantity_1.doMultiplication)(x, y);
+                            }
+                            else if (x.isUncertainty && y.isUncertainty) {
+                                if (x.low.isQuantity) {
+                                    return new uncertainty_1.Uncertainty((0, quantity_1.doMultiplication)(x.low, y.low), (0, quantity_1.doMultiplication)(x.high, y.high));
+                                }
+                                else {
+                                    return new uncertainty_1.Uncertainty(x.low * y.low, x.high * y.high);
+                                }
+                            }
+                            else {
+                                return x * y;
+                            }
+                        });
+                        if (MathUtil.overflowsOrUnderflows(product)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, product];
                 }
-                else {
-                    return new uncertainty_1.Uncertainty(x.low * y.low, x.high * y.high);
-                }
-            }
-            else {
-                return x * y;
-            }
+            });
         });
-        if (MathUtil.overflowsOrUnderflows(product)) {
-            return null;
-        }
-        return product;
     };
     return Multiply;
 }(expression_1.Expression));
@@ -3488,38 +3698,47 @@ var Divide = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Divide.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args == null || args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        var quotient = args.reduce(function (x, y) {
-            if (x.isUncertainty && !y.isUncertainty) {
-                y = new uncertainty_1.Uncertainty(y, y);
-            }
-            else if (y.isUncertainty && !x.isUncertainty) {
-                x = new uncertainty_1.Uncertainty(x, x);
-            }
-            if (x.isQuantity) {
-                return (0, quantity_1.doDivision)(x, y);
-            }
-            else if (x.isUncertainty && y.isUncertainty) {
-                if (x.low.isQuantity) {
-                    return new uncertainty_1.Uncertainty((0, quantity_1.doDivision)(x.low, y.high), (0, quantity_1.doDivision)(x.high, y.low));
+        return __awaiter(this, void 0, void 0, function () {
+            var args, quotient;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args == null || args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        quotient = args.reduce(function (x, y) {
+                            if (x.isUncertainty && !y.isUncertainty) {
+                                y = new uncertainty_1.Uncertainty(y, y);
+                            }
+                            else if (y.isUncertainty && !x.isUncertainty) {
+                                x = new uncertainty_1.Uncertainty(x, x);
+                            }
+                            if (x.isQuantity) {
+                                return (0, quantity_1.doDivision)(x, y);
+                            }
+                            else if (x.isUncertainty && y.isUncertainty) {
+                                if (x.low.isQuantity) {
+                                    return new uncertainty_1.Uncertainty((0, quantity_1.doDivision)(x.low, y.high), (0, quantity_1.doDivision)(x.high, y.low));
+                                }
+                                else {
+                                    return new uncertainty_1.Uncertainty(x.low / y.high, x.high / y.low);
+                                }
+                            }
+                            else {
+                                return x / y;
+                            }
+                        });
+                        // Note, anything divided by 0 is Infinity in Javascript, which will be
+                        // considered as overflow by this check.
+                        if (MathUtil.overflowsOrUnderflows(quotient)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, quotient];
                 }
-                else {
-                    return new uncertainty_1.Uncertainty(x.low / y.high, x.high / y.low);
-                }
-            }
-            else {
-                return x / y;
-            }
+            });
         });
-        // Note, anything divided by 0 is Infinity in Javascript, which will be
-        // considered as overflow by this check.
-        if (MathUtil.overflowsOrUnderflows(quotient)) {
-            return null;
-        }
-        return quotient;
     };
     return Divide;
 }(expression_1.Expression));
@@ -3530,16 +3749,25 @@ var TruncatedDivide = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     TruncatedDivide.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args == null || args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        var quotient = args.reduce(function (x, y) { return x / y; });
-        var truncatedQuotient = quotient >= 0 ? Math.floor(quotient) : Math.ceil(quotient);
-        if (MathUtil.overflowsOrUnderflows(truncatedQuotient)) {
-            return null;
-        }
-        return truncatedQuotient;
+        return __awaiter(this, void 0, void 0, function () {
+            var args, quotient, truncatedQuotient;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args == null || args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        quotient = args.reduce(function (x, y) { return x / y; });
+                        truncatedQuotient = quotient >= 0 ? Math.floor(quotient) : Math.ceil(quotient);
+                        if (MathUtil.overflowsOrUnderflows(truncatedQuotient)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, truncatedQuotient];
+                }
+            });
+        });
     };
     return TruncatedDivide;
 }(expression_1.Expression));
@@ -3550,12 +3778,21 @@ var Modulo = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Modulo.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args == null || args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        var modulo = args.reduce(function (x, y) { return x % y; });
-        return MathUtil.decimalOrNull(modulo);
+        return __awaiter(this, void 0, void 0, function () {
+            var args, modulo;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args == null || args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        modulo = args.reduce(function (x, y) { return x % y; });
+                        return [2 /*return*/, MathUtil.decimalOrNull(modulo)];
+                }
+            });
+        });
     };
     return Modulo;
 }(expression_1.Expression));
@@ -3566,11 +3803,20 @@ var Ceiling = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Ceiling.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        return Math.ceil(arg);
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, Math.ceil(arg)];
+                }
+            });
+        });
     };
     return Ceiling;
 }(expression_1.Expression));
@@ -3581,11 +3827,20 @@ var Floor = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Floor.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        return Math.floor(arg);
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, Math.floor(arg)];
+                }
+            });
+        });
     };
     return Floor;
 }(expression_1.Expression));
@@ -3596,11 +3851,20 @@ var Truncate = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Truncate.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        return arg >= 0 ? Math.floor(arg) : Math.ceil(arg);
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, arg >= 0 ? Math.floor(arg) : Math.ceil(arg)];
+                }
+            });
+        });
     };
     return Truncate;
 }(expression_1.Expression));
@@ -3611,16 +3875,26 @@ var Abs = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Abs.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        else if (arg.isQuantity) {
-            return new quantity_1.Quantity(Math.abs(arg.value), arg.unit);
-        }
-        else {
-            return Math.abs(arg);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        else if (arg.isQuantity) {
+                            return [2 /*return*/, new quantity_1.Quantity(Math.abs(arg.value), arg.unit)];
+                        }
+                        else {
+                            return [2 /*return*/, Math.abs(arg)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Abs;
 }(expression_1.Expression));
@@ -3631,16 +3905,26 @@ var Negate = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Negate.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        else if (arg.isQuantity) {
-            return new quantity_1.Quantity(arg.value * -1, arg.unit);
-        }
-        else {
-            return arg * -1;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        else if (arg.isQuantity) {
+                            return [2 /*return*/, new quantity_1.Quantity(arg.value * -1, arg.unit)];
+                        }
+                        else {
+                            return [2 /*return*/, arg * -1];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Negate;
 }(expression_1.Expression));
@@ -3653,12 +3937,30 @@ var Round = /** @class */ (function (_super) {
         return _this;
     }
     Round.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        var dec = this.precision != null ? this.precision.execute(ctx) : 0;
-        return Math.round(arg * Math.pow(10, dec)) / Math.pow(10, dec);
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, dec, _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _b.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        if (!(this.precision != null)) return [3 /*break*/, 3];
+                        return [4 /*yield*/, this.precision.execute(ctx)];
+                    case 2:
+                        _a = _b.sent();
+                        return [3 /*break*/, 4];
+                    case 3:
+                        _a = 0;
+                        _b.label = 4;
+                    case 4:
+                        dec = _a;
+                        return [2 /*return*/, Math.round(arg * Math.pow(10, dec)) / Math.pow(10, dec)];
+                }
+            });
+        });
     };
     return Round;
 }(expression_1.Expression));
@@ -3669,12 +3971,21 @@ var Ln = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Ln.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        var ln = Math.log(arg);
-        return MathUtil.decimalOrNull(ln);
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, ln;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        ln = Math.log(arg);
+                        return [2 /*return*/, MathUtil.decimalOrNull(ln)];
+                }
+            });
+        });
     };
     return Ln;
 }(expression_1.Expression));
@@ -3685,15 +3996,24 @@ var Exp = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Exp.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        var power = Math.exp(arg);
-        if (MathUtil.overflowsOrUnderflows(power)) {
-            return null;
-        }
-        return power;
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, power;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        power = Math.exp(arg);
+                        if (MathUtil.overflowsOrUnderflows(power)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, power];
+                }
+            });
+        });
     };
     return Exp;
 }(expression_1.Expression));
@@ -3704,12 +4024,21 @@ var Log = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Log.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args == null || args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        var log = args.reduce(function (x, y) { return Math.log(x) / Math.log(y); });
-        return MathUtil.decimalOrNull(log);
+        return __awaiter(this, void 0, void 0, function () {
+            var args, log;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args == null || args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        log = args.reduce(function (x, y) { return Math.log(x) / Math.log(y); });
+                        return [2 /*return*/, MathUtil.decimalOrNull(log)];
+                }
+            });
+        });
     };
     return Log;
 }(expression_1.Expression));
@@ -3720,15 +4049,24 @@ var Power = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Power.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args == null || args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        var power = args.reduce(function (x, y) { return Math.pow(x, y); });
-        if (MathUtil.overflowsOrUnderflows(power)) {
-            return null;
-        }
-        return power;
+        return __awaiter(this, void 0, void 0, function () {
+            var args, power;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args == null || args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        power = args.reduce(function (x, y) { return Math.pow(x, y); });
+                        if (MathUtil.overflowsOrUnderflows(power)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, power];
+                }
+            });
+        });
     };
     return Power;
 }(expression_1.Expression));
@@ -3741,19 +4079,25 @@ var MinValue = /** @class */ (function (_super) {
         return _this;
     }
     MinValue.prototype.exec = function (ctx) {
-        if (MinValue.MIN_VALUES[this.valueType]) {
-            if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
-                var minDateTime = MinValue.MIN_VALUES[this.valueType].copy();
-                minDateTime.timezoneOffset = ctx.getTimezoneOffset();
-                return minDateTime;
-            }
-            else {
-                return MinValue.MIN_VALUES[this.valueType];
-            }
-        }
-        else {
-            throw new Error("Minimum not supported for ".concat(this.valueType));
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var minDateTime;
+            return __generator(this, function (_a) {
+                if (MinValue.MIN_VALUES[this.valueType]) {
+                    if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
+                        minDateTime = MinValue.MIN_VALUES[this.valueType].copy();
+                        minDateTime.timezoneOffset = ctx.getTimezoneOffset();
+                        return [2 /*return*/, minDateTime];
+                    }
+                    else {
+                        return [2 /*return*/, MinValue.MIN_VALUES[this.valueType]];
+                    }
+                }
+                else {
+                    throw new Error("Minimum not supported for ".concat(this.valueType));
+                }
+                return [2 /*return*/];
+            });
+        });
     };
     MinValue.MIN_VALUES = {
         '{urn:hl7-org:elm-types:r1}Integer': MathUtil.MIN_INT_VALUE,
@@ -3773,19 +4117,25 @@ var MaxValue = /** @class */ (function (_super) {
         return _this;
     }
     MaxValue.prototype.exec = function (ctx) {
-        if (MaxValue.MAX_VALUES[this.valueType] != null) {
-            if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
-                var maxDateTime = MaxValue.MAX_VALUES[this.valueType].copy();
-                maxDateTime.timezoneOffset = ctx.getTimezoneOffset();
-                return maxDateTime;
-            }
-            else {
-                return MaxValue.MAX_VALUES[this.valueType];
-            }
-        }
-        else {
-            throw new Error("Maximum not supported for ".concat(this.valueType));
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var maxDateTime;
+            return __generator(this, function (_a) {
+                if (MaxValue.MAX_VALUES[this.valueType] != null) {
+                    if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
+                        maxDateTime = MaxValue.MAX_VALUES[this.valueType].copy();
+                        maxDateTime.timezoneOffset = ctx.getTimezoneOffset();
+                        return [2 /*return*/, maxDateTime];
+                    }
+                    else {
+                        return [2 /*return*/, MaxValue.MAX_VALUES[this.valueType]];
+                    }
+                }
+                else {
+                    throw new Error("Maximum not supported for ".concat(this.valueType));
+                }
+                return [2 /*return*/];
+            });
+        });
     };
     MaxValue.MAX_VALUES = {
         '{urn:hl7-org:elm-types:r1}Integer': MathUtil.MAX_INT_VALUE,
@@ -3803,25 +4153,34 @@ var Successor = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Successor.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        var successor = null;
-        try {
-            // MathUtil.successor throws on overflow, and the exception is used in
-            // the logic for evaluating `meets`, so it can't be changed to just return null
-            successor = MathUtil.successor(arg);
-        }
-        catch (e) {
-            if (e instanceof MathUtil.OverFlowException) {
-                return null;
-            }
-        }
-        if (MathUtil.overflowsOrUnderflows(successor)) {
-            return null;
-        }
-        return successor;
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, successor;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        successor = null;
+                        try {
+                            // MathUtil.successor throws on overflow, and the exception is used in
+                            // the logic for evaluating `meets`, so it can't be changed to just return null
+                            successor = MathUtil.successor(arg);
+                        }
+                        catch (e) {
+                            if (e instanceof MathUtil.OverFlowException) {
+                                return [2 /*return*/, null];
+                            }
+                        }
+                        if (MathUtil.overflowsOrUnderflows(successor)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, successor];
+                }
+            });
+        });
     };
     return Successor;
 }(expression_1.Expression));
@@ -3832,25 +4191,34 @@ var Predecessor = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Predecessor.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        var predecessor = null;
-        try {
-            // MathUtil.predecessor throws on underflow, and the exception is used in
-            // the logic for evaluating `meets`, so it can't be changed to just return null
-            predecessor = MathUtil.predecessor(arg);
-        }
-        catch (e) {
-            if (e instanceof MathUtil.OverFlowException) {
-                return null;
-            }
-        }
-        if (MathUtil.overflowsOrUnderflows(predecessor)) {
-            return null;
-        }
-        return predecessor;
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, predecessor;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        predecessor = null;
+                        try {
+                            // MathUtil.predecessor throws on underflow, and the exception is used in
+                            // the logic for evaluating `meets`, so it can't be changed to just return null
+                            predecessor = MathUtil.predecessor(arg);
+                        }
+                        catch (e) {
+                            if (e instanceof MathUtil.OverFlowException) {
+                                return [2 /*return*/, null];
+                            }
+                        }
+                        if (MathUtil.overflowsOrUnderflows(predecessor)) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, predecessor];
+                }
+            });
+        });
     };
     return Predecessor;
 }(expression_1.Expression));
@@ -3948,6 +4316,42 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.CalculateAgeAt = exports.CalculateAge = exports.Concept = exports.ConceptRef = exports.ConceptDef = exports.Code = exports.CodeRef = exports.CodeDef = exports.CodeSystemDef = exports.InValueSet = exports.AnyInValueSet = exports.ValueSetRef = exports.ValueSetDef = void 0;
 var expression_1 = require("./expression");
@@ -3964,9 +4368,14 @@ var ValueSetDef = /** @class */ (function (_super) {
     }
     //todo: code systems and versions
     ValueSetDef.prototype.exec = function (ctx) {
-        var valueset = ctx.codeService.findValueSet(this.id, this.version) || new dt.ValueSet(this.id, this.version);
-        ctx.rootContext().set(this.name, valueset);
-        return valueset;
+        return __awaiter(this, void 0, void 0, function () {
+            var valueset;
+            return __generator(this, function (_a) {
+                valueset = ctx.codeService.findValueSet(this.id, this.version) || new dt.ValueSet(this.id, this.version);
+                ctx.rootContext().set(this.name, valueset);
+                return [2 /*return*/, valueset];
+            });
+        });
     };
     return ValueSetDef;
 }(expression_1.Expression));
@@ -3980,12 +4389,21 @@ var ValueSetRef = /** @class */ (function (_super) {
         return _this;
     }
     ValueSetRef.prototype.exec = function (ctx) {
-        // TODO: This calls the code service every time-- should be optimized
-        var valueset = ctx.getValueSet(this.name, this.libraryName);
-        if (valueset instanceof expression_1.Expression) {
-            valueset = valueset.execute(ctx);
-        }
-        return valueset;
+        return __awaiter(this, void 0, void 0, function () {
+            var valueset;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        valueset = ctx.getValueSet(this.name, this.libraryName);
+                        if (!(valueset instanceof expression_1.Expression)) return [3 /*break*/, 2];
+                        return [4 /*yield*/, valueset.execute(ctx)];
+                    case 1:
+                        valueset = _a.sent();
+                        _a.label = 2;
+                    case 2: return [2 /*return*/, valueset];
+                }
+            });
+        });
     };
     return ValueSetRef;
 }(expression_1.Expression));
@@ -3999,13 +4417,24 @@ var AnyInValueSet = /** @class */ (function (_super) {
         return _this;
     }
     AnyInValueSet.prototype.exec = function (ctx) {
-        var valueset = this.valueset.execute(ctx);
-        // If the value set reference cannot be resolved, a run-time error is thrown.
-        if (valueset == null || !valueset.isValueSet) {
-            throw new Error('ValueSet must be provided to InValueSet function');
-        }
-        var codes = this.codes.exec(ctx);
-        return codes != null && codes.some(function (code) { return valueset.hasMatch(code); });
+        return __awaiter(this, void 0, void 0, function () {
+            var valueset, codes;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.valueset.execute(ctx)];
+                    case 1:
+                        valueset = _a.sent();
+                        // If the value set reference cannot be resolved, a run-time error is thrown.
+                        if (valueset == null || !valueset.isValueSet) {
+                            throw new Error('ValueSet must be provided to InValueSet function');
+                        }
+                        return [4 /*yield*/, this.codes.exec(ctx)];
+                    case 2:
+                        codes = _a.sent();
+                        return [2 /*return*/, codes != null && codes.some(function (code) { return valueset.hasMatch(code); })];
+                }
+            });
+        });
     };
     return AnyInValueSet;
 }(expression_1.Expression));
@@ -4019,24 +4448,36 @@ var InValueSet = /** @class */ (function (_super) {
         return _this;
     }
     InValueSet.prototype.exec = function (ctx) {
-        // If the code argument is null, the result is false
-        if (this.code == null) {
-            return false;
-        }
-        if (this.valueset == null) {
-            throw new Error('ValueSet must be provided to InValueSet function');
-        }
-        var code = this.code.execute(ctx);
-        // spec indicates to return false if code is null, throw error if value set cannot be resolved
-        if (code == null) {
-            return false;
-        }
-        var valueset = this.valueset.execute(ctx);
-        if (valueset == null || !valueset.isValueSet) {
-            throw new Error('ValueSet must be provided to InValueSet function');
-        }
-        // If there is a code and valueset return whether or not the valueset has the code
-        return valueset.hasMatch(code);
+        return __awaiter(this, void 0, void 0, function () {
+            var code, valueset;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        // If the code argument is null, the result is false
+                        if (this.code == null) {
+                            return [2 /*return*/, false];
+                        }
+                        if (this.valueset == null) {
+                            throw new Error('ValueSet must be provided to InValueSet function');
+                        }
+                        return [4 /*yield*/, this.code.execute(ctx)];
+                    case 1:
+                        code = _a.sent();
+                        // spec indicates to return false if code is null, throw error if value set cannot be resolved
+                        if (code == null) {
+                            return [2 /*return*/, false];
+                        }
+                        return [4 /*yield*/, this.valueset.execute(ctx)];
+                    case 2:
+                        valueset = _a.sent();
+                        if (valueset == null || !valueset.isValueSet) {
+                            throw new Error('ValueSet must be provided to InValueSet function');
+                        }
+                        // If there is a code and valueset return whether or not the valueset has the code
+                        return [2 /*return*/, valueset.hasMatch(code)];
+                }
+            });
+        });
     };
     return InValueSet;
 }(expression_1.Expression));
@@ -4051,7 +4492,11 @@ var CodeSystemDef = /** @class */ (function (_super) {
         return _this;
     }
     CodeSystemDef.prototype.exec = function (_ctx) {
-        return new dt.CodeSystem(this.id, this.version);
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, new dt.CodeSystem(this.id, this.version)];
+            });
+        });
     };
     return CodeSystemDef;
 }(expression_1.Expression));
@@ -4067,8 +4512,17 @@ var CodeDef = /** @class */ (function (_super) {
         return _this;
     }
     CodeDef.prototype.exec = function (ctx) {
-        var system = ctx.getCodeSystem(this.systemName).execute(ctx);
-        return new dt.Code(this.id, system.id, system.version, this.display);
+        return __awaiter(this, void 0, void 0, function () {
+            var system;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, ctx.getCodeSystem(this.systemName).execute(ctx)];
+                    case 1:
+                        system = _a.sent();
+                        return [2 /*return*/, new dt.Code(this.id, system.id, system.version, this.display)];
+                }
+            });
+        });
     };
     return CodeDef;
 }(expression_1.Expression));
@@ -4082,9 +4536,14 @@ var CodeRef = /** @class */ (function (_super) {
         return _this;
     }
     CodeRef.prototype.exec = function (ctx) {
-        ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
-        var codeDef = ctx.getCode(this.name);
-        return codeDef ? codeDef.execute(ctx) : undefined;
+        return __awaiter(this, void 0, void 0, function () {
+            var codeDef;
+            return __generator(this, function (_a) {
+                ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
+                codeDef = ctx.getCode(this.name);
+                return [2 /*return*/, codeDef ? codeDef.execute(ctx) : undefined];
+            });
+        });
     };
     return CodeRef;
 }(expression_1.Expression));
@@ -4109,8 +4568,13 @@ var Code = /** @class */ (function (_super) {
         configurable: true
     });
     Code.prototype.exec = function (ctx) {
-        var system = ctx.getCodeSystem(this.systemName) || {};
-        return new dt.Code(this.code, system.id, this.version, this.display);
+        return __awaiter(this, void 0, void 0, function () {
+            var system;
+            return __generator(this, function (_a) {
+                system = ctx.getCodeSystem(this.systemName) || {};
+                return [2 /*return*/, new dt.Code(this.code, system.id, this.version, this.display)];
+            });
+        });
     };
     return Code;
 }(expression_1.Expression));
@@ -4125,11 +4589,24 @@ var ConceptDef = /** @class */ (function (_super) {
         return _this;
     }
     ConceptDef.prototype.exec = function (ctx) {
-        var codes = this.codes.map(function (code) {
-            var codeDef = ctx.getCode(code.name);
-            return codeDef ? codeDef.execute(ctx) : undefined;
+        return __awaiter(this, void 0, void 0, function () {
+            var codes;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, Promise.all(this.codes.map(function (code) { return __awaiter(_this, void 0, void 0, function () {
+                            var codeDef;
+                            return __generator(this, function (_a) {
+                                codeDef = ctx.getCode(code.name);
+                                return [2 /*return*/, codeDef ? codeDef.execute(ctx) : undefined];
+                            });
+                        }); }))];
+                    case 1:
+                        codes = _a.sent();
+                        return [2 /*return*/, new dt.Concept(codes, this.display)];
+                }
+            });
         });
-        return new dt.Concept(codes, this.display);
     };
     return ConceptDef;
 }(expression_1.Expression));
@@ -4142,8 +4619,13 @@ var ConceptRef = /** @class */ (function (_super) {
         return _this;
     }
     ConceptRef.prototype.exec = function (ctx) {
-        var conceptDef = ctx.getConcept(this.name);
-        return conceptDef ? conceptDef.execute(ctx) : undefined;
+        return __awaiter(this, void 0, void 0, function () {
+            var conceptDef;
+            return __generator(this, function (_a) {
+                conceptDef = ctx.getConcept(this.name);
+                return [2 /*return*/, conceptDef ? conceptDef.execute(ctx) : undefined];
+            });
+        });
     };
     return ConceptRef;
 }(expression_1.Expression));
@@ -4170,9 +4652,14 @@ var Concept = /** @class */ (function (_super) {
         return new dt.Code(code.code, system.id, code.version, code.display);
     };
     Concept.prototype.exec = function (ctx) {
-        var _this = this;
-        var codes = this.codes.map(function (code) { return _this.toCode(ctx, code); });
-        return new dt.Concept(codes, this.display);
+        return __awaiter(this, void 0, void 0, function () {
+            var codes;
+            var _this = this;
+            return __generator(this, function (_a) {
+                codes = this.codes.map(function (code) { return _this.toCode(ctx, code); });
+                return [2 /*return*/, new dt.Concept(codes, this.display)];
+            });
+        });
     };
     return Concept;
 }(expression_1.Expression));
@@ -4185,15 +4672,25 @@ var CalculateAge = /** @class */ (function (_super) {
         return _this;
     }
     CalculateAge.prototype.exec = function (ctx) {
-        var date1 = this.execArgs(ctx);
-        var date2 = dt.DateTime.fromJSDate(ctx.getExecutionDateTime());
-        var result = date1 != null ? date1.durationBetween(date2, this.precision.toLowerCase()) : undefined;
-        if (result != null && result.isPoint()) {
-            return result.low;
-        }
-        else {
-            return result;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var date1, date2, result;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        date1 = _a.sent();
+                        date2 = dt.DateTime.fromJSDate(ctx.getExecutionDateTime());
+                        result = date1 != null ? date1.durationBetween(date2, this.precision.toLowerCase()) : undefined;
+                        if (result != null && result.isPoint()) {
+                            return [2 /*return*/, result.low];
+                        }
+                        else {
+                            return [2 /*return*/, result];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return CalculateAge;
 }(expression_1.Expression));
@@ -4206,22 +4703,30 @@ var CalculateAgeAt = /** @class */ (function (_super) {
         return _this;
     }
     CalculateAgeAt.prototype.exec = function (ctx) {
-        // eslint-disable-next-line prefer-const
-        var _a = this.execArgs(ctx), date1 = _a[0], date2 = _a[1];
-        if (date1 != null && date2 != null) {
-            // date1 is the birthdate, convert it to date if date2 is a date (to support ignoring time)
-            if (date2.isDate && date1.isDateTime) {
-                date1 = date1.getDate();
-            }
-            var result = date1.durationBetween(date2, this.precision.toLowerCase());
-            if (result != null && result.isPoint()) {
-                return result.low;
-            }
-            else {
-                return result;
-            }
-        }
-        return null;
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, date1, date2, result;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), date1 = _a[0], date2 = _a[1];
+                        if (date1 != null && date2 != null) {
+                            // date1 is the birthdate, convert it to date if date2 is a date (to support ignoring time)
+                            if (date2.isDate && date1.isDateTime) {
+                                date1 = date1.getDate();
+                            }
+                            result = date1.durationBetween(date2, this.precision.toLowerCase());
+                            if (result != null && result.isPoint()) {
+                                return [2 /*return*/, result.low];
+                            }
+                            else {
+                                return [2 /*return*/, result];
+                            }
+                        }
+                        return [2 /*return*/, null];
+                }
+            });
+        });
     };
     return CalculateAgeAt;
 }(expression_1.Expression));
@@ -4244,6 +4749,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.GreaterOrEqual = exports.Greater = exports.LessOrEqual = exports.Less = void 0;
 var expression_1 = require("./expression");
@@ -4256,11 +4797,20 @@ var Less = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Less.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx).map(function (x) { return datatypes_1.Uncertainty.from(x); });
-        if (args[0] == null || args[1] == null) {
-            return null;
-        }
-        return args[0].lessThan(args[1]);
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = (_a.sent()).map(function (x) { return datatypes_1.Uncertainty.from(x); });
+                        if (args[0] == null || args[1] == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, args[0].lessThan(args[1])];
+                }
+            });
+        });
     };
     return Less;
 }(expression_1.Expression));
@@ -4271,11 +4821,20 @@ var LessOrEqual = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     LessOrEqual.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx).map(function (x) { return datatypes_1.Uncertainty.from(x); });
-        if (args[0] == null || args[1] == null) {
-            return null;
-        }
-        return args[0].lessThanOrEquals(args[1]);
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = (_a.sent()).map(function (x) { return datatypes_1.Uncertainty.from(x); });
+                        if (args[0] == null || args[1] == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, args[0].lessThanOrEquals(args[1])];
+                }
+            });
+        });
     };
     return LessOrEqual;
 }(expression_1.Expression));
@@ -4286,11 +4845,20 @@ var Greater = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Greater.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx).map(function (x) { return datatypes_1.Uncertainty.from(x); });
-        if (args[0] == null || args[1] == null) {
-            return null;
-        }
-        return args[0].greaterThan(args[1]);
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = (_a.sent()).map(function (x) { return datatypes_1.Uncertainty.from(x); });
+                        if (args[0] == null || args[1] == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, args[0].greaterThan(args[1])];
+                }
+            });
+        });
     };
     return Greater;
 }(expression_1.Expression));
@@ -4301,11 +4869,20 @@ var GreaterOrEqual = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     GreaterOrEqual.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx).map(function (x) { return datatypes_1.Uncertainty.from(x); });
-        if (args[0] == null || args[1] == null) {
-            return null;
-        }
-        return args[0].greaterThanOrEquals(args[1]);
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = (_a.sent()).map(function (x) { return datatypes_1.Uncertainty.from(x); });
+                        if (args[0] == null || args[1] == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, args[0].greaterThanOrEquals(args[1])];
+                }
+            });
+        });
     };
     return GreaterOrEqual;
 }(expression_1.Expression));
@@ -4328,6 +4905,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Case = exports.CaseItem = exports.If = void 0;
 var expression_1 = require("./expression");
@@ -4344,12 +4957,21 @@ var If = /** @class */ (function (_super) {
         return _this;
     }
     If.prototype.exec = function (ctx) {
-        if (this.condition.execute(ctx)) {
-            return this.th.execute(ctx);
-        }
-        else {
-            return this.els.execute(ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.condition.execute(ctx)];
+                    case 1:
+                        if (_a.sent()) {
+                            return [2 /*return*/, this.th.execute(ctx)];
+                        }
+                        else {
+                            return [2 /*return*/, this.els.execute(ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return If;
 }(expression_1.Expression));
@@ -4372,31 +4994,70 @@ var Case = /** @class */ (function (_super) {
         return _this;
     }
     Case.prototype.exec = function (ctx) {
-        if (this.comparand) {
-            return this.exec_selected(ctx);
-        }
-        else {
-            return this.exec_standard(ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (this.comparand) {
+                    return [2 /*return*/, this.exec_selected(ctx)];
+                }
+                else {
+                    return [2 /*return*/, this.exec_standard(ctx)];
+                }
+                return [2 /*return*/];
+            });
+        });
     };
     Case.prototype.exec_selected = function (ctx) {
-        var val = this.comparand.execute(ctx);
-        for (var _i = 0, _a = this.caseItems; _i < _a.length; _i++) {
-            var ci = _a[_i];
-            if ((0, comparison_1.equals)(ci.when.execute(ctx), val)) {
-                return ci.then.execute(ctx);
-            }
-        }
-        return this.els.execute(ctx);
+        return __awaiter(this, void 0, void 0, function () {
+            var val, _i, _a, ci, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0: return [4 /*yield*/, this.comparand.execute(ctx)];
+                    case 1:
+                        val = _c.sent();
+                        _i = 0, _a = this.caseItems;
+                        _c.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3 /*break*/, 5];
+                        ci = _a[_i];
+                        _b = comparison_1.equals;
+                        return [4 /*yield*/, ci.when.execute(ctx)];
+                    case 3:
+                        if (_b.apply(void 0, [_c.sent(), val])) {
+                            return [2 /*return*/, ci.then.execute(ctx)];
+                        }
+                        _c.label = 4;
+                    case 4:
+                        _i++;
+                        return [3 /*break*/, 2];
+                    case 5: return [2 /*return*/, this.els.execute(ctx)];
+                }
+            });
+        });
     };
     Case.prototype.exec_standard = function (ctx) {
-        for (var _i = 0, _a = this.caseItems; _i < _a.length; _i++) {
-            var ci = _a[_i];
-            if (ci.when.execute(ctx)) {
-                return ci.then.execute(ctx);
-            }
-        }
-        return this.els.execute(ctx);
+        return __awaiter(this, void 0, void 0, function () {
+            var _i, _a, ci;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        _i = 0, _a = this.caseItems;
+                        _b.label = 1;
+                    case 1:
+                        if (!(_i < _a.length)) return [3 /*break*/, 4];
+                        ci = _a[_i];
+                        return [4 /*yield*/, ci.when.execute(ctx)];
+                    case 2:
+                        if (_b.sent()) {
+                            return [2 /*return*/, ci.then.execute(ctx)];
+                        }
+                        _b.label = 3;
+                    case 3:
+                        _i++;
+                        return [3 /*break*/, 1];
+                    case 4: return [2 /*return*/, this.els.execute(ctx)];
+                }
+            });
+        });
     };
     return Case;
 }(expression_1.Expression));
@@ -4438,6 +5099,42 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
     if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
         if (ar || !(i in from)) {
@@ -4462,27 +5159,40 @@ var DateTime = /** @class */ (function (_super) {
         return _this;
     }
     DateTime.prototype.exec = function (ctx) {
-        var _a;
-        var _this = this;
-        for (var _i = 0, _b = DateTime.PROPERTIES; _i < _b.length; _i++) {
-            var property = _b[_i];
-            // if json does not contain 'timezoneOffset' set it to the executionDateTime from the context
-            if (this.json[property] != null) {
-                // @ts-ignore
-                this[property] = (0, builder_1.build)(this.json[property]);
-            }
-            else if (property === 'timezoneOffset' && ctx.getTimezoneOffset() != null) {
-                // @ts-ignore
-                this[property] = literal_1.Literal.from({
-                    type: 'Literal',
-                    value: ctx.getTimezoneOffset(),
-                    valueType: '{urn:hl7-org:elm-types:r1}Integer'
-                });
-            }
-        }
-        // @ts-ignore
-        var args = DateTime.PROPERTIES.map(function (p) { return (_this[p] != null ? _this[p].execute(ctx) : undefined); });
-        return new ((_a = DT.DateTime).bind.apply(_a, __spreadArray([void 0], args, false)))();
+        return __awaiter(this, void 0, void 0, function () {
+            var _i, _a, property, args;
+            var _b;
+            var _this = this;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        for (_i = 0, _a = DateTime.PROPERTIES; _i < _a.length; _i++) {
+                            property = _a[_i];
+                            // if json does not contain 'timezoneOffset' set it to the executionDateTime from the context
+                            if (this.json[property] != null) {
+                                // @ts-ignore
+                                this[property] = (0, builder_1.build)(this.json[property]);
+                            }
+                            else if (property === 'timezoneOffset' && ctx.getTimezoneOffset() != null) {
+                                // @ts-ignore
+                                this[property] = literal_1.Literal.from({
+                                    type: 'Literal',
+                                    value: ctx.getTimezoneOffset(),
+                                    valueType: '{urn:hl7-org:elm-types:r1}Integer'
+                                });
+                            }
+                        }
+                        return [4 /*yield*/, Promise.all(
+                            // @ts-ignore
+                            DateTime.PROPERTIES.map(function (p) { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+                                return [2 /*return*/, (this[p] != null ? this[p].execute(ctx) : undefined)];
+                            }); }); }))];
+                    case 1:
+                        args = _c.sent();
+                        return [2 /*return*/, new ((_b = DT.DateTime).bind.apply(_b, __spreadArray([void 0], args, false)))()];
+                }
+            });
+        });
     };
     DateTime.PROPERTIES = [
         'year',
@@ -4505,18 +5215,31 @@ var Date = /** @class */ (function (_super) {
         return _this;
     }
     Date.prototype.exec = function (ctx) {
-        var _a;
-        var _this = this;
-        for (var _i = 0, _b = Date.PROPERTIES; _i < _b.length; _i++) {
-            var property = _b[_i];
-            if (this.json[property] != null) {
-                // @ts-ignore
-                this[property] = (0, builder_1.build)(this.json[property]);
-            }
-        }
-        // @ts-ignore
-        var args = Date.PROPERTIES.map(function (p) { return (_this[p] != null ? _this[p].execute(ctx) : undefined); });
-        return new ((_a = DT.Date).bind.apply(_a, __spreadArray([void 0], args, false)))();
+        return __awaiter(this, void 0, void 0, function () {
+            var _i, _a, property, args;
+            var _b;
+            var _this = this;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        for (_i = 0, _a = Date.PROPERTIES; _i < _a.length; _i++) {
+                            property = _a[_i];
+                            if (this.json[property] != null) {
+                                // @ts-ignore
+                                this[property] = (0, builder_1.build)(this.json[property]);
+                            }
+                        }
+                        return [4 /*yield*/, Promise.all(
+                            // @ts-ignore
+                            Date.PROPERTIES.map(function (p) { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+                                return [2 /*return*/, (this[p] != null ? this[p].execute(ctx) : undefined)];
+                            }); }); }))];
+                    case 1:
+                        args = _c.sent();
+                        return [2 /*return*/, new ((_b = DT.Date).bind.apply(_b, __spreadArray([void 0], args, false)))()];
+                }
+            });
+        });
     };
     Date.PROPERTIES = ['year', 'month', 'day'];
     return Date;
@@ -4536,11 +5259,23 @@ var Time = /** @class */ (function (_super) {
         return _this;
     }
     Time.prototype.exec = function (ctx) {
-        var _a;
-        var _this = this;
-        // @ts-ignore
-        var args = Time.PROPERTIES.map(function (p) { return (_this[p] != null ? _this[p].execute(ctx) : undefined); });
-        return new ((_a = DT.DateTime).bind.apply(_a, __spreadArray([void 0, 0, 1, 1], args, false)))().getTime();
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            var _a;
+            var _this = this;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, Promise.all(
+                        // @ts-ignore
+                        Time.PROPERTIES.map(function (p) { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+                            return [2 /*return*/, (this[p] != null ? this[p].execute(ctx) : undefined)];
+                        }); }); }))];
+                    case 1:
+                        args = _b.sent();
+                        return [2 /*return*/, new ((_a = DT.DateTime).bind.apply(_a, __spreadArray([void 0, 0, 1, 1], args, false)))().getTime()];
+                }
+            });
+        });
     };
     Time.PROPERTIES = ['hour', 'minute', 'second', 'millisecond'];
     return Time;
@@ -4552,7 +5287,11 @@ var Today = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Today.prototype.exec = function (ctx) {
-        return ctx.getExecutionDateTime().getDate();
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, ctx.getExecutionDateTime().getDate()];
+            });
+        });
     };
     return Today;
 }(expression_1.Expression));
@@ -4563,7 +5302,11 @@ var Now = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Now.prototype.exec = function (ctx) {
-        return ctx.getExecutionDateTime();
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, ctx.getExecutionDateTime()];
+            });
+        });
     };
     return Now;
 }(expression_1.Expression));
@@ -4574,7 +5317,11 @@ var TimeOfDay = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     TimeOfDay.prototype.exec = function (ctx) {
-        return ctx.getExecutionDateTime().getTime();
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, ctx.getExecutionDateTime().getTime()];
+            });
+        });
     };
     return TimeOfDay;
 }(expression_1.Expression));
@@ -4587,13 +5334,23 @@ var DateTimeComponentFrom = /** @class */ (function (_super) {
         return _this;
     }
     DateTimeComponentFrom.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            return arg[this.precision.toLowerCase()];
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            return [2 /*return*/, arg[this.precision.toLowerCase()]];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return DateTimeComponentFrom;
 }(expression_1.Expression));
@@ -4604,13 +5361,23 @@ var DateFrom = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     DateFrom.prototype.exec = function (ctx) {
-        var date = this.execArgs(ctx);
-        if (date != null) {
-            return date.getDate();
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var date;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        date = _a.sent();
+                        if (date != null) {
+                            return [2 /*return*/, date.getDate()];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return DateFrom;
 }(expression_1.Expression));
@@ -4621,13 +5388,23 @@ var TimeFrom = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     TimeFrom.prototype.exec = function (ctx) {
-        var date = this.execArgs(ctx);
-        if (date != null) {
-            return date.getTime();
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var date;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        date = _a.sent();
+                        if (date != null) {
+                            return [2 /*return*/, date.getTime()];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return TimeFrom;
 }(expression_1.Expression));
@@ -4638,13 +5415,23 @@ var TimezoneOffsetFrom = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     TimezoneOffsetFrom.prototype.exec = function (ctx) {
-        var date = this.execArgs(ctx);
-        if (date != null) {
-            return date.timezoneOffset;
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var date;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        date = _a.sent();
+                        if (date != null) {
+                            return [2 /*return*/, date.timezoneOffset];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return TimezoneOffsetFrom;
 }(expression_1.Expression));
@@ -4667,21 +5454,31 @@ var DifferenceBetween = /** @class */ (function (_super) {
         return _this;
     }
     DifferenceBetween.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        // Check to make sure args exist and that they have differenceBetween functions so that they can be compared to one another
-        if (args[0] == null ||
-            args[1] == null ||
-            typeof args[0].differenceBetween !== 'function' ||
-            typeof args[1].differenceBetween !== 'function') {
-            return null;
-        }
-        var result = args[0].differenceBetween(args[1], this.precision != null ? this.precision.toLowerCase() : undefined);
-        if (result != null && result.isPoint()) {
-            return result.low;
-        }
-        else {
-            return result;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var args, result;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        // Check to make sure args exist and that they have differenceBetween functions so that they can be compared to one another
+                        if (args[0] == null ||
+                            args[1] == null ||
+                            typeof args[0].differenceBetween !== 'function' ||
+                            typeof args[1].differenceBetween !== 'function') {
+                            return [2 /*return*/, null];
+                        }
+                        result = args[0].differenceBetween(args[1], this.precision != null ? this.precision.toLowerCase() : undefined);
+                        if (result != null && result.isPoint()) {
+                            return [2 /*return*/, result.low];
+                        }
+                        else {
+                            return [2 /*return*/, result];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return DifferenceBetween;
 }(expression_1.Expression));
@@ -4694,21 +5491,31 @@ var DurationBetween = /** @class */ (function (_super) {
         return _this;
     }
     DurationBetween.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        // Check to make sure args exist and that they have durationBetween functions so that they can be compared to one another
-        if (args[0] == null ||
-            args[1] == null ||
-            typeof args[0].durationBetween !== 'function' ||
-            typeof args[1].durationBetween !== 'function') {
-            return null;
-        }
-        var result = args[0].durationBetween(args[1], this.precision != null ? this.precision.toLowerCase() : undefined);
-        if (result != null && result.isPoint()) {
-            return result.low;
-        }
-        else {
-            return result;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var args, result;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        // Check to make sure args exist and that they have durationBetween functions so that they can be compared to one another
+                        if (args[0] == null ||
+                            args[1] == null ||
+                            typeof args[0].durationBetween !== 'function' ||
+                            typeof args[1].durationBetween !== 'function') {
+                            return [2 /*return*/, null];
+                        }
+                        result = args[0].durationBetween(args[1], this.precision != null ? this.precision.toLowerCase() : undefined);
+                        if (result != null && result.isPoint()) {
+                            return [2 /*return*/, result.low];
+                        }
+                        else {
+                            return [2 /*return*/, result];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return DurationBetween;
 }(expression_1.Expression));
@@ -4776,6 +5583,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.UnimplementedExpression = exports.Expression = void 0;
 var util_1 = require("../util/util");
@@ -4796,29 +5639,47 @@ var Expression = /** @class */ (function () {
         }
     }
     Expression.prototype.execute = function (ctx) {
-        if (this.localId != null) {
-            // Store the localId and result on the root context of this library
-            var execValue = this.exec(ctx);
-            ctx.rootContext().setLocalIdWithResult(this.localId, execValue);
-            return execValue;
-        }
-        else {
-            return this.exec(ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var execValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        if (!(this.localId != null)) return [3 /*break*/, 2];
+                        return [4 /*yield*/, this.exec(ctx)];
+                    case 1:
+                        execValue = _a.sent();
+                        ctx.rootContext().setLocalIdWithResult(this.localId, execValue);
+                        return [2 /*return*/, execValue];
+                    case 2: return [2 /*return*/, this.exec(ctx)];
+                }
+            });
+        });
     };
     Expression.prototype.exec = function (_ctx) {
-        return this;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this];
+            });
+        });
     };
     Expression.prototype.execArgs = function (ctx) {
-        if (this.args != null) {
-            return this.args.map(function (arg) { return arg.execute(ctx); });
-        }
-        else if (this.arg != null) {
-            return this.arg.execute(ctx);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _this = this;
+            return __generator(this, function (_a) {
+                if (this.args != null) {
+                    return [2 /*return*/, Promise.all(this.args.map(function (arg) { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+                            return [2 /*return*/, arg.execute(ctx)];
+                        }); }); }))];
+                }
+                else if (this.arg != null) {
+                    return [2 /*return*/, this.arg.execute(ctx)];
+                }
+                else {
+                    return [2 /*return*/, null];
+                }
+                return [2 /*return*/];
+            });
+        });
     };
     return Expression;
 }());
@@ -4831,7 +5692,11 @@ var UnimplementedExpression = /** @class */ (function (_super) {
         return _this;
     }
     UnimplementedExpression.prototype.exec = function (_ctx) {
-        throw new Error("Unimplemented Expression: ".concat(this.json.type));
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                throw new Error("Unimplemented Expression: ".concat(this.json.type));
+            });
+        });
     };
     return UnimplementedExpression;
 }(Expression));
@@ -4907,6 +5772,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Retrieve = void 0;
 var expression_1 = require("./expression");
@@ -4925,31 +5826,45 @@ var Retrieve = /** @class */ (function (_super) {
         return _this;
     }
     Retrieve.prototype.exec = function (ctx) {
-        var _a;
-        var _this = this;
-        var records = ctx.findRecords(this.templateId != null ? this.templateId : this.datatype);
-        var codes = this.codes;
-        if (this.codes && typeof this.codes.exec === 'function') {
-            codes = this.codes.execute(ctx);
-            if (codes == null) {
-                return [];
-            }
-        }
-        if (codes) {
-            records = records.filter(function (r) { return _this.recordMatchesCodesOrVS(r, codes); });
-        }
-        // TODO: Added @dateProperty check due to previous fix in cql4browsers in cql_qdm_patient_api hash: ddbc57
-        if (this.dateRange && this.dateProperty) {
-            var range_1 = this.dateRange.execute(ctx);
-            records = records.filter(function (r) { return range_1.includes(r.getDateOrInterval(_this.dateProperty)); });
-        }
-        if (Array.isArray(records)) {
-            (_a = ctx.evaluatedRecords).push.apply(_a, records);
-        }
-        else {
-            ctx.evaluatedRecords.push(records);
-        }
-        return records;
+        return __awaiter(this, void 0, void 0, function () {
+            var records, codes, range_1;
+            var _a;
+            var _this = this;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, ctx.findRecords(this.templateId != null ? this.templateId : this.datatype)];
+                    case 1:
+                        records = _b.sent();
+                        codes = this.codes;
+                        if (!(this.codes && typeof this.codes.exec === 'function')) return [3 /*break*/, 3];
+                        return [4 /*yield*/, this.codes.execute(ctx)];
+                    case 2:
+                        codes = _b.sent();
+                        if (codes == null) {
+                            return [2 /*return*/, []];
+                        }
+                        _b.label = 3;
+                    case 3:
+                        if (codes) {
+                            records = records.filter(function (r) { return _this.recordMatchesCodesOrVS(r, codes); });
+                        }
+                        if (!(this.dateRange && this.dateProperty)) return [3 /*break*/, 5];
+                        return [4 /*yield*/, this.dateRange.execute(ctx)];
+                    case 4:
+                        range_1 = _b.sent();
+                        records = records.filter(function (r) { return range_1.includes(r.getDateOrInterval(_this.dateProperty)); });
+                        _b.label = 5;
+                    case 5:
+                        if (Array.isArray(records)) {
+                            (_a = ctx.evaluatedRecords).push.apply(_a, records);
+                        }
+                        else {
+                            ctx.evaluatedRecords.push(records);
+                        }
+                        return [2 /*return*/, records];
+                }
+            });
+        });
     };
     Retrieve.prototype.recordMatchesCodesOrVS = function (record, codes) {
         var _this = this;
@@ -4981,6 +5896,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Instance = void 0;
 var expression_1 = require("./expression");
@@ -4993,7 +5944,11 @@ var Element = /** @class */ (function () {
         this.value = (0, builder_1.build)(json.value);
     }
     Element.prototype.exec = function (ctx) {
-        return this.value != null ? this.value.execute(ctx) : undefined;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.value != null ? this.value.execute(ctx) : undefined];
+            });
+        });
     };
     return Element;
 }());
@@ -5006,21 +5961,41 @@ var Instance = /** @class */ (function (_super) {
         return _this;
     }
     Instance.prototype.exec = function (ctx) {
-        var obj = {};
-        for (var _i = 0, _a = this.element; _i < _a.length; _i++) {
-            var el = _a[_i];
-            obj[el.name] = el.exec(ctx);
-        }
-        switch (this.classType) {
-            case '{urn:hl7-org:elm-types:r1}Quantity':
-                return new quantity_1.Quantity(obj.value, obj.unit);
-            case '{urn:hl7-org:elm-types:r1}Code':
-                return new datatypes_1.Code(obj.code, obj.system, obj.version, obj.display);
-            case '{urn:hl7-org:elm-types:r1}Concept':
-                return new datatypes_1.Concept(obj.codes, obj.display);
-            default:
-                return obj;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var obj, _i, _a, el, _b, _c;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
+                    case 0:
+                        obj = {};
+                        _i = 0, _a = this.element;
+                        _d.label = 1;
+                    case 1:
+                        if (!(_i < _a.length)) return [3 /*break*/, 4];
+                        el = _a[_i];
+                        _b = obj;
+                        _c = el.name;
+                        return [4 /*yield*/, el.exec(ctx)];
+                    case 2:
+                        _b[_c] = _d.sent();
+                        _d.label = 3;
+                    case 3:
+                        _i++;
+                        return [3 /*break*/, 1];
+                    case 4:
+                        switch (this.classType) {
+                            case '{urn:hl7-org:elm-types:r1}Quantity':
+                                return [2 /*return*/, new quantity_1.Quantity(obj.value, obj.unit)];
+                            case '{urn:hl7-org:elm-types:r1}Code':
+                                return [2 /*return*/, new datatypes_1.Code(obj.code, obj.system, obj.version, obj.display)];
+                            case '{urn:hl7-org:elm-types:r1}Concept':
+                                return [2 /*return*/, new datatypes_1.Concept(obj.codes, obj.display)];
+                            default:
+                                return [2 /*return*/, obj];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Instance;
 }(expression_1.Expression));
@@ -5062,6 +6037,42 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Collapse = exports.Expand = exports.Ends = exports.Starts = exports.End = exports.Start = exports.Size = exports.Width = exports.doIntersect = exports.doExcept = exports.doUnion = exports.OverlapsBefore = exports.OverlapsAfter = exports.Overlaps = exports.MeetsBefore = exports.MeetsAfter = exports.Meets = exports.doBefore = exports.doAfter = exports.doProperIncludes = exports.doIncludes = exports.doContains = exports.Interval = void 0;
 var expression_1 = require("./expression");
@@ -5092,26 +6103,60 @@ var Interval = /** @class */ (function (_super) {
         configurable: true
     });
     Interval.prototype.exec = function (ctx) {
-        var lowValue = this.low.execute(ctx);
-        var highValue = this.high.execute(ctx);
-        var lowClosed = this.lowClosed != null
-            ? this.lowClosed
-            : this.lowClosedExpression && this.lowClosedExpression.execute(ctx);
-        var highClosed = this.highClosed != null
-            ? this.highClosed
-            : this.highClosedExpression && this.highClosedExpression.execute(ctx);
-        var defaultPointType;
-        if (lowValue == null && highValue == null) {
-            // try to get the default point type from a cast
-            if (this.low.asTypeSpecifier && this.low.asTypeSpecifier.type === 'NamedTypeSpecifier') {
-                defaultPointType = this.low.asTypeSpecifier.name;
-            }
-            else if (this.high.asTypeSpecifier &&
-                this.high.asTypeSpecifier.type === 'NamedTypeSpecifier') {
-                defaultPointType = this.high.asTypeSpecifier.name;
-            }
-        }
-        return new dtivl.Interval(lowValue, highValue, lowClosed, highClosed, defaultPointType);
+        return __awaiter(this, void 0, void 0, function () {
+            var lowValue, highValue, lowClosed, _a, _b, highClosed, _c, _d, defaultPointType;
+            return __generator(this, function (_e) {
+                switch (_e.label) {
+                    case 0: return [4 /*yield*/, this.low.execute(ctx)];
+                    case 1:
+                        lowValue = _e.sent();
+                        return [4 /*yield*/, this.high.execute(ctx)];
+                    case 2:
+                        highValue = _e.sent();
+                        if (!(this.lowClosed != null)) return [3 /*break*/, 3];
+                        _a = this.lowClosed;
+                        return [3 /*break*/, 6];
+                    case 3:
+                        _b = this.lowClosedExpression;
+                        if (!_b) return [3 /*break*/, 5];
+                        return [4 /*yield*/, this.lowClosedExpression.execute(ctx)];
+                    case 4:
+                        _b = (_e.sent());
+                        _e.label = 5;
+                    case 5:
+                        _a = _b;
+                        _e.label = 6;
+                    case 6:
+                        lowClosed = _a;
+                        if (!(this.highClosed != null)) return [3 /*break*/, 7];
+                        _c = this.highClosed;
+                        return [3 /*break*/, 10];
+                    case 7:
+                        _d = this.highClosedExpression;
+                        if (!_d) return [3 /*break*/, 9];
+                        return [4 /*yield*/, this.highClosedExpression.execute(ctx)];
+                    case 8:
+                        _d = (_e.sent());
+                        _e.label = 9;
+                    case 9:
+                        _c = _d;
+                        _e.label = 10;
+                    case 10:
+                        highClosed = _c;
+                        if (lowValue == null && highValue == null) {
+                            // try to get the default point type from a cast
+                            if (this.low.asTypeSpecifier && this.low.asTypeSpecifier.type === 'NamedTypeSpecifier') {
+                                defaultPointType = this.low.asTypeSpecifier.name;
+                            }
+                            else if (this.high.asTypeSpecifier &&
+                                this.high.asTypeSpecifier.type === 'NamedTypeSpecifier') {
+                                defaultPointType = this.high.asTypeSpecifier.name;
+                            }
+                        }
+                        return [2 /*return*/, new dtivl.Interval(lowValue, highValue, lowClosed, highClosed, defaultPointType)];
+                }
+            });
+        });
     };
     return Interval;
 }(expression_1.Expression));
@@ -5151,13 +6196,23 @@ var Meets = /** @class */ (function (_super) {
         return _this;
     }
     Meets.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.meets(b, this.precision);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.meets(b, this.precision)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Meets;
 }(expression_1.Expression));
@@ -5170,13 +6225,23 @@ var MeetsAfter = /** @class */ (function (_super) {
         return _this;
     }
     MeetsAfter.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.meetsAfter(b, this.precision);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.meetsAfter(b, this.precision)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return MeetsAfter;
 }(expression_1.Expression));
@@ -5189,13 +6254,23 @@ var MeetsBefore = /** @class */ (function (_super) {
         return _this;
     }
     MeetsBefore.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.meetsBefore(b, this.precision);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.meetsBefore(b, this.precision)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return MeetsBefore;
 }(expression_1.Expression));
@@ -5208,13 +6283,23 @@ var Overlaps = /** @class */ (function (_super) {
         return _this;
     }
     Overlaps.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.overlaps(b, this.precision);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.overlaps(b, this.precision)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Overlaps;
 }(expression_1.Expression));
@@ -5227,13 +6312,23 @@ var OverlapsAfter = /** @class */ (function (_super) {
         return _this;
     }
     OverlapsAfter.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.overlapsAfter(b, this.precision);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.overlapsAfter(b, this.precision)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return OverlapsAfter;
 }(expression_1.Expression));
@@ -5246,13 +6341,23 @@ var OverlapsBefore = /** @class */ (function (_super) {
         return _this;
     }
     OverlapsBefore.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.overlapsBefore(b, this.precision);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.overlapsBefore(b, this.precision)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return OverlapsBefore;
 }(expression_1.Expression));
@@ -5288,11 +6393,21 @@ var Width = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Width.prototype.exec = function (ctx) {
-        var interval = this.arg.execute(ctx);
-        if (interval == null) {
-            return null;
-        }
-        return interval.width();
+        var _a;
+        return __awaiter(this, void 0, void 0, function () {
+            var interval;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, ((_a = this.arg) === null || _a === void 0 ? void 0 : _a.execute(ctx))];
+                    case 1:
+                        interval = _b.sent();
+                        if (interval == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, interval.width()];
+                }
+            });
+        });
     };
     return Width;
 }(expression_1.Expression));
@@ -5303,11 +6418,21 @@ var Size = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Size.prototype.exec = function (ctx) {
-        var interval = this.arg.execute(ctx);
-        if (interval == null) {
-            return null;
-        }
-        return interval.size();
+        var _a;
+        return __awaiter(this, void 0, void 0, function () {
+            var interval;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, ((_a = this.arg) === null || _a === void 0 ? void 0 : _a.execute(ctx))];
+                    case 1:
+                        interval = _b.sent();
+                        if (interval == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, interval.size()];
+                }
+            });
+        });
     };
     return Size;
 }(expression_1.Expression));
@@ -5318,16 +6443,26 @@ var Start = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Start.prototype.exec = function (ctx) {
-        var interval = this.arg.execute(ctx);
-        if (interval == null) {
-            return null;
-        }
-        var start = interval.start();
-        // fix the timezoneOffset of minimum Datetime to match context offset
-        if (start && start.isDateTime && start.equals(math_1.MIN_DATETIME_VALUE)) {
-            start.timezoneOffset = ctx.getTimezoneOffset();
-        }
-        return start;
+        var _a;
+        return __awaiter(this, void 0, void 0, function () {
+            var interval, start;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, ((_a = this.arg) === null || _a === void 0 ? void 0 : _a.execute(ctx))];
+                    case 1:
+                        interval = _b.sent();
+                        if (interval == null) {
+                            return [2 /*return*/, null];
+                        }
+                        start = interval.start();
+                        // fix the timezoneOffset of minimum Datetime to match context offset
+                        if (start && start.isDateTime && start.equals(math_1.MIN_DATETIME_VALUE)) {
+                            start.timezoneOffset = ctx.getTimezoneOffset();
+                        }
+                        return [2 /*return*/, start];
+                }
+            });
+        });
     };
     return Start;
 }(expression_1.Expression));
@@ -5338,16 +6473,26 @@ var End = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     End.prototype.exec = function (ctx) {
-        var interval = this.arg.execute(ctx);
-        if (interval == null) {
-            return null;
-        }
-        var end = interval.end();
-        // fix the timezoneOffset of maximum Datetime to match context offset
-        if (end && end.isDateTime && end.equals(math_1.MAX_DATETIME_VALUE)) {
-            end.timezoneOffset = ctx.getTimezoneOffset();
-        }
-        return end;
+        var _a;
+        return __awaiter(this, void 0, void 0, function () {
+            var interval, end;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, ((_a = this.arg) === null || _a === void 0 ? void 0 : _a.execute(ctx))];
+                    case 1:
+                        interval = _b.sent();
+                        if (interval == null) {
+                            return [2 /*return*/, null];
+                        }
+                        end = interval.end();
+                        // fix the timezoneOffset of maximum Datetime to match context offset
+                        if (end && end.isDateTime && end.equals(math_1.MAX_DATETIME_VALUE)) {
+                            end.timezoneOffset = ctx.getTimezoneOffset();
+                        }
+                        return [2 /*return*/, end];
+                }
+            });
+        });
     };
     return End;
 }(expression_1.Expression));
@@ -5360,13 +6505,23 @@ var Starts = /** @class */ (function (_super) {
         return _this;
     }
     Starts.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.starts(b, this.precision);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.starts(b, this.precision)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Starts;
 }(expression_1.Expression));
@@ -5379,13 +6534,23 @@ var Ends = /** @class */ (function (_super) {
         return _this;
     }
     Ends.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.ends(b, this.precision);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.ends(b, this.precision)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Ends;
 }(expression_1.Expression));
@@ -5487,63 +6652,70 @@ var Expand = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Expand.prototype.exec = function (ctx) {
-        // expand(argument List<Interval<T>>, per Quantity) List<Interval<T>>
-        var defaultPer, expandFunction;
-        var _a = this.execArgs(ctx), intervals = _a[0], per = _a[1];
-        // CQL 1.5 introduced an overload to allow singular intervals; make it a list so we can use the same logic for either overload
-        if (!Array.isArray(intervals)) {
-            intervals = [intervals];
-        }
-        var type = intervalListType(intervals);
-        if (type === 'mismatch') {
-            throw new Error('List of intervals contains mismatched types.');
-        }
-        if (type == null) {
-            return null;
-        }
-        // this step collapses overlaps, and also returns a clone of intervals so we can feel free to mutate
-        intervals = collapseIntervals(intervals, per);
-        if (intervals.length === 0) {
-            return [];
-        }
-        if (['time', 'date', 'datetime'].includes(type)) {
-            expandFunction = this.expandDTishInterval;
-            defaultPer = function (interval) { return new quantity_1.Quantity(1, interval.low.getPrecision()); };
-        }
-        else if (['quantity'].includes(type)) {
-            expandFunction = this.expandQuantityInterval;
-            defaultPer = function (interval) { return new quantity_1.Quantity(1, interval.low.unit); };
-        }
-        else if (['integer', 'decimal'].includes(type)) {
-            expandFunction = this.expandNumericInterval;
-            defaultPer = function (_interval) { return new quantity_1.Quantity(1, '1'); };
-        }
-        else {
-            throw new Error('Interval list type not yet supported.');
-        }
-        var results = [];
-        for (var _i = 0, intervals_2 = intervals; _i < intervals_2.length; _i++) {
-            var interval = intervals_2[_i];
-            if (interval == null) {
-                continue;
-            }
-            // We do not support open ended intervals since result would likely be too long
-            if (interval.low == null || interval.high == null) {
-                return null;
-            }
-            if (type === 'datetime') {
-                //support for implicitly converting dates to datetime
-                interval.low = interval.low.getDateTime();
-                interval.high = interval.high.getDateTime();
-            }
-            per = per != null ? per : defaultPer(interval);
-            var items = expandFunction.call(this, interval, per);
-            if (items === null) {
-                return null;
-            }
-            results.push.apply(results, (items || []));
-        }
-        return results;
+        return __awaiter(this, void 0, void 0, function () {
+            var defaultPer, expandFunction, _a, intervals, per, type, results, _i, intervals_2, interval, items;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), intervals = _a[0], per = _a[1];
+                        // CQL 1.5 introduced an overload to allow singular intervals; make it a list so we can use the same logic for either overload
+                        if (!Array.isArray(intervals)) {
+                            intervals = [intervals];
+                        }
+                        type = intervalListType(intervals);
+                        if (type === 'mismatch') {
+                            throw new Error('List of intervals contains mismatched types.');
+                        }
+                        if (type == null) {
+                            return [2 /*return*/, null];
+                        }
+                        // this step collapses overlaps, and also returns a clone of intervals so we can feel free to mutate
+                        intervals = collapseIntervals(intervals, per);
+                        if (intervals.length === 0) {
+                            return [2 /*return*/, []];
+                        }
+                        if (['time', 'date', 'datetime'].includes(type)) {
+                            expandFunction = this.expandDTishInterval;
+                            defaultPer = function (interval) { return new quantity_1.Quantity(1, interval.low.getPrecision()); };
+                        }
+                        else if (['quantity'].includes(type)) {
+                            expandFunction = this.expandQuantityInterval;
+                            defaultPer = function (interval) { return new quantity_1.Quantity(1, interval.low.unit); };
+                        }
+                        else if (['integer', 'decimal'].includes(type)) {
+                            expandFunction = this.expandNumericInterval;
+                            defaultPer = function (_interval) { return new quantity_1.Quantity(1, '1'); };
+                        }
+                        else {
+                            throw new Error('Interval list type not yet supported.');
+                        }
+                        results = [];
+                        for (_i = 0, intervals_2 = intervals; _i < intervals_2.length; _i++) {
+                            interval = intervals_2[_i];
+                            if (interval == null) {
+                                continue;
+                            }
+                            // We do not support open ended intervals since result would likely be too long
+                            if (interval.low == null || interval.high == null) {
+                                return [2 /*return*/, null];
+                            }
+                            if (type === 'datetime') {
+                                //support for implicitly converting dates to datetime
+                                interval.low = interval.low.getDateTime();
+                                interval.high = interval.high.getDateTime();
+                            }
+                            per = per != null ? per : defaultPer(interval);
+                            items = expandFunction.call(this, interval, per);
+                            if (items === null) {
+                                return [2 /*return*/, null];
+                            }
+                            results.push.apply(results, (items || []));
+                        }
+                        return [2 /*return*/, results];
+                }
+            });
+        });
     };
     Expand.prototype.expandDTishInterval = function (interval, per) {
         per.unit = (0, units_1.convertToCQLDateUnit)(per.unit);
@@ -5680,9 +6852,17 @@ var Collapse = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Collapse.prototype.exec = function (ctx) {
-        // collapse(argument List<Interval<T>>, per Quantity) List<Interval<T>>
-        var _a = this.execArgs(ctx), intervals = _a[0], perWidth = _a[1];
-        return collapseIntervals(intervals, perWidth);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, intervals, perWidth;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), intervals = _a[0], perWidth = _a[1];
+                        return [2 /*return*/, collapseIntervals(intervals, perWidth)];
+                }
+            });
+        });
     };
     return Collapse;
 }(expression_1.Expression));
@@ -5948,6 +7128,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Slice = exports.Last = exports.First = exports.Current = exports.Distinct = exports.Flatten = exports.ForEach = exports.doProperIncludes = exports.doIncludes = exports.doContains = exports.IndexOf = exports.ToList = exports.SingletonFrom = exports.Filter = exports.Times = exports.doIntersect = exports.doExcept = exports.doUnion = exports.Exists = exports.List = void 0;
 var expression_1 = require("./expression");
@@ -5969,7 +7185,14 @@ var List = /** @class */ (function (_super) {
         configurable: true
     });
     List.prototype.exec = function (ctx) {
-        return this.elements.map(function (item) { return item.execute(ctx); });
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, Promise.all(this.elements.map(function (item) { return item.execute(ctx); }))];
+                    case 1: return [2 /*return*/, _a.sent()];
+                }
+            });
+        });
     };
     return List;
 }(expression_1.Expression));
@@ -5980,12 +7203,21 @@ var Exists = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Exists.prototype.exec = function (ctx) {
-        var list = this.execArgs(ctx);
-        // if list exists and has non empty length we need to make sure it isnt just full of nulls
-        if (list) {
-            return list.some(function (item) { return item != null; });
-        }
-        return false;
+        return __awaiter(this, void 0, void 0, function () {
+            var list;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        list = _a.sent();
+                        // if list exists and has non empty length we need to make sure it isnt just full of nulls
+                        if (list) {
+                            return [2 /*return*/, list.some(function (item) { return item != null; })];
+                        }
+                        return [2 /*return*/, false];
+                }
+            });
+        });
     };
     return Exists;
 }(expression_1.Expression));
@@ -6036,16 +7268,26 @@ var SingletonFrom = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     SingletonFrom.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null && arg.length > 1) {
-            throw new Error("IllegalArgument: 'SingletonFrom' requires a 0 or 1 arg array");
-        }
-        else if (arg != null && arg.length === 1) {
-            return arg[0];
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null && arg.length > 1) {
+                            throw new Error("IllegalArgument: 'SingletonFrom' requires a 0 or 1 arg array");
+                        }
+                        else if (arg != null && arg.length === 1) {
+                            return [2 /*return*/, arg[0]];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return SingletonFrom;
 }(expression_1.Expression));
@@ -6056,13 +7298,23 @@ var ToList = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToList.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            return [arg];
-        }
-        else {
-            return [];
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            return [2 /*return*/, [arg]];
+                        }
+                        else {
+                            return [2 /*return*/, []];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ToList;
 }(expression_1.Expression));
@@ -6076,25 +7328,36 @@ var IndexOf = /** @class */ (function (_super) {
         return _this;
     }
     IndexOf.prototype.exec = function (ctx) {
-        var index;
-        var src = this.source.execute(ctx);
-        var el = this.element.execute(ctx);
-        if (src == null || el == null) {
-            return null;
-        }
-        for (var i = 0; i < src.length; i++) {
-            var itm = src[i];
-            if ((0, comparison_1.equals)(itm, el)) {
-                index = i;
-                break;
-            }
-        }
-        if (index != null) {
-            return index;
-        }
-        else {
-            return -1;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var index, src, el, i, itm;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        src = _a.sent();
+                        return [4 /*yield*/, this.element.execute(ctx)];
+                    case 2:
+                        el = _a.sent();
+                        if (src == null || el == null) {
+                            return [2 /*return*/, null];
+                        }
+                        for (i = 0; i < src.length; i++) {
+                            itm = src[i];
+                            if ((0, comparison_1.equals)(itm, el)) {
+                                index = i;
+                                break;
+                            }
+                        }
+                        if (index != null) {
+                            return [2 /*return*/, index];
+                        }
+                        else {
+                            return [2 /*return*/, -1];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return IndexOf;
 }(expression_1.Expression));
@@ -6131,13 +7394,23 @@ var Flatten = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Flatten.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if ((0, util_1.typeIsArray)(arg) && arg.every(function (x) { return (0, util_1.typeIsArray)(x); })) {
-            return arg.reduce(function (x, y) { return x.concat(y); }, []);
-        }
-        else {
-            return arg;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if ((0, util_1.typeIsArray)(arg) && arg.every(function (x) { return (0, util_1.typeIsArray)(x); })) {
+                            return [2 /*return*/, arg.reduce(function (x, y) { return x.concat(y); }, [])];
+                        }
+                        else {
+                            return [2 /*return*/, arg];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Flatten;
 }(expression_1.Expression));
@@ -6148,11 +7421,20 @@ var Distinct = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Distinct.prototype.exec = function (ctx) {
-        var result = this.execArgs(ctx);
-        if (result == null) {
-            return null;
-        }
-        return doDistinct(result);
+        return __awaiter(this, void 0, void 0, function () {
+            var result;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        result = _a.sent();
+                        if (result == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, doDistinct(result)];
+                }
+            });
+        });
     };
     return Distinct;
 }(expression_1.Expression));
@@ -6200,13 +7482,23 @@ var First = /** @class */ (function (_super) {
         return _this;
     }
     First.prototype.exec = function (ctx) {
-        var src = this.source.exec(ctx);
-        if (src != null && (0, util_1.typeIsArray)(src) && src.length > 0) {
-            return src[0];
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var src;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.exec(ctx)];
+                    case 1:
+                        src = _a.sent();
+                        if (src != null && (0, util_1.typeIsArray)(src) && src.length > 0) {
+                            return [2 /*return*/, src[0]];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return First;
 }(expression_1.Expression));
@@ -6219,13 +7511,23 @@ var Last = /** @class */ (function (_super) {
         return _this;
     }
     Last.prototype.exec = function (ctx) {
-        var src = this.source.exec(ctx);
-        if (src != null && (0, util_1.typeIsArray)(src) && src.length > 0) {
-            return src[src.length - 1];
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var src;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.exec(ctx)];
+                    case 1:
+                        src = _a.sent();
+                        if (src != null && (0, util_1.typeIsArray)(src) && src.length > 0) {
+                            return [2 /*return*/, src[src.length - 1]];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Last;
 }(expression_1.Expression));
@@ -6240,18 +7542,30 @@ var Slice = /** @class */ (function (_super) {
         return _this;
     }
     Slice.prototype.exec = function (ctx) {
-        var src = this.source.exec(ctx);
-        if (src != null && (0, util_1.typeIsArray)(src)) {
-            var startIndex = this.startIndex.exec(ctx);
-            var endIndex = this.endIndex.exec(ctx);
-            var start = startIndex != null ? startIndex : 0;
-            var end = endIndex != null ? endIndex : src.length;
-            if (src.length === 0 || start < 0 || end < 0 || end < start) {
-                return [];
-            }
-            return src.slice(start, end);
-        }
-        return null;
+        return __awaiter(this, void 0, void 0, function () {
+            var src, startIndex, endIndex, start, end;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.exec(ctx)];
+                    case 1:
+                        src = _a.sent();
+                        if (!(src != null && (0, util_1.typeIsArray)(src))) return [3 /*break*/, 4];
+                        return [4 /*yield*/, this.startIndex.exec(ctx)];
+                    case 2:
+                        startIndex = _a.sent();
+                        return [4 /*yield*/, this.endIndex.exec(ctx)];
+                    case 3:
+                        endIndex = _a.sent();
+                        start = startIndex != null ? startIndex : 0;
+                        end = endIndex != null ? endIndex : src.length;
+                        if (src.length === 0 || start < 0 || end < 0 || end < start) {
+                            return [2 /*return*/, []];
+                        }
+                        return [2 /*return*/, src.slice(start, end)];
+                    case 4: return [2 /*return*/, null];
+                }
+            });
+        });
     };
     return Slice;
 }(expression_1.Expression));
@@ -6275,6 +7589,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.StringLiteral = exports.DecimalLiteral = exports.IntegerLiteral = exports.BooleanLiteral = exports.Literal = void 0;
 var expression_1 = require("./expression");
@@ -6301,7 +7651,11 @@ var Literal = /** @class */ (function (_super) {
         }
     };
     Literal.prototype.exec = function (_ctx) {
-        return this.value;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.value];
+            });
+        });
     };
     return Literal;
 }(expression_1.Expression));
@@ -6324,7 +7678,11 @@ var BooleanLiteral = /** @class */ (function (_super) {
         configurable: true
     });
     BooleanLiteral.prototype.exec = function (_ctx) {
-        return this.value;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.value];
+            });
+        });
     };
     return BooleanLiteral;
 }(Literal));
@@ -6346,7 +7704,11 @@ var IntegerLiteral = /** @class */ (function (_super) {
         configurable: true
     });
     IntegerLiteral.prototype.exec = function (_ctx) {
-        return this.value;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.value];
+            });
+        });
     };
     return IntegerLiteral;
 }(Literal));
@@ -6368,7 +7730,11 @@ var DecimalLiteral = /** @class */ (function (_super) {
         configurable: true
     });
     DecimalLiteral.prototype.exec = function (_ctx) {
-        return this.value;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.value];
+            });
+        });
     };
     return DecimalLiteral;
 }(Literal));
@@ -6388,8 +7754,12 @@ var StringLiteral = /** @class */ (function (_super) {
         configurable: true
     });
     StringLiteral.prototype.exec = function (_ctx) {
-        // TODO: Remove these replacements when CQL-to-ELM fixes bug: https://github.com/cqframework/clinical_quality_language/issues/82
-        return this.value.replace(/\\'/g, "'").replace(/\\"/g, '"');
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                // TODO: Remove these replacements when CQL-to-ELM fixes bug: https://github.com/cqframework/clinical_quality_language/issues/82
+                return [2 /*return*/, this.value.replace(/\\'/g, "'").replace(/\\"/g, '"')];
+            });
+        });
     };
     return StringLiteral;
 }(Literal));
@@ -6412,6 +7782,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.IsFalse = exports.IsTrue = exports.Xor = exports.Not = exports.Or = exports.And = void 0;
 var expression_1 = require("./expression");
@@ -6422,7 +7828,18 @@ var And = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     And.prototype.exec = function (ctx) {
-        return datatypes_1.ThreeValuedLogic.and.apply(datatypes_1.ThreeValuedLogic, this.execArgs(ctx));
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, _b, _c;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
+                    case 0:
+                        _b = (_a = datatypes_1.ThreeValuedLogic.and).apply;
+                        _c = [datatypes_1.ThreeValuedLogic];
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1: return [2 /*return*/, _b.apply(_a, _c.concat([(_d.sent())]))];
+                }
+            });
+        });
     };
     return And;
 }(expression_1.Expression));
@@ -6433,7 +7850,18 @@ var Or = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Or.prototype.exec = function (ctx) {
-        return datatypes_1.ThreeValuedLogic.or.apply(datatypes_1.ThreeValuedLogic, this.execArgs(ctx));
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, _b, _c;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
+                    case 0:
+                        _b = (_a = datatypes_1.ThreeValuedLogic.or).apply;
+                        _c = [datatypes_1.ThreeValuedLogic];
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1: return [2 /*return*/, _b.apply(_a, _c.concat([(_d.sent())]))];
+                }
+            });
+        });
     };
     return Or;
 }(expression_1.Expression));
@@ -6444,7 +7872,17 @@ var Not = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Not.prototype.exec = function (ctx) {
-        return datatypes_1.ThreeValuedLogic.not(this.execArgs(ctx));
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, _b;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        _b = (_a = datatypes_1.ThreeValuedLogic).not;
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1: return [2 /*return*/, _b.apply(_a, [_c.sent()])];
+                }
+            });
+        });
     };
     return Not;
 }(expression_1.Expression));
@@ -6455,7 +7893,18 @@ var Xor = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Xor.prototype.exec = function (ctx) {
-        return datatypes_1.ThreeValuedLogic.xor.apply(datatypes_1.ThreeValuedLogic, this.execArgs(ctx));
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, _b, _c;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
+                    case 0:
+                        _b = (_a = datatypes_1.ThreeValuedLogic.xor).apply;
+                        _c = [datatypes_1.ThreeValuedLogic];
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1: return [2 /*return*/, _b.apply(_a, _c.concat([(_d.sent())]))];
+                }
+            });
+        });
     };
     return Xor;
 }(expression_1.Expression));
@@ -6466,7 +7915,17 @@ var IsTrue = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     IsTrue.prototype.exec = function (ctx) {
-        return true === this.execArgs(ctx);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        _a = true;
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1: return [2 /*return*/, _a === (_b.sent())];
+                }
+            });
+        });
     };
     return IsTrue;
 }(expression_1.Expression));
@@ -6477,7 +7936,17 @@ var IsFalse = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     IsFalse.prototype.exec = function (ctx) {
-        return false === this.execArgs(ctx);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        _a = false;
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1: return [2 /*return*/, _a === (_b.sent())];
+                }
+            });
+        });
     };
     return IsFalse;
 }(expression_1.Expression));
@@ -6500,6 +7969,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Message = void 0;
 var expression_1 = require("./expression");
@@ -6516,18 +8021,35 @@ var Message = /** @class */ (function (_super) {
         return _this;
     }
     Message.prototype.exec = function (ctx) {
-        var source = this.source.execute(ctx);
-        var condition = this.condition.execute(ctx);
-        if (condition) {
-            var code = this.code.execute(ctx);
-            var severity = this.severity.execute(ctx);
-            var message = this.message.execute(ctx);
-            var listener = ctx.getMessageListener();
-            if (listener && typeof listener.onMessage === 'function') {
-                listener.onMessage(source, code, severity, message);
-            }
-        }
-        return source;
+        return __awaiter(this, void 0, void 0, function () {
+            var source, condition, code, severity, message, listener;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        source = _a.sent();
+                        return [4 /*yield*/, this.condition.execute(ctx)];
+                    case 2:
+                        condition = _a.sent();
+                        if (!condition) return [3 /*break*/, 6];
+                        return [4 /*yield*/, this.code.execute(ctx)];
+                    case 3:
+                        code = _a.sent();
+                        return [4 /*yield*/, this.severity.execute(ctx)];
+                    case 4:
+                        severity = _a.sent();
+                        return [4 /*yield*/, this.message.execute(ctx)];
+                    case 5:
+                        message = _a.sent();
+                        listener = ctx.getMessageListener();
+                        if (listener && typeof listener.onMessage === 'function') {
+                            listener.onMessage(source, code, severity, message);
+                        }
+                        _a.label = 6;
+                    case 6: return [2 /*return*/, source];
+                }
+            });
+        });
     };
     return Message;
 }(expression_1.Expression));
@@ -6550,6 +8072,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Coalesce = exports.IsNull = exports.Null = void 0;
 var expression_1 = require("./expression");
@@ -6559,7 +8117,11 @@ var Null = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Null.prototype.exec = function (_ctx) {
-        return null;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, null];
+            });
+        });
     };
     return Null;
 }(expression_1.Expression));
@@ -6570,7 +8132,14 @@ var IsNull = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     IsNull.prototype.exec = function (ctx) {
-        return this.execArgs(ctx) == null;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1: return [2 /*return*/, (_a.sent()) == null];
+                }
+            });
+        });
     };
     return IsNull;
 }(expression_1.Expression));
@@ -6581,25 +8150,40 @@ var Coalesce = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Coalesce.prototype.exec = function (ctx) {
-        if (this.args) {
-            for (var _i = 0, _a = this.args; _i < _a.length; _i++) {
-                var arg = _a[_i];
-                var result = arg.execute(ctx);
-                // if a single arg that's a list, coalesce over the list
-                if (this.args.length === 1 && Array.isArray(result)) {
-                    var item = result.find(function (item) { return item != null; });
-                    if (item != null) {
-                        return item;
-                    }
+        return __awaiter(this, void 0, void 0, function () {
+            var _i, _a, arg, result, item;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        if (!this.args) return [3 /*break*/, 4];
+                        _i = 0, _a = this.args;
+                        _b.label = 1;
+                    case 1:
+                        if (!(_i < _a.length)) return [3 /*break*/, 4];
+                        arg = _a[_i];
+                        return [4 /*yield*/, arg.execute(ctx)];
+                    case 2:
+                        result = _b.sent();
+                        // if a single arg that's a list, coalesce over the list
+                        if (this.args.length === 1 && Array.isArray(result)) {
+                            item = result.find(function (item) { return item != null; });
+                            if (item != null) {
+                                return [2 /*return*/, item];
+                            }
+                        }
+                        else {
+                            if (result != null) {
+                                return [2 /*return*/, result];
+                            }
+                        }
+                        _b.label = 3;
+                    case 3:
+                        _i++;
+                        return [3 /*break*/, 1];
+                    case 4: return [2 /*return*/, null];
                 }
-                else {
-                    if (result != null) {
-                        return result;
-                    }
-                }
-            }
-        }
-        return null;
+            });
+        });
     };
     return Coalesce;
 }(expression_1.Expression));
@@ -6641,6 +8225,42 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Precision = exports.SameOrBefore = exports.SameOrAfter = exports.SameAs = exports.Before = exports.After = exports.Length = exports.ProperIncludedIn = exports.ProperIncludes = exports.IncludedIn = exports.Includes = exports.Contains = exports.In = exports.Indexer = exports.Intersect = exports.Except = exports.Union = exports.NotEqual = exports.Equivalent = exports.Equal = void 0;
 /* eslint-disable @typescript-eslint/ban-ts-comment */
@@ -6658,12 +8278,21 @@ var Equal = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Equal.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args[0] == null || args[1] == null) {
-            return null;
-        }
-        // @ts-ignore
-        return comparison_1.equals.apply(void 0, args);
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args[0] == null || args[1] == null) {
+                            return [2 /*return*/, null];
+                        }
+                        // @ts-ignore
+                        return [2 /*return*/, comparison_1.equals.apply(void 0, args)];
+                }
+            });
+        });
     };
     return Equal;
 }(expression_1.Expression));
@@ -6674,16 +8303,26 @@ var Equivalent = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Equivalent.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a == null && b == null) {
-            return true;
-        }
-        else if (a == null || b == null) {
-            return false;
-        }
-        else {
-            return (0, comparison_1.equivalent)(a, b);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a == null && b == null) {
+                            return [2 /*return*/, true];
+                        }
+                        else if (a == null || b == null) {
+                            return [2 /*return*/, false];
+                        }
+                        else {
+                            return [2 /*return*/, (0, comparison_1.equivalent)(a, b)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Equivalent;
 }(expression_1.Expression));
@@ -6694,12 +8333,26 @@ var NotEqual = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     NotEqual.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args[0] == null || args[1] == null) {
-            return null;
-        }
-        // @ts-ignore
-        return logic_1.ThreeValuedLogic.not(comparison_1.equals.apply(void 0, this.execArgs(ctx)));
+        return __awaiter(this, void 0, void 0, function () {
+            var args, _a, _b, _c, _d, _e;
+            return __generator(this, function (_f) {
+                switch (_f.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _f.sent();
+                        if (args[0] == null || args[1] == null) {
+                            return [2 /*return*/, null];
+                        }
+                        _b = (_a = logic_1.ThreeValuedLogic).not;
+                        _d = (_c = comparison_1.equals).apply;
+                        _e = [void 0];
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 2: 
+                    // @ts-ignore
+                    return [2 /*return*/, _b.apply(_a, [_d.apply(_c, _e.concat([(_f.sent())]))])];
+                }
+            });
+        });
     };
     return NotEqual;
 }(expression_1.Expression));
@@ -6710,21 +8363,30 @@ var Union = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Union.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a == null && b == null) {
-            return this.listTypeArgs() ? [] : null;
-        }
-        if (a == null || b == null) {
-            var notNull = a || b;
-            if ((0, util_1.typeIsArray)(notNull)) {
-                return notNull;
-            }
-            else {
-                return null;
-            }
-        }
-        var lib = (0, util_1.typeIsArray)(a) ? LIST : IVL;
-        return lib.doUnion(a, b);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b, notNull, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a == null && b == null) {
+                            return [2 /*return*/, this.listTypeArgs() ? [] : null];
+                        }
+                        if (a == null || b == null) {
+                            notNull = a || b;
+                            if ((0, util_1.typeIsArray)(notNull)) {
+                                return [2 /*return*/, notNull];
+                            }
+                            else {
+                                return [2 /*return*/, null];
+                            }
+                        }
+                        lib = (0, util_1.typeIsArray)(a) ? LIST : IVL;
+                        return [2 /*return*/, lib.doUnion(a, b)];
+                }
+            });
+        });
     };
     Union.prototype.listTypeArgs = function () {
         var _a;
@@ -6741,15 +8403,24 @@ var Except = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Except.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a == null) {
-            return null;
-        }
-        if (b == null) {
-            return (0, util_1.typeIsArray)(a) ? a : null;
-        }
-        var lib = (0, util_1.typeIsArray)(a) ? LIST : IVL;
-        return lib.doExcept(a, b);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a == null) {
+                            return [2 /*return*/, null];
+                        }
+                        if (b == null) {
+                            return [2 /*return*/, (0, util_1.typeIsArray)(a) ? a : null];
+                        }
+                        lib = (0, util_1.typeIsArray)(a) ? LIST : IVL;
+                        return [2 /*return*/, lib.doExcept(a, b)];
+                }
+            });
+        });
     };
     return Except;
 }(expression_1.Expression));
@@ -6760,12 +8431,21 @@ var Intersect = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Intersect.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a == null || b == null) {
-            return null;
-        }
-        var lib = (0, util_1.typeIsArray)(a) ? LIST : IVL;
-        return lib.doIntersect(a, b);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a == null || b == null) {
+                            return [2 /*return*/, null];
+                        }
+                        lib = (0, util_1.typeIsArray)(a) ? LIST : IVL;
+                        return [2 /*return*/, lib.doIntersect(a, b)];
+                }
+            });
+        });
     };
     return Intersect;
 }(expression_1.Expression));
@@ -6776,14 +8456,23 @@ var Indexer = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Indexer.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), operand = _a[0], index = _a[1];
-        if (operand == null || index == null) {
-            return null;
-        }
-        if (index < 0 || index >= operand.length) {
-            return null;
-        }
-        return operand[index];
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, operand, index;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), operand = _a[0], index = _a[1];
+                        if (operand == null || index == null) {
+                            return [2 /*return*/, null];
+                        }
+                        if (index < 0 || index >= operand.length) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, operand[index]];
+                }
+            });
+        });
     };
     return Indexer;
 }(expression_1.Expression));
@@ -6796,15 +8485,24 @@ var In = /** @class */ (function (_super) {
         return _this;
     }
     In.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), item = _a[0], container = _a[1];
-        if (item == null) {
-            return null;
-        }
-        if (container == null) {
-            return false;
-        }
-        var lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
-        return lib.doContains(container, item, this.precision);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, item, container, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), item = _a[0], container = _a[1];
+                        if (item == null) {
+                            return [2 /*return*/, null];
+                        }
+                        if (container == null) {
+                            return [2 /*return*/, false];
+                        }
+                        lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
+                        return [2 /*return*/, lib.doContains(container, item, this.precision)];
+                }
+            });
+        });
     };
     return In;
 }(expression_1.Expression));
@@ -6817,15 +8515,24 @@ var Contains = /** @class */ (function (_super) {
         return _this;
     }
     Contains.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), container = _a[0], item = _a[1];
-        if (container == null) {
-            return false;
-        }
-        if (item == null) {
-            return null;
-        }
-        var lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
-        return lib.doContains(container, item, this.precision);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, container, item, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), container = _a[0], item = _a[1];
+                        if (container == null) {
+                            return [2 /*return*/, false];
+                        }
+                        if (item == null) {
+                            return [2 /*return*/, null];
+                        }
+                        lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
+                        return [2 /*return*/, lib.doContains(container, item, this.precision)];
+                }
+            });
+        });
     };
     return Contains;
 }(expression_1.Expression));
@@ -6838,12 +8545,21 @@ var Includes = /** @class */ (function (_super) {
         return _this;
     }
     Includes.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), container = _a[0], contained = _a[1];
-        if (container == null || contained == null) {
-            return null;
-        }
-        var lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
-        return lib.doIncludes(container, contained, this.precision);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, container, contained, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), container = _a[0], contained = _a[1];
+                        if (container == null || contained == null) {
+                            return [2 /*return*/, null];
+                        }
+                        lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
+                        return [2 /*return*/, lib.doIncludes(container, contained, this.precision)];
+                }
+            });
+        });
     };
     return Includes;
 }(expression_1.Expression));
@@ -6856,12 +8572,21 @@ var IncludedIn = /** @class */ (function (_super) {
         return _this;
     }
     IncludedIn.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), contained = _a[0], container = _a[1];
-        if (container == null || contained == null) {
-            return null;
-        }
-        var lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
-        return lib.doIncludes(container, contained, this.precision);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, contained, container, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), contained = _a[0], container = _a[1];
+                        if (container == null || contained == null) {
+                            return [2 /*return*/, null];
+                        }
+                        lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
+                        return [2 /*return*/, lib.doIncludes(container, contained, this.precision)];
+                }
+            });
+        });
     };
     return IncludedIn;
 }(expression_1.Expression));
@@ -6874,12 +8599,21 @@ var ProperIncludes = /** @class */ (function (_super) {
         return _this;
     }
     ProperIncludes.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), container = _a[0], contained = _a[1];
-        if (container == null || contained == null) {
-            return null;
-        }
-        var lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
-        return lib.doProperIncludes(container, contained, this.precision);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, container, contained, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), container = _a[0], contained = _a[1];
+                        if (container == null || contained == null) {
+                            return [2 /*return*/, null];
+                        }
+                        lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
+                        return [2 /*return*/, lib.doProperIncludes(container, contained, this.precision)];
+                }
+            });
+        });
     };
     return ProperIncludes;
 }(expression_1.Expression));
@@ -6892,12 +8626,21 @@ var ProperIncludedIn = /** @class */ (function (_super) {
         return _this;
     }
     ProperIncludedIn.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), contained = _a[0], container = _a[1];
-        if (container == null || contained == null) {
-            return null;
-        }
-        var lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
-        return lib.doProperIncludes(container, contained, this.precision);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, contained, container, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), contained = _a[0], container = _a[1];
+                        if (container == null || contained == null) {
+                            return [2 /*return*/, null];
+                        }
+                        lib = (0, util_1.typeIsArray)(container) ? LIST : IVL;
+                        return [2 /*return*/, lib.doProperIncludes(container, contained, this.precision)];
+                }
+            });
+        });
     };
     return ProperIncludedIn;
 }(expression_1.Expression));
@@ -6908,16 +8651,26 @@ var Length = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Length.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            return arg.length;
-        }
-        else if (this.arg.asTypeSpecifier.type === 'ListTypeSpecifier') {
-            return 0;
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            return [2 /*return*/, arg.length];
+                        }
+                        else if (this.arg.asTypeSpecifier.type === 'ListTypeSpecifier') {
+                            return [2 /*return*/, 0];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Length;
 }(expression_1.Expression));
@@ -6930,12 +8683,21 @@ var After = /** @class */ (function (_super) {
         return _this;
     }
     After.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a == null || b == null) {
-            return null;
-        }
-        var lib = a instanceof datetime_1.DateTime ? DT : IVL;
-        return lib.doAfter(a, b, this.precision);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a == null || b == null) {
+                            return [2 /*return*/, null];
+                        }
+                        lib = a instanceof datetime_1.DateTime ? DT : IVL;
+                        return [2 /*return*/, lib.doAfter(a, b, this.precision)];
+                }
+            });
+        });
     };
     return After;
 }(expression_1.Expression));
@@ -6948,12 +8710,21 @@ var Before = /** @class */ (function (_super) {
         return _this;
     }
     Before.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a == null || b == null) {
-            return null;
-        }
-        var lib = a instanceof datetime_1.DateTime ? DT : IVL;
-        return lib.doBefore(a, b, this.precision);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b, lib;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a == null || b == null) {
+                            return [2 /*return*/, null];
+                        }
+                        lib = a instanceof datetime_1.DateTime ? DT : IVL;
+                        return [2 /*return*/, lib.doBefore(a, b, this.precision)];
+                }
+            });
+        });
     };
     return Before;
 }(expression_1.Expression));
@@ -6966,13 +8737,23 @@ var SameAs = /** @class */ (function (_super) {
         return _this;
     }
     SameAs.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), a = _a[0], b = _a[1];
-        if (a != null && b != null) {
-            return a.sameAs(b, this.precision != null ? this.precision.toLowerCase() : undefined);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, a, b;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), a = _a[0], b = _a[1];
+                        if (a != null && b != null) {
+                            return [2 /*return*/, a.sameAs(b, this.precision != null ? this.precision.toLowerCase() : undefined)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return SameAs;
 }(expression_1.Expression));
@@ -6985,13 +8766,23 @@ var SameOrAfter = /** @class */ (function (_super) {
         return _this;
     }
     SameOrAfter.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), d1 = _a[0], d2 = _a[1];
-        if (d1 != null && d2 != null) {
-            return d1.sameOrAfter(d2, this.precision != null ? this.precision.toLowerCase() : undefined);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, d1, d2;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), d1 = _a[0], d2 = _a[1];
+                        if (d1 != null && d2 != null) {
+                            return [2 /*return*/, d1.sameOrAfter(d2, this.precision != null ? this.precision.toLowerCase() : undefined)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return SameOrAfter;
 }(expression_1.Expression));
@@ -7004,13 +8795,23 @@ var SameOrBefore = /** @class */ (function (_super) {
         return _this;
     }
     SameOrBefore.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), d1 = _a[0], d2 = _a[1];
-        if (d1 != null && d2 != null) {
-            return d1.sameOrBefore(d2, this.precision != null ? this.precision.toLowerCase() : undefined);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, d1, d2;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), d1 = _a[0], d2 = _a[1];
+                        if (d1 != null && d2 != null) {
+                            return [2 /*return*/, d1.sameOrBefore(d2, this.precision != null ? this.precision.toLowerCase() : undefined)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return SameOrBefore;
 }(expression_1.Expression));
@@ -7022,16 +8823,25 @@ var Precision = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Precision.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        // Since we can't extend UnimplementedExpression directly for this overloaded function,
-        // we have to copy the error to throw here if we are not using the correct type
-        if (!arg.getPrecisionValue) {
-            throw new Error("Unimplemented Expression: Precision");
-        }
-        return arg.getPrecisionValue();
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        // Since we can't extend UnimplementedExpression directly for this overloaded function,
+                        // we have to copy the error to throw here if we are not using the correct type
+                        if (!arg.getPrecisionValue) {
+                            throw new Error("Unimplemented Expression: Precision");
+                        }
+                        return [2 /*return*/, arg.getPrecisionValue()];
+                }
+            });
+        });
     };
     return Precision;
 }(expression_1.Expression));
@@ -7054,6 +8864,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ParameterRef = exports.ParameterDef = void 0;
 var expression_1 = require("./expression");
@@ -7068,19 +8914,27 @@ var ParameterDef = /** @class */ (function (_super) {
         return _this;
     }
     ParameterDef.prototype.exec = function (ctx) {
-        // If context parameters contains the name, return value.
-        if (ctx && ctx.parameters[this.name] !== undefined) {
-            return ctx.parameters[this.name];
-            // If the parent context contains the name, return that
-        }
-        else if (ctx.getParentParameter(this.name) !== undefined) {
-            var parentParam = ctx.getParentParameter(this.name);
-            return parentParam.default != null ? parentParam.default.execute(ctx) : parentParam;
-            // If default type exists, execute the default type
-        }
-        else if (this.default != null) {
-            this.default.execute(ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var parentParam;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        if (!(ctx && ctx.parameters[this.name] !== undefined)) return [3 /*break*/, 1];
+                        return [2 /*return*/, ctx.parameters[this.name]];
+                    case 1:
+                        if (!(ctx.getParentParameter(this.name) !== undefined)) return [3 /*break*/, 2];
+                        parentParam = ctx.getParentParameter(this.name);
+                        return [2 /*return*/, parentParam.default != null ? parentParam.default.execute(ctx) : parentParam];
+                    case 2:
+                        if (!(this.default != null)) return [3 /*break*/, 4];
+                        return [4 /*yield*/, this.default.execute(ctx)];
+                    case 3:
+                        _a.sent();
+                        _a.label = 4;
+                    case 4: return [2 /*return*/];
+                }
+            });
+        });
     };
     return ParameterDef;
 }(expression_1.Expression));
@@ -7094,9 +8948,14 @@ var ParameterRef = /** @class */ (function (_super) {
         return _this;
     }
     ParameterRef.prototype.exec = function (ctx) {
-        ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
-        var param = ctx.getParameter(this.name);
-        return param != null ? param.execute(ctx) : undefined;
+        return __awaiter(this, void 0, void 0, function () {
+            var param;
+            return __generator(this, function (_a) {
+                ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
+                param = ctx.getParameter(this.name);
+                return [2 /*return*/, param != null ? param.execute(ctx) : undefined];
+            });
+        });
     };
     return ParameterRef;
 }(expression_1.Expression));
@@ -7138,6 +8997,42 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Quantity = void 0;
 var expression_1 = require("./expression");
@@ -7153,7 +9048,11 @@ var Quantity = /** @class */ (function (_super) {
         return _this;
     }
     Quantity.prototype.exec = function (_ctx) {
-        return new DT.Quantity(this.value, this.unit);
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, new DT.Quantity(this.value, this.unit)];
+            });
+        });
     };
     return Quantity;
 }(expression_1.Expression));
@@ -7176,6 +9075,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.QueryLetRef = exports.AliasRef = exports.Query = exports.SortClause = exports.ReturnClause = exports.ByColumn = exports.ByExpression = exports.ByDirection = exports.Sort = exports.Without = exports.With = exports.LetClause = exports.AliasedQuerySource = void 0;
 var expression_1 = require("./expression");
@@ -7209,17 +9144,28 @@ var With = /** @class */ (function (_super) {
         return _this;
     }
     With.prototype.exec = function (ctx) {
-        var _this = this;
-        var records = this.expression.execute(ctx);
-        if (!(0, util_1.typeIsArray)(records)) {
-            records = [records];
-        }
-        var returns = records.map(function (rec) {
-            var childCtx = ctx.childContext();
-            childCtx.set(_this.alias, rec);
-            return _this.suchThat.execute(childCtx);
+        return __awaiter(this, void 0, void 0, function () {
+            var records, returns;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.expression.execute(ctx)];
+                    case 1:
+                        records = _a.sent();
+                        if (!(0, util_1.typeIsArray)(records)) {
+                            records = [records];
+                        }
+                        return [4 /*yield*/, Promise.all(records.map(function (rec) {
+                                var childCtx = ctx.childContext();
+                                childCtx.set(_this.alias, rec);
+                                return _this.suchThat.execute(childCtx);
+                            }))];
+                    case 2:
+                        returns = _a.sent();
+                        return [2 /*return*/, returns.some(function (x) { return x; })];
+                }
+            });
         });
-        return returns.some(function (x) { return x; });
     };
     return With;
 }(expression_1.Expression));
@@ -7230,7 +9176,14 @@ var Without = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Without.prototype.exec = function (ctx) {
-        return !_super.prototype.exec.call(this, ctx);
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, _super.prototype.exec.call(this, ctx)];
+                    case 1: return [2 /*return*/, !(_a.sent())];
+                }
+            });
+        });
     };
     return Without;
 }(With));
@@ -7256,23 +9209,28 @@ var ByDirection = /** @class */ (function (_super) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     ByDirection.prototype.exec = function (ctx, a, b) {
-        if (a === b) {
-            return 0;
-        }
-        else if (a.isQuantity && b.isQuantity) {
-            if (a.before(b)) {
-                return this.low_order;
-            }
-            else {
-                return this.high_order;
-            }
-        }
-        else if (a < b) {
-            return this.low_order;
-        }
-        else {
-            return this.high_order;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                if (a === b) {
+                    return [2 /*return*/, 0];
+                }
+                else if (a.isQuantity && b.isQuantity) {
+                    if (a.before(b)) {
+                        return [2 /*return*/, this.low_order];
+                    }
+                    else {
+                        return [2 /*return*/, this.high_order];
+                    }
+                }
+                else if (a < b) {
+                    return [2 /*return*/, this.low_order];
+                }
+                else {
+                    return [2 /*return*/, this.high_order];
+                }
+                return [2 /*return*/];
+            });
+        });
     };
     return ByDirection;
 }(expression_1.Expression));
@@ -7290,22 +9248,35 @@ var ByExpression = /** @class */ (function (_super) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     ByExpression.prototype.exec = function (ctx, a, b) {
-        var sctx = ctx.childContext(a);
-        var a_val = this.expression.execute(sctx);
-        sctx = ctx.childContext(b);
-        var b_val = this.expression.execute(sctx);
-        if (a_val === b_val || (a_val == null && b_val == null)) {
-            return 0;
-        }
-        else if (a_val == null || b_val == null) {
-            return a_val == null ? this.low_order : this.high_order;
-        }
-        else if (a_val.isQuantity && b_val.isQuantity) {
-            return a_val.before(b_val) ? this.low_order : this.high_order;
-        }
-        else {
-            return a_val < b_val ? this.low_order : this.high_order;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var sctx, a_val, b_val;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        sctx = ctx.childContext(a);
+                        return [4 /*yield*/, this.expression.execute(sctx)];
+                    case 1:
+                        a_val = _a.sent();
+                        sctx = ctx.childContext(b);
+                        return [4 /*yield*/, this.expression.execute(sctx)];
+                    case 2:
+                        b_val = _a.sent();
+                        if (a_val === b_val || (a_val == null && b_val == null)) {
+                            return [2 /*return*/, 0];
+                        }
+                        else if (a_val == null || b_val == null) {
+                            return [2 /*return*/, a_val == null ? this.low_order : this.high_order];
+                        }
+                        else if (a_val.isQuantity && b_val.isQuantity) {
+                            return [2 /*return*/, a_val.before(b_val) ? this.low_order : this.high_order];
+                        }
+                        else {
+                            return [2 /*return*/, a_val < b_val ? this.low_order : this.high_order];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ByExpression;
 }(expression_1.Expression));
@@ -7336,21 +9307,40 @@ var SortClause = /** @class */ (function () {
         this.by = (0, builder_1.build)(json != null ? json.by : undefined);
     }
     SortClause.prototype.sort = function (ctx, values) {
-        var _this = this;
-        if (this.by) {
-            return values.sort(function (a, b) {
-                var order = 0;
-                for (var _i = 0, _a = _this.by; _i < _a.length; _i++) {
-                    var item = _a[_i];
-                    // Do not use execute here because the value of the sort order is not important.
-                    order = item.exec(ctx, a, b);
-                    if (order !== 0) {
-                        break;
-                    }
+        return __awaiter(this, void 0, void 0, function () {
+            var _this = this;
+            return __generator(this, function (_a) {
+                if (this.by) {
+                    return [2 /*return*/, (0, util_1.asyncMergeSort)(values, function (a, b) { return __awaiter(_this, void 0, void 0, function () {
+                            var order, _i, _a, item;
+                            return __generator(this, function (_b) {
+                                switch (_b.label) {
+                                    case 0:
+                                        order = 0;
+                                        _i = 0, _a = this.by;
+                                        _b.label = 1;
+                                    case 1:
+                                        if (!(_i < _a.length)) return [3 /*break*/, 4];
+                                        item = _a[_i];
+                                        return [4 /*yield*/, item.exec(ctx, a, b)];
+                                    case 2:
+                                        // Do not use execute here because the value of the sort order is not important.
+                                        order = _b.sent();
+                                        if (order !== 0) {
+                                            return [3 /*break*/, 4];
+                                        }
+                                        _b.label = 3;
+                                    case 3:
+                                        _i++;
+                                        return [3 /*break*/, 1];
+                                    case 4: return [2 /*return*/, order];
+                                }
+                            });
+                        }); })];
                 }
-                return order;
+                return [2 /*return*/, values];
             });
-        }
+        });
     };
     return SortClause;
 }());
@@ -7375,14 +9365,39 @@ var AggregateClause = /** @class */ (function (_super) {
         return _this;
     }
     AggregateClause.prototype.aggregate = function (returnedValues, ctx) {
-        var _this = this;
-        var aggregateValue = this.starting != null ? this.starting.exec(ctx) : null;
-        returnedValues.forEach(function (contextValues) {
-            var childContext = ctx.childContext(contextValues);
-            childContext.set(_this.identifier, aggregateValue);
-            aggregateValue = _this.expression.exec(childContext);
+        return __awaiter(this, void 0, void 0, function () {
+            var aggregateValue, _a, _i, returnedValues_1, contextValues, childContext;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        if (!(this.starting != null)) return [3 /*break*/, 2];
+                        return [4 /*yield*/, this.starting.exec(ctx)];
+                    case 1:
+                        _a = _b.sent();
+                        return [3 /*break*/, 3];
+                    case 2:
+                        _a = null;
+                        _b.label = 3;
+                    case 3:
+                        aggregateValue = _a;
+                        _i = 0, returnedValues_1 = returnedValues;
+                        _b.label = 4;
+                    case 4:
+                        if (!(_i < returnedValues_1.length)) return [3 /*break*/, 7];
+                        contextValues = returnedValues_1[_i];
+                        childContext = ctx.childContext(contextValues);
+                        childContext.set(this.identifier, aggregateValue);
+                        return [4 /*yield*/, this.expression.exec(childContext)];
+                    case 5:
+                        aggregateValue = _b.sent();
+                        _b.label = 6;
+                    case 6:
+                        _i++;
+                        return [3 /*break*/, 4];
+                    case 7: return [2 /*return*/, aggregateValue];
+                }
+            });
         });
-        return aggregateValue;
     };
     return AggregateClause;
 }(expression_1.Expression));
@@ -7410,48 +9425,99 @@ var Query = /** @class */ (function (_super) {
         return true;
     };
     Query.prototype.exec = function (ctx) {
-        var _this = this;
-        var returnedValues = [];
-        this.sources.forEach(ctx, function (rctx) {
-            for (var _i = 0, _a = _this.letClauses; _i < _a.length; _i++) {
-                var def = _a[_i];
-                rctx.set(def.identifier, def.expression.execute(rctx));
-            }
-            var relations = _this.relationship.map(function (rel) {
-                var child_ctx = rctx.childContext();
-                return rel.execute(child_ctx);
+        return __awaiter(this, void 0, void 0, function () {
+            var returnedValues;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        returnedValues = [];
+                        return [4 /*yield*/, this.sources.forEach(ctx, function (rctx) { return __awaiter(_this, void 0, void 0, function () {
+                                var _i, _a, def, _b, _c, _d, relations, passed, _e, _f, val;
+                                return __generator(this, function (_g) {
+                                    switch (_g.label) {
+                                        case 0:
+                                            _i = 0, _a = this.letClauses;
+                                            _g.label = 1;
+                                        case 1:
+                                            if (!(_i < _a.length)) return [3 /*break*/, 4];
+                                            def = _a[_i];
+                                            _c = (_b = rctx).set;
+                                            _d = [def.identifier];
+                                            return [4 /*yield*/, def.expression.execute(rctx)];
+                                        case 2:
+                                            _c.apply(_b, _d.concat([_g.sent()]));
+                                            _g.label = 3;
+                                        case 3:
+                                            _i++;
+                                            return [3 /*break*/, 1];
+                                        case 4: return [4 /*yield*/, Promise.all(this.relationship.map(function (rel) {
+                                                var child_ctx = rctx.childContext();
+                                                return rel.execute(child_ctx);
+                                            }))];
+                                        case 5:
+                                            relations = _g.sent();
+                                            _e = (0, util_1.allTrue)(relations);
+                                            if (!_e) return [3 /*break*/, 9];
+                                            if (!this.where) return [3 /*break*/, 7];
+                                            return [4 /*yield*/, this.where.execute(rctx)];
+                                        case 6:
+                                            _f = _g.sent();
+                                            return [3 /*break*/, 8];
+                                        case 7:
+                                            _f = true;
+                                            _g.label = 8;
+                                        case 8:
+                                            _e = (_f);
+                                            _g.label = 9;
+                                        case 9:
+                                            passed = _e;
+                                            if (!passed) return [3 /*break*/, 12];
+                                            if (!(this.returnClause != null)) return [3 /*break*/, 11];
+                                            return [4 /*yield*/, this.returnClause.expression.execute(rctx)];
+                                        case 10:
+                                            val = _g.sent();
+                                            returnedValues.push(val);
+                                            return [3 /*break*/, 12];
+                                        case 11:
+                                            if (this.aliases.length === 1 && this.aggregateClause == null) {
+                                                returnedValues.push(rctx.get(this.aliases[0]));
+                                            }
+                                            else {
+                                                returnedValues.push(rctx.context_values);
+                                            }
+                                            _g.label = 12;
+                                        case 12: return [2 /*return*/];
+                                    }
+                                });
+                            }); })];
+                    case 1:
+                        _a.sent();
+                        if (this.isDistinct()) {
+                            returnedValues = toDistinctList(returnedValues);
+                        }
+                        if (!(this.aggregateClause != null)) return [3 /*break*/, 3];
+                        return [4 /*yield*/, this.aggregateClause.aggregate(returnedValues, ctx)];
+                    case 2:
+                        returnedValues = _a.sent();
+                        _a.label = 3;
+                    case 3:
+                        if (!(this.sortClause != null)) return [3 /*break*/, 5];
+                        return [4 /*yield*/, this.sortClause.sort(ctx, returnedValues)];
+                    case 4:
+                        returnedValues = _a.sent();
+                        _a.label = 5;
+                    case 5:
+                        if (this.sources.returnsList() || this.aggregateClause != null) {
+                            return [2 /*return*/, returnedValues];
+                        }
+                        else {
+                            return [2 /*return*/, returnedValues[0]];
+                        }
+                        return [2 /*return*/];
+                }
             });
-            var passed = (0, util_1.allTrue)(relations) && (_this.where ? _this.where.execute(rctx) : true);
-            if (passed) {
-                if (_this.returnClause != null) {
-                    var val = _this.returnClause.expression.execute(rctx);
-                    returnedValues.push(val);
-                }
-                else {
-                    if (_this.aliases.length === 1 && _this.aggregateClause == null) {
-                        returnedValues.push(rctx.get(_this.aliases[0]));
-                    }
-                    else {
-                        returnedValues.push(rctx.context_values);
-                    }
-                }
-            }
         });
-        if (this.isDistinct()) {
-            returnedValues = toDistinctList(returnedValues);
-        }
-        if (this.aggregateClause != null) {
-            returnedValues = this.aggregateClause.aggregate(returnedValues, ctx);
-        }
-        if (this.sortClause != null) {
-            this.sortClause.sort(ctx, returnedValues);
-        }
-        if (this.sources.returnsList() || this.aggregateClause != null) {
-            return returnedValues;
-        }
-        else {
-            return returnedValues[0];
-        }
     };
     return Query;
 }(expression_1.Expression));
@@ -7464,7 +9530,11 @@ var AliasRef = /** @class */ (function (_super) {
         return _this;
     }
     AliasRef.prototype.exec = function (ctx) {
-        return ctx != null ? ctx.get(this.name) : undefined;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, ctx != null ? ctx.get(this.name) : undefined];
+            });
+        });
     };
     return AliasRef;
 }(expression_1.Expression));
@@ -7499,19 +9569,32 @@ var MultiSource = /** @class */ (function () {
         return this.isList || (this.rest && this.rest.returnsList());
     };
     MultiSource.prototype.forEach = function (ctx, func) {
-        var _this = this;
-        var records = this.expression.execute(ctx);
-        this.isList = (0, util_1.typeIsArray)(records);
-        records = this.isList ? records : [records];
-        return records.map(function (rec) {
-            var rctx = new context_1.Context(ctx);
-            rctx.set(_this.alias, rec);
-            if (_this.rest) {
-                return _this.rest.forEach(rctx, func);
-            }
-            else {
-                return func(rctx);
-            }
+        return __awaiter(this, void 0, void 0, function () {
+            var records;
+            var _this = this;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.expression.execute(ctx)];
+                    case 1:
+                        records = _a.sent();
+                        this.isList = (0, util_1.typeIsArray)(records);
+                        records = this.isList ? records : [records];
+                        return [2 /*return*/, Promise.all(records.map(function (rec) { return __awaiter(_this, void 0, void 0, function () {
+                                var rctx;
+                                return __generator(this, function (_a) {
+                                    rctx = new context_1.Context(ctx);
+                                    rctx.set(this.alias, rec);
+                                    if (this.rest) {
+                                        return [2 /*return*/, this.rest.forEach(rctx, func)];
+                                    }
+                                    else {
+                                        return [2 /*return*/, func(rctx)];
+                                    }
+                                    return [2 /*return*/];
+                                });
+                            }); }))];
+                }
+            });
         });
     };
     return MultiSource;
@@ -7553,6 +9636,42 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Ratio = void 0;
 var expression_1 = require("./expression");
@@ -7577,7 +9696,11 @@ var Ratio = /** @class */ (function (_super) {
         return _this;
     }
     Ratio.prototype.exec = function (_ctx) {
-        return new DT.Ratio(this.numerator, this.denominator);
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, new DT.Ratio(this.numerator, this.denominator)];
+            });
+        });
     };
     return Ratio;
 }(expression_1.Expression));
@@ -7600,6 +9723,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.IdentifierRef = exports.OperandRef = exports.FunctionRef = exports.FunctionDef = exports.ExpressionRef = exports.ExpressionDef = void 0;
 var expression_1 = require("./expression");
@@ -7614,9 +9773,26 @@ var ExpressionDef = /** @class */ (function (_super) {
         return _this;
     }
     ExpressionDef.prototype.exec = function (ctx) {
-        var value = this.expression != null ? this.expression.execute(ctx) : undefined;
-        ctx.rootContext().set(this.name, value);
-        return value;
+        return __awaiter(this, void 0, void 0, function () {
+            var value, _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        if (!(this.expression != null)) return [3 /*break*/, 2];
+                        return [4 /*yield*/, this.expression.execute(ctx)];
+                    case 1:
+                        _a = _b.sent();
+                        return [3 /*break*/, 3];
+                    case 2:
+                        _a = undefined;
+                        _b.label = 3;
+                    case 3:
+                        value = _a;
+                        ctx.rootContext().set(this.name, value);
+                        return [2 /*return*/, value];
+                }
+            });
+        });
     };
     return ExpressionDef;
 }(expression_1.Expression));
@@ -7630,12 +9806,22 @@ var ExpressionRef = /** @class */ (function (_super) {
         return _this;
     }
     ExpressionRef.prototype.exec = function (ctx) {
-        ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
-        var value = ctx.get(this.name);
-        if (value instanceof expression_1.Expression) {
-            value = value.execute(ctx);
-        }
-        return value;
+        return __awaiter(this, void 0, void 0, function () {
+            var value;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
+                        value = ctx.get(this.name);
+                        if (!(value instanceof expression_1.Expression)) return [3 /*break*/, 2];
+                        return [4 /*yield*/, value.execute(ctx)];
+                    case 1:
+                        value = _a.sent();
+                        _a.label = 2;
+                    case 2: return [2 /*return*/, value];
+                }
+            });
+        });
     };
     return ExpressionRef;
 }(expression_1.Expression));
@@ -7650,7 +9836,11 @@ var FunctionDef = /** @class */ (function (_super) {
         return _this;
     }
     FunctionDef.prototype.exec = function (_ctx) {
-        return this;
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this];
+            });
+        });
     };
     return FunctionDef;
 }(expression_1.Expression));
@@ -7664,54 +9854,61 @@ var FunctionRef = /** @class */ (function (_super) {
         return _this;
     }
     FunctionRef.prototype.exec = function (ctx) {
-        var functionDefs, child_ctx;
-        if (this.library) {
-            var lib = ctx.get(this.library);
-            functionDefs = lib ? lib.getFunction(this.name) : undefined;
-            var libCtx = ctx.getLibraryContext(this.library);
-            child_ctx = libCtx ? libCtx.childContext() : undefined;
-        }
-        else {
-            functionDefs = ctx.get(this.name);
-            child_ctx = ctx.childContext();
-        }
-        var args = this.execArgs(ctx);
-        // Filter out functions w/ wrong number of arguments.
-        functionDefs = functionDefs.filter(function (f) { return f.parameters.length === args.length; });
-        // If there is still > 1 matching function, filter by argument types
-        if (functionDefs.length > 1) {
-            functionDefs = functionDefs.filter(function (f) {
-                var match = true;
-                for (var i = 0; i < args.length && match; i++) {
-                    if (args[i] !== null) {
-                        var operandTypeSpecifier = f.parameters[i].operandTypeSpecifier;
-                        if (operandTypeSpecifier == null && f.parameters[i].operandType != null) {
-                            // convert it to a NamedTypedSpecifier
-                            operandTypeSpecifier = {
-                                name: f.parameters[i].operandType,
-                                type: 'NamedTypeSpecifier'
-                            };
+        return __awaiter(this, void 0, void 0, function () {
+            var functionDefs, child_ctx, lib, libCtx, args, functionDef, i;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        if (this.library) {
+                            lib = ctx.get(this.library);
+                            functionDefs = lib ? lib.getFunction(this.name) : undefined;
+                            libCtx = ctx.getLibraryContext(this.library);
+                            child_ctx = libCtx ? libCtx.childContext() : undefined;
                         }
-                        match = ctx.matchesTypeSpecifier(args[i], operandTypeSpecifier);
-                    }
+                        else {
+                            functionDefs = ctx.get(this.name);
+                            child_ctx = ctx.childContext();
+                        }
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        // Filter out functions w/ wrong number of arguments.
+                        functionDefs = functionDefs.filter(function (f) { return f.parameters.length === args.length; });
+                        // If there is still > 1 matching function, filter by argument types
+                        if (functionDefs.length > 1) {
+                            functionDefs = functionDefs.filter(function (f) {
+                                var match = true;
+                                for (var i = 0; i < args.length && match; i++) {
+                                    if (args[i] !== null) {
+                                        var operandTypeSpecifier = f.parameters[i].operandTypeSpecifier;
+                                        if (operandTypeSpecifier == null && f.parameters[i].operandType != null) {
+                                            // convert it to a NamedTypedSpecifier
+                                            operandTypeSpecifier = {
+                                                name: f.parameters[i].operandType,
+                                                type: 'NamedTypeSpecifier'
+                                            };
+                                        }
+                                        match = ctx.matchesTypeSpecifier(args[i], operandTypeSpecifier);
+                                    }
+                                }
+                                return match;
+                            });
+                        }
+                        // If there is still > 1 matching function, calculate a score based on quality of matches
+                        if (functionDefs.length > 1) {
+                            // TODO
+                        }
+                        if (functionDefs.length === 0) {
+                            throw new Error('no function with matching signature could be found');
+                        }
+                        functionDef = functionDefs[functionDefs.length - 1];
+                        for (i = 0; i < functionDef.parameters.length; i++) {
+                            child_ctx.set(functionDef.parameters[i].name, args[i]);
+                        }
+                        return [2 /*return*/, functionDef.expression.execute(child_ctx)];
                 }
-                return match;
             });
-        }
-        // If there is still > 1 matching function, calculate a score based on quality of matches
-        if (functionDefs.length > 1) {
-            // TODO
-        }
-        if (functionDefs.length === 0) {
-            throw new Error('no function with matching signature could be found');
-        }
-        // By this point, we should have only one function, but until implementation is completed,
-        // use the last one (no matter how many still remain)
-        var functionDef = functionDefs[functionDefs.length - 1];
-        for (var i = 0; i < functionDef.parameters.length; i++) {
-            child_ctx.set(functionDef.parameters[i].name, args[i]);
-        }
-        return functionDef.expression.execute(child_ctx);
+        });
     };
     return FunctionRef;
 }(expression_1.Expression));
@@ -7724,7 +9921,11 @@ var OperandRef = /** @class */ (function (_super) {
         return _this;
     }
     OperandRef.prototype.exec = function (ctx) {
-        return ctx.get(this.name);
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, ctx.get(this.name)];
+            });
+        });
     };
     return OperandRef;
 }(expression_1.Expression));
@@ -7738,38 +9939,39 @@ var IdentifierRef = /** @class */ (function (_super) {
         return _this;
     }
     IdentifierRef.prototype.exec = function (ctx) {
-        // TODO: Technically, the ELM Translator should never output one of these
-        // but this code is needed since it does, as a work-around to get queries
-        // to work properly when sorting by a field in a tuple
-        var lib = this.library ? ctx.get(this.library) : undefined;
-        var val = lib ? lib.get(this.name) : ctx.get(this.name);
-        if (val == null) {
-            var parts = this.name.split('.');
-            val = ctx.get(parts[0]);
-            if (val != null && parts.length > 1) {
-                var curr_obj = val;
-                for (var _i = 0, _a = parts.slice(1); _i < _a.length; _i++) {
-                    var part = _a[_i];
-                    // _obj = curr_obj?[part] ? curr_obj?.get?(part)
-                    // curr_obj = if _obj instanceof Function then _obj.call(curr_obj) else _obj
-                    var _obj = void 0;
-                    if (curr_obj != null) {
-                        _obj = curr_obj[part];
-                        if (_obj === undefined && typeof curr_obj.get === 'function') {
-                            _obj = curr_obj.get(part);
+        return __awaiter(this, void 0, void 0, function () {
+            var lib, val, parts, curr_obj, _i, _a, part, _obj;
+            return __generator(this, function (_b) {
+                lib = this.library ? ctx.get(this.library) : undefined;
+                val = lib ? lib.get(this.name) : ctx.get(this.name);
+                if (val == null) {
+                    parts = this.name.split('.');
+                    val = ctx.get(parts[0]);
+                    if (val != null && parts.length > 1) {
+                        curr_obj = val;
+                        for (_i = 0, _a = parts.slice(1); _i < _a.length; _i++) {
+                            part = _a[_i];
+                            _obj = void 0;
+                            if (curr_obj != null) {
+                                _obj = curr_obj[part];
+                                if (_obj === undefined && typeof curr_obj.get === 'function') {
+                                    _obj = curr_obj.get(part);
+                                }
+                            }
+                            curr_obj = _obj instanceof Function ? _obj.call(curr_obj) : _obj;
                         }
+                        val = curr_obj;
                     }
-                    curr_obj = _obj instanceof Function ? _obj.call(curr_obj) : _obj;
                 }
-                val = curr_obj;
-            }
-        }
-        if (val instanceof Function) {
-            return val.call(ctx.context_values);
-        }
-        else {
-            return val;
-        }
+                if (val instanceof Function) {
+                    return [2 /*return*/, val.call(ctx.context_values)];
+                }
+                else {
+                    return [2 /*return*/, val];
+                }
+                return [2 /*return*/];
+            });
+        });
     };
     return IdentifierRef;
 }(expression_1.Expression));
@@ -7792,6 +9994,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.ReplaceMatches = exports.EndsWith = exports.StartsWith = exports.Substring = exports.Matches = exports.LastPositionOf = exports.PositionOf = exports.Lower = exports.Upper = exports.SplitOnMatches = exports.Split = exports.Combine = exports.Concatenate = void 0;
 var expression_1 = require("./expression");
@@ -7802,13 +10040,23 @@ var Concatenate = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Concatenate.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        else {
-            return args.reduce(function (x, y) { return x + y; });
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, args.reduce(function (x, y) { return x + y; })];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Concatenate;
 }(expression_1.Expression));
@@ -7822,20 +10070,39 @@ var Combine = /** @class */ (function (_super) {
         return _this;
     }
     Combine.prototype.exec = function (ctx) {
-        var source = this.source.execute(ctx);
-        var separator = this.separator != null ? this.separator.execute(ctx) : '';
-        if (source == null) {
-            return null;
-        }
-        else {
-            var filteredArray = source.filter(function (x) { return x != null; });
-            if (filteredArray.length === 0) {
-                return null;
-            }
-            else {
-                return filteredArray.join(separator);
-            }
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var source, separator, _a, filteredArray;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.source.execute(ctx)];
+                    case 1:
+                        source = _b.sent();
+                        if (!(this.separator != null)) return [3 /*break*/, 3];
+                        return [4 /*yield*/, this.separator.execute(ctx)];
+                    case 2:
+                        _a = _b.sent();
+                        return [3 /*break*/, 4];
+                    case 3:
+                        _a = '';
+                        _b.label = 4;
+                    case 4:
+                        separator = _a;
+                        if (source == null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            filteredArray = source.filter(function (x) { return x != null; });
+                            if (filteredArray.length === 0) {
+                                return [2 /*return*/, null];
+                            }
+                            else {
+                                return [2 /*return*/, filteredArray.join(separator)];
+                            }
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Combine;
 }(expression_1.Expression));
@@ -7849,12 +10116,23 @@ var Split = /** @class */ (function (_super) {
         return _this;
     }
     Split.prototype.exec = function (ctx) {
-        var stringToSplit = this.stringToSplit.execute(ctx);
-        var separator = this.separator.execute(ctx);
-        if (stringToSplit && separator) {
-            return stringToSplit.split(separator);
-        }
-        return stringToSplit ? [stringToSplit] : null;
+        return __awaiter(this, void 0, void 0, function () {
+            var stringToSplit, separator;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.stringToSplit.execute(ctx)];
+                    case 1:
+                        stringToSplit = _a.sent();
+                        return [4 /*yield*/, this.separator.execute(ctx)];
+                    case 2:
+                        separator = _a.sent();
+                        if (stringToSplit && separator) {
+                            return [2 /*return*/, stringToSplit.split(separator)];
+                        }
+                        return [2 /*return*/, stringToSplit ? [stringToSplit] : null];
+                }
+            });
+        });
     };
     return Split;
 }(expression_1.Expression));
@@ -7868,12 +10146,23 @@ var SplitOnMatches = /** @class */ (function (_super) {
         return _this;
     }
     SplitOnMatches.prototype.exec = function (ctx) {
-        var stringToSplit = this.stringToSplit.execute(ctx);
-        var separatorPattern = this.separatorPattern.execute(ctx);
-        if (stringToSplit && separatorPattern) {
-            return stringToSplit.split(new RegExp(separatorPattern));
-        }
-        return stringToSplit ? [stringToSplit] : null;
+        return __awaiter(this, void 0, void 0, function () {
+            var stringToSplit, separatorPattern;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.stringToSplit.execute(ctx)];
+                    case 1:
+                        stringToSplit = _a.sent();
+                        return [4 /*yield*/, this.separatorPattern.execute(ctx)];
+                    case 2:
+                        separatorPattern = _a.sent();
+                        if (stringToSplit && separatorPattern) {
+                            return [2 /*return*/, stringToSplit.split(new RegExp(separatorPattern))];
+                        }
+                        return [2 /*return*/, stringToSplit ? [stringToSplit] : null];
+                }
+            });
+        });
     };
     return SplitOnMatches;
 }(expression_1.Expression));
@@ -7885,13 +10174,23 @@ var Upper = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Upper.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            return arg.toUpperCase();
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            return [2 /*return*/, arg.toUpperCase()];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Upper;
 }(expression_1.Expression));
@@ -7902,13 +10201,23 @@ var Lower = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Lower.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            return arg.toLowerCase();
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            return [2 /*return*/, arg.toLowerCase()];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Lower;
 }(expression_1.Expression));
@@ -7923,14 +10232,26 @@ var PositionOf = /** @class */ (function (_super) {
         return _this;
     }
     PositionOf.prototype.exec = function (ctx) {
-        var pattern = this.pattern.execute(ctx);
-        var string = this.string.execute(ctx);
-        if (pattern == null || string == null) {
-            return null;
-        }
-        else {
-            return string.indexOf(pattern);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var pattern, string;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.pattern.execute(ctx)];
+                    case 1:
+                        pattern = _a.sent();
+                        return [4 /*yield*/, this.string.execute(ctx)];
+                    case 2:
+                        string = _a.sent();
+                        if (pattern == null || string == null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, string.indexOf(pattern)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return PositionOf;
 }(expression_1.Expression));
@@ -7944,14 +10265,26 @@ var LastPositionOf = /** @class */ (function (_super) {
         return _this;
     }
     LastPositionOf.prototype.exec = function (ctx) {
-        var pattern = this.pattern.execute(ctx);
-        var string = this.string.execute(ctx);
-        if (pattern == null || string == null) {
-            return null;
-        }
-        else {
-            return string.lastIndexOf(pattern);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var pattern, string;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.pattern.execute(ctx)];
+                    case 1:
+                        pattern = _a.sent();
+                        return [4 /*yield*/, this.string.execute(ctx)];
+                    case 2:
+                        string = _a.sent();
+                        if (pattern == null || string == null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, string.lastIndexOf(pattern)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return LastPositionOf;
 }(expression_1.Expression));
@@ -7962,11 +10295,20 @@ var Matches = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     Matches.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), string = _a[0], pattern = _a[1];
-        if (string == null || pattern == null) {
-            return null;
-        }
-        return new RegExp('^' + pattern + '$').test(string);
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, string, pattern;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), string = _a[0], pattern = _a[1];
+                        if (string == null || pattern == null) {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/, new RegExp('^' + pattern + '$').test(string)];
+                }
+            });
+        });
     };
     return Matches;
 }(expression_1.Expression));
@@ -7981,22 +10323,43 @@ var Substring = /** @class */ (function (_super) {
         return _this;
     }
     Substring.prototype.exec = function (ctx) {
-        var stringToSub = this.stringToSub.execute(ctx);
-        var startIndex = this.startIndex.execute(ctx);
-        var length = this.length != null ? this.length.execute(ctx) : null;
-        // According to spec: If stringToSub or startIndex is null, or startIndex is out of range, the result is null.
-        if (stringToSub == null ||
-            startIndex == null ||
-            startIndex < 0 ||
-            startIndex >= stringToSub.length) {
-            return null;
-        }
-        else if (length != null) {
-            return stringToSub.substr(startIndex, length);
-        }
-        else {
-            return stringToSub.substr(startIndex);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var stringToSub, startIndex, length, _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.stringToSub.execute(ctx)];
+                    case 1:
+                        stringToSub = _b.sent();
+                        return [4 /*yield*/, this.startIndex.execute(ctx)];
+                    case 2:
+                        startIndex = _b.sent();
+                        if (!(this.length != null)) return [3 /*break*/, 4];
+                        return [4 /*yield*/, this.length.execute(ctx)];
+                    case 3:
+                        _a = _b.sent();
+                        return [3 /*break*/, 5];
+                    case 4:
+                        _a = null;
+                        _b.label = 5;
+                    case 5:
+                        length = _a;
+                        // According to spec: If stringToSub or startIndex is null, or startIndex is out of range, the result is null.
+                        if (stringToSub == null ||
+                            startIndex == null ||
+                            startIndex < 0 ||
+                            startIndex >= stringToSub.length) {
+                            return [2 /*return*/, null];
+                        }
+                        else if (length != null) {
+                            return [2 /*return*/, stringToSub.substr(startIndex, length)];
+                        }
+                        else {
+                            return [2 /*return*/, stringToSub.substr(startIndex)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Substring;
 }(expression_1.Expression));
@@ -8007,13 +10370,23 @@ var StartsWith = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     StartsWith.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        else {
-            return args[0].slice(0, args[1].length) === args[1];
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, args[0].slice(0, args[1].length) === args[1]];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return StartsWith;
 }(expression_1.Expression));
@@ -8024,13 +10397,23 @@ var EndsWith = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     EndsWith.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        else {
-            return args[1] === '' || args[0].slice(-args[1].length) === args[1];
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, args[1] === '' || args[0].slice(-args[1].length) === args[1]];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return EndsWith;
 }(expression_1.Expression));
@@ -8041,13 +10424,23 @@ var ReplaceMatches = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ReplaceMatches.prototype.exec = function (ctx) {
-        var args = this.execArgs(ctx);
-        if (args.some(function (x) { return x == null; })) {
-            return null;
-        }
-        else {
-            return args[0].replace(new RegExp(args[1], 'g'), args[2]);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var args;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        args = _a.sent();
+                        if (args.some(function (x) { return x == null; })) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, args[0].replace(new RegExp(args[1], 'g'), args[2])];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ReplaceMatches;
 }(expression_1.Expression));
@@ -8070,6 +10463,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.TupleElementDefinition = exports.TupleElement = exports.Tuple = exports.Property = void 0;
 var expression_1 = require("./expression");
@@ -8084,27 +10513,39 @@ var Property = /** @class */ (function (_super) {
         return _this;
     }
     Property.prototype.exec = function (ctx) {
-        var obj = this.scope != null ? ctx.get(this.scope) : this.source;
-        if (obj instanceof expression_1.Expression) {
-            obj = obj.execute(ctx);
-        }
-        var val = getPropertyFromObject(obj, this.path);
-        if (val == null) {
-            var parts = this.path.split('.');
-            var curr_obj = obj;
-            for (var _i = 0, parts_1 = parts; _i < parts_1.length; _i++) {
-                var part = parts_1[_i];
-                var _obj = getPropertyFromObject(curr_obj, part);
-                curr_obj = _obj instanceof Function ? _obj.call(curr_obj) : _obj;
-            }
-            val = curr_obj != null ? curr_obj : null; // convert undefined to null
-        }
-        if (val instanceof Function) {
-            return val.call(obj);
-        }
-        else {
-            return val;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var obj, val, parts, curr_obj, _i, parts_1, part, _obj;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        obj = this.scope != null ? ctx.get(this.scope) : this.source;
+                        if (!(obj instanceof expression_1.Expression)) return [3 /*break*/, 2];
+                        return [4 /*yield*/, obj.execute(ctx)];
+                    case 1:
+                        obj = _a.sent();
+                        _a.label = 2;
+                    case 2:
+                        val = getPropertyFromObject(obj, this.path);
+                        if (val == null) {
+                            parts = this.path.split('.');
+                            curr_obj = obj;
+                            for (_i = 0, parts_1 = parts; _i < parts_1.length; _i++) {
+                                part = parts_1[_i];
+                                _obj = getPropertyFromObject(curr_obj, part);
+                                curr_obj = _obj instanceof Function ? _obj.call(curr_obj) : _obj;
+                            }
+                            val = curr_obj != null ? curr_obj : null; // convert undefined to null
+                        }
+                        if (val instanceof Function) {
+                            return [2 /*return*/, val.call(obj)];
+                        }
+                        else {
+                            return [2 /*return*/, val];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return Property;
 }(expression_1.Expression));
@@ -8140,12 +10581,37 @@ var Tuple = /** @class */ (function (_super) {
         configurable: true
     });
     Tuple.prototype.exec = function (ctx) {
-        var val = {};
-        for (var _i = 0, _a = this.elements; _i < _a.length; _i++) {
-            var el = _a[_i];
-            val[el.name] = el.value != null ? el.value.execute(ctx) : undefined;
-        }
-        return val;
+        return __awaiter(this, void 0, void 0, function () {
+            var val, _i, _a, el, _b, _c, _d;
+            return __generator(this, function (_e) {
+                switch (_e.label) {
+                    case 0:
+                        val = {};
+                        _i = 0, _a = this.elements;
+                        _e.label = 1;
+                    case 1:
+                        if (!(_i < _a.length)) return [3 /*break*/, 6];
+                        el = _a[_i];
+                        _b = val;
+                        _c = el.name;
+                        if (!(el.value != null)) return [3 /*break*/, 3];
+                        return [4 /*yield*/, el.value.execute(ctx)];
+                    case 2:
+                        _d = _e.sent();
+                        return [3 /*break*/, 4];
+                    case 3:
+                        _d = undefined;
+                        _e.label = 4;
+                    case 4:
+                        _b[_c] = _d;
+                        _e.label = 5;
+                    case 5:
+                        _i++;
+                        return [3 /*break*/, 1];
+                    case 6: return [2 /*return*/, val];
+                }
+            });
+        });
     };
     return Tuple;
 }(expression_1.Expression));
@@ -8184,6 +10650,42 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.TupleTypeSpecifier = exports.NamedTypeSpecifier = exports.ListTypeSpecifier = exports.IntervalTypeSpecifier = exports.Is = exports.CanConvertQuantity = exports.ConvertQuantity = exports.ConvertsToTime = exports.ConvertsToString = exports.ConvertsToRatio = exports.ConvertsToQuantity = exports.ConvertsToInteger = exports.ConvertsToDecimal = exports.ConvertsToDateTime = exports.ConvertsToDate = exports.ConvertsToBoolean = exports.Convert = exports.ToTime = exports.ToString = exports.ToRatio = exports.ToQuantity = exports.ToInteger = exports.ToDecimal = exports.ToDateTime = exports.ToDate = exports.ToConcept = exports.ToBoolean = exports.As = void 0;
 var expression_1 = require("./expression");
@@ -8213,23 +10715,33 @@ var As = /** @class */ (function (_super) {
         return _this;
     }
     As.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        // If it is null, return null
-        if (arg == null) {
-            return null;
-        }
-        if (ctx.matchesTypeSpecifier(arg, this.asTypeSpecifier)) {
-            // TODO: request patient source to change type identification
-            return arg;
-        }
-        else if (this.strict) {
-            var argTypeString = specifierToString(guessSpecifierType(arg));
-            var asTypeString = specifierToString(this.asTypeSpecifier);
-            throw new Error("Cannot cast ".concat(argTypeString, " as ").concat(asTypeString));
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, argTypeString, asTypeString;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        // If it is null, return null
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        if (ctx.matchesTypeSpecifier(arg, this.asTypeSpecifier)) {
+                            // TODO: request patient source to change type identification
+                            return [2 /*return*/, arg];
+                        }
+                        else if (this.strict) {
+                            argTypeString = specifierToString(guessSpecifierType(arg));
+                            asTypeString = specifierToString(this.asTypeSpecifier);
+                            throw new Error("Cannot cast ".concat(argTypeString, " as ").concat(asTypeString));
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return As;
 }(expression_1.Expression));
@@ -8240,17 +10752,26 @@ var ToBoolean = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToBoolean.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            var strArg = arg.toString().toLowerCase();
-            if (['true', 't', 'yes', 'y', '1'].includes(strArg)) {
-                return true;
-            }
-            else if (['false', 'f', 'no', 'n', '0'].includes(strArg)) {
-                return false;
-            }
-        }
-        return null;
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, strArg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            strArg = arg.toString().toLowerCase();
+                            if (['true', 't', 'yes', 'y', '1'].includes(strArg)) {
+                                return [2 /*return*/, true];
+                            }
+                            else if (['false', 'f', 'no', 'n', '0'].includes(strArg)) {
+                                return [2 /*return*/, false];
+                            }
+                        }
+                        return [2 /*return*/, null];
+                }
+            });
+        });
     };
     return ToBoolean;
 }(expression_1.Expression));
@@ -8261,13 +10782,23 @@ var ToConcept = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToConcept.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            return new clinical_1.Concept([arg], arg.display);
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            return [2 /*return*/, new clinical_1.Concept([arg], arg.display)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ToConcept;
 }(expression_1.Expression));
@@ -8278,16 +10809,26 @@ var ToDate = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToDate.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        else if (arg.isDateTime) {
-            return arg.getDate();
-        }
-        else {
-            return datetime_1.Date.parse(arg.toString());
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        else if (arg.isDateTime) {
+                            return [2 /*return*/, arg.getDate()];
+                        }
+                        else {
+                            return [2 /*return*/, datetime_1.Date.parse(arg.toString())];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ToDate;
 }(expression_1.Expression));
@@ -8298,16 +10839,26 @@ var ToDateTime = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToDateTime.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg == null) {
-            return null;
-        }
-        else if (arg.isDate) {
-            return arg.getDateTime();
-        }
-        else {
-            return datetime_1.DateTime.parse(arg.toString());
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg == null) {
+                            return [2 /*return*/, null];
+                        }
+                        else if (arg.isDate) {
+                            return [2 /*return*/, arg.getDateTime()];
+                        }
+                        else {
+                            return [2 /*return*/, datetime_1.DateTime.parse(arg.toString())];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ToDateTime;
 }(expression_1.Expression));
@@ -8318,21 +10869,30 @@ var ToDecimal = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToDecimal.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            if (arg.isUncertainty) {
-                var low = (0, math_1.limitDecimalPrecision)(parseFloat(arg.low.toString()));
-                var high = (0, math_1.limitDecimalPrecision)(parseFloat(arg.high.toString()));
-                return new uncertainty_1.Uncertainty(low, high);
-            }
-            else {
-                var decimal = (0, math_1.limitDecimalPrecision)(parseFloat(arg.toString()));
-                if ((0, math_1.isValidDecimal)(decimal)) {
-                    return decimal;
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, low, high, decimal;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            if (arg.isUncertainty) {
+                                low = (0, math_1.limitDecimalPrecision)(parseFloat(arg.low.toString()));
+                                high = (0, math_1.limitDecimalPrecision)(parseFloat(arg.high.toString()));
+                                return [2 /*return*/, new uncertainty_1.Uncertainty(low, high)];
+                            }
+                            else {
+                                decimal = (0, math_1.limitDecimalPrecision)(parseFloat(arg.toString()));
+                                if ((0, math_1.isValidDecimal)(decimal)) {
+                                    return [2 /*return*/, decimal];
+                                }
+                            }
+                        }
+                        return [2 /*return*/, null];
                 }
-            }
-        }
-        return null;
+            });
+        });
     };
     return ToDecimal;
 }(expression_1.Expression));
@@ -8343,17 +10903,26 @@ var ToInteger = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToInteger.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (typeof arg === 'string') {
-            var integer = parseInt(arg);
-            if ((0, math_1.isValidInteger)(integer)) {
-                return integer;
-            }
-        }
-        else if (typeof arg === 'boolean') {
-            return arg ? 1 : 0;
-        }
-        return null;
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, integer;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (typeof arg === 'string') {
+                            integer = parseInt(arg);
+                            if ((0, math_1.isValidInteger)(integer)) {
+                                return [2 /*return*/, integer];
+                            }
+                        }
+                        else if (typeof arg === 'boolean') {
+                            return [2 /*return*/, arg ? 1 : 0];
+                        }
+                        return [2 /*return*/, null];
+                }
+            });
+        });
     };
     return ToInteger;
 }(expression_1.Expression));
@@ -8364,7 +10933,17 @@ var ToQuantity = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToQuantity.prototype.exec = function (ctx) {
-        return this.convertValue(this.execArgs(ctx));
+        return __awaiter(this, void 0, void 0, function () {
+            var _a;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        _a = this.convertValue;
+                        return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1: return [2 /*return*/, _a.apply(this, [_b.sent()])];
+                }
+            });
+        });
     };
     ToQuantity.prototype.convertValue = function (val) {
         if (val == null) {
@@ -8394,35 +10973,43 @@ var ToRatio = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToRatio.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            // Argument will be of form '<quantity>:<quantity>'
-            var denominator = void 0, numerator = void 0;
-            try {
-                // String will be split into an array. Numerator will be at index 1, Denominator will be at index 4
-                var splitRatioString = arg
-                    .toString()
-                    .match(/^(\d+(\.\d+)?\s*('.+')?)\s*:\s*(\d+(\.\d+)?\s*('.+')?)$/);
-                if (splitRatioString == null) {
-                    return null;
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, denominator, numerator, splitRatioString;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            denominator = void 0, numerator = void 0;
+                            try {
+                                splitRatioString = arg
+                                    .toString()
+                                    .match(/^(\d+(\.\d+)?\s*('.+')?)\s*:\s*(\d+(\.\d+)?\s*('.+')?)$/);
+                                if (splitRatioString == null) {
+                                    return [2 /*return*/, null];
+                                }
+                                numerator = (0, quantity_1.parseQuantity)(splitRatioString[1]);
+                                denominator = (0, quantity_1.parseQuantity)(splitRatioString[4]);
+                            }
+                            catch (error) {
+                                // If the input string is not formatted correctly, or cannot be
+                                // interpreted as a valid Quantity value, the result is null.
+                                return [2 /*return*/, null];
+                            }
+                            // The value element of a Quantity must be present.
+                            if (numerator == null || denominator == null) {
+                                return [2 /*return*/, null];
+                            }
+                            return [2 /*return*/, new ratio_1.Ratio(numerator, denominator)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
                 }
-                numerator = (0, quantity_1.parseQuantity)(splitRatioString[1]);
-                denominator = (0, quantity_1.parseQuantity)(splitRatioString[4]);
-            }
-            catch (error) {
-                // If the input string is not formatted correctly, or cannot be
-                // interpreted as a valid Quantity value, the result is null.
-                return null;
-            }
-            // The value element of a Quantity must be present.
-            if (numerator == null || denominator == null) {
-                return null;
-            }
-            return new ratio_1.Ratio(numerator, denominator);
-        }
-        else {
-            return null;
-        }
+            });
+        });
     };
     return ToRatio;
 }(expression_1.Expression));
@@ -8433,13 +11020,23 @@ var ToString = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToString.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            return arg.toString();
-        }
-        else {
-            return null;
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            return [2 /*return*/, arg.toString()];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ToString;
 }(expression_1.Expression));
@@ -8450,47 +11047,55 @@ var ToTime = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ToTime.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg != null) {
-            var timeString = arg.toString();
-            // Return null if string doesn't represent a valid ISO-8601 Time
-            // hh:mm:ss.fff or hh:mm:ss.fff
-            var matches = /^T?((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?$/.exec(timeString);
-            if (matches == null) {
-                return null;
-            }
-            var hours = matches[2];
-            var minutes = matches[4];
-            var seconds = matches[6];
-            // Validate h/m/s if they exist, but allow null
-            if (hours != null) {
-                if (hours < 0 || hours > 23) {
-                    return null;
+        return __awaiter(this, void 0, void 0, function () {
+            var arg, timeString, matches, hours, minutes, seconds, milliseconds;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg != null) {
+                            timeString = arg.toString();
+                            matches = /^T?((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?$/.exec(timeString);
+                            if (matches == null) {
+                                return [2 /*return*/, null];
+                            }
+                            hours = matches[2];
+                            minutes = matches[4];
+                            seconds = matches[6];
+                            // Validate h/m/s if they exist, but allow null
+                            if (hours != null) {
+                                if (hours < 0 || hours > 23) {
+                                    return [2 /*return*/, null];
+                                }
+                                hours = parseInt(hours, 10);
+                            }
+                            if (minutes != null) {
+                                if (minutes < 0 || minutes > 59) {
+                                    return [2 /*return*/, null];
+                                }
+                                minutes = parseInt(minutes, 10);
+                            }
+                            if (seconds != null) {
+                                if (seconds < 0 || seconds > 59) {
+                                    return [2 /*return*/, null];
+                                }
+                                seconds = parseInt(seconds, 10);
+                            }
+                            milliseconds = matches[8];
+                            if (milliseconds != null) {
+                                milliseconds = parseInt((0, util_1.normalizeMillisecondsField)(milliseconds));
+                            }
+                            // Time is implemented as Datetime with year 0, month 1, day 1 and null timezoneOffset
+                            return [2 /*return*/, new datetime_1.DateTime(0, 1, 1, hours, minutes, seconds, milliseconds, null)];
+                        }
+                        else {
+                            return [2 /*return*/, null];
+                        }
+                        return [2 /*return*/];
                 }
-                hours = parseInt(hours, 10);
-            }
-            if (minutes != null) {
-                if (minutes < 0 || minutes > 59) {
-                    return null;
-                }
-                minutes = parseInt(minutes, 10);
-            }
-            if (seconds != null) {
-                if (seconds < 0 || seconds > 59) {
-                    return null;
-                }
-                seconds = parseInt(seconds, 10);
-            }
-            var milliseconds = matches[8];
-            if (milliseconds != null) {
-                milliseconds = parseInt((0, util_1.normalizeMillisecondsField)(milliseconds));
-            }
-            // Time is implemented as Datetime with year 0, month 1, day 1 and null timezoneOffset
-            return new datetime_1.DateTime(0, 1, 1, hours, minutes, seconds, milliseconds, null);
-        }
-        else {
-            return null;
-        }
+            });
+        });
     };
     return ToTime;
 }(expression_1.Expression));
@@ -8504,28 +11109,33 @@ var Convert = /** @class */ (function (_super) {
         return _this;
     }
     Convert.prototype.exec = function (ctx) {
-        switch (this.toType) {
-            case '{urn:hl7-org:elm-types:r1}Boolean':
-                return new ToBoolean({ type: 'ToBoolean', operand: this.operand }).execute(ctx);
-            case '{urn:hl7-org:elm-types:r1}Concept':
-                return new ToConcept({ type: 'ToConcept', operand: this.operand }).execute(ctx);
-            case '{urn:hl7-org:elm-types:r1}Decimal':
-                return new ToDecimal({ type: 'ToDecimal', operand: this.operand }).execute(ctx);
-            case '{urn:hl7-org:elm-types:r1}Integer':
-                return new ToInteger({ type: 'ToInteger', operand: this.operand }).execute(ctx);
-            case '{urn:hl7-org:elm-types:r1}String':
-                return new ToString({ type: 'ToString', operand: this.operand }).execute(ctx);
-            case '{urn:hl7-org:elm-types:r1}Quantity':
-                return new ToQuantity({ type: 'ToQuantity', operand: this.operand }).execute(ctx);
-            case '{urn:hl7-org:elm-types:r1}DateTime':
-                return new ToDateTime({ type: 'ToDateTime', operand: this.operand }).execute(ctx);
-            case '{urn:hl7-org:elm-types:r1}Date':
-                return new ToDate({ type: 'ToDate', operand: this.operand }).execute(ctx);
-            case '{urn:hl7-org:elm-types:r1}Time':
-                return new ToTime({ type: 'ToTime', operand: this.operand }).execute(ctx);
-            default:
-                return this.execArgs(ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                switch (this.toType) {
+                    case '{urn:hl7-org:elm-types:r1}Boolean':
+                        return [2 /*return*/, new ToBoolean({ type: 'ToBoolean', operand: this.operand }).execute(ctx)];
+                    case '{urn:hl7-org:elm-types:r1}Concept':
+                        return [2 /*return*/, new ToConcept({ type: 'ToConcept', operand: this.operand }).execute(ctx)];
+                    case '{urn:hl7-org:elm-types:r1}Decimal':
+                        return [2 /*return*/, new ToDecimal({ type: 'ToDecimal', operand: this.operand }).execute(ctx)];
+                    case '{urn:hl7-org:elm-types:r1}Integer':
+                        return [2 /*return*/, new ToInteger({ type: 'ToInteger', operand: this.operand }).execute(ctx)];
+                    case '{urn:hl7-org:elm-types:r1}String':
+                        return [2 /*return*/, new ToString({ type: 'ToString', operand: this.operand }).execute(ctx)];
+                    case '{urn:hl7-org:elm-types:r1}Quantity':
+                        return [2 /*return*/, new ToQuantity({ type: 'ToQuantity', operand: this.operand }).execute(ctx)];
+                    case '{urn:hl7-org:elm-types:r1}DateTime':
+                        return [2 /*return*/, new ToDateTime({ type: 'ToDateTime', operand: this.operand }).execute(ctx)];
+                    case '{urn:hl7-org:elm-types:r1}Date':
+                        return [2 /*return*/, new ToDate({ type: 'ToDate', operand: this.operand }).execute(ctx)];
+                    case '{urn:hl7-org:elm-types:r1}Time':
+                        return [2 /*return*/, new ToTime({ type: 'ToTime', operand: this.operand }).execute(ctx)];
+                    default:
+                        return [2 /*return*/, this.execArgs(ctx)];
+                }
+                return [2 /*return*/];
+            });
+        });
     };
     return Convert;
 }(expression_1.Expression));
@@ -8538,13 +11148,23 @@ var ConvertsToBoolean = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToBoolean.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToBoolean, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToBoolean, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToBoolean;
 }(expression_1.Expression));
@@ -8557,13 +11177,23 @@ var ConvertsToDate = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToDate.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToDate, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToDate, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToDate;
 }(expression_1.Expression));
@@ -8576,13 +11206,23 @@ var ConvertsToDateTime = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToDateTime.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToDateTime, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToDateTime, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToDateTime;
 }(expression_1.Expression));
@@ -8595,13 +11235,23 @@ var ConvertsToDecimal = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToDecimal.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToDecimal, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToDecimal, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToDecimal;
 }(expression_1.Expression));
@@ -8614,13 +11264,23 @@ var ConvertsToInteger = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToInteger.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToInteger, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToInteger, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToInteger;
 }(expression_1.Expression));
@@ -8633,13 +11293,23 @@ var ConvertsToQuantity = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToQuantity.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToQuantity, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToQuantity, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToQuantity;
 }(expression_1.Expression));
@@ -8652,13 +11322,23 @@ var ConvertsToRatio = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToRatio.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToRatio, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToRatio, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToRatio;
 }(expression_1.Expression));
@@ -8671,13 +11351,23 @@ var ConvertsToString = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToString.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToString, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToString, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToString;
 }(expression_1.Expression));
@@ -8690,30 +11380,51 @@ var ConvertsToTime = /** @class */ (function (_super) {
         return _this;
     }
     ConvertsToTime.prototype.exec = function (ctx) {
-        var operatorValue = this.execArgs(ctx);
-        if (operatorValue === null) {
-            return null;
-        }
-        else {
-            return canConvertToType(ToTime, this.operand, ctx);
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var operatorValue;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        operatorValue = _a.sent();
+                        if (operatorValue === null) {
+                            return [2 /*return*/, null];
+                        }
+                        else {
+                            return [2 /*return*/, canConvertToType(ToTime, this.operand, ctx)];
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertsToTime;
 }(expression_1.Expression));
 exports.ConvertsToTime = ConvertsToTime;
 function canConvertToType(toFunction, operand, ctx) {
-    try {
-        var value = new toFunction({ type: toFunction.name, operand: operand }).execute(ctx);
-        if (value != null) {
-            return true;
-        }
-        else {
-            return false;
-        }
-    }
-    catch (error) {
-        return false;
-    }
+    return __awaiter(this, void 0, void 0, function () {
+        var value, error_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    _a.trys.push([0, 2, , 3]);
+                    return [4 /*yield*/, new toFunction({ type: toFunction.name, operand: operand }).execute(ctx)];
+                case 1:
+                    value = _a.sent();
+                    if (value != null) {
+                        return [2 /*return*/, true];
+                    }
+                    else {
+                        return [2 /*return*/, false];
+                    }
+                    return [3 /*break*/, 3];
+                case 2:
+                    error_1 = _a.sent();
+                    return [2 /*return*/, false];
+                case 3: return [2 /*return*/];
+            }
+        });
+    });
 }
 var ConvertQuantity = /** @class */ (function (_super) {
     __extends(ConvertQuantity, _super);
@@ -8721,16 +11432,26 @@ var ConvertQuantity = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     ConvertQuantity.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), quantity = _a[0], newUnit = _a[1];
-        if (quantity != null && newUnit != null) {
-            try {
-                return quantity.convertUnit(newUnit);
-            }
-            catch (error) {
-                // Cannot convert input to target unit, spec says to return null
-                return null;
-            }
-        }
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, quantity, newUnit;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), quantity = _a[0], newUnit = _a[1];
+                        if (quantity != null && newUnit != null) {
+                            try {
+                                return [2 /*return*/, quantity.convertUnit(newUnit)];
+                            }
+                            catch (error) {
+                                // Cannot convert input to target unit, spec says to return null
+                                return [2 /*return*/, null];
+                            }
+                        }
+                        return [2 /*return*/];
+                }
+            });
+        });
     };
     return ConvertQuantity;
 }(expression_1.Expression));
@@ -8741,17 +11462,26 @@ var CanConvertQuantity = /** @class */ (function (_super) {
         return _super.call(this, json) || this;
     }
     CanConvertQuantity.prototype.exec = function (ctx) {
-        var _a = this.execArgs(ctx), quantity = _a[0], newUnit = _a[1];
-        if (quantity != null && newUnit != null) {
-            try {
-                quantity.convertUnit(newUnit);
-                return true;
-            }
-            catch (error) {
-                return false;
-            }
-        }
-        return null;
+        return __awaiter(this, void 0, void 0, function () {
+            var _a, quantity, newUnit;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        _a = _b.sent(), quantity = _a[0], newUnit = _a[1];
+                        if (quantity != null && newUnit != null) {
+                            try {
+                                quantity.convertUnit(newUnit);
+                                return [2 /*return*/, true];
+                            }
+                            catch (error) {
+                                return [2 /*return*/, false];
+                            }
+                        }
+                        return [2 /*return*/, null];
+                }
+            });
+        });
     };
     return CanConvertQuantity;
 }(expression_1.Expression));
@@ -8773,15 +11503,24 @@ var Is = /** @class */ (function (_super) {
         return _this;
     }
     Is.prototype.exec = function (ctx) {
-        var arg = this.execArgs(ctx);
-        if (arg === null) {
-            return false;
-        }
-        if (typeof arg._is !== 'function' && !isSystemType(this.isTypeSpecifier)) {
-            // We need an _is implementation in order to check non System types
-            throw new Error("Patient Source does not support Is operation for localId: ".concat(this.localId));
-        }
-        return ctx.matchesTypeSpecifier(arg, this.isTypeSpecifier);
+        return __awaiter(this, void 0, void 0, function () {
+            var arg;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.execArgs(ctx)];
+                    case 1:
+                        arg = _a.sent();
+                        if (arg === null) {
+                            return [2 /*return*/, false];
+                        }
+                        if (typeof arg._is !== 'function' && !isSystemType(this.isTypeSpecifier)) {
+                            // We need an _is implementation in order to check non System types
+                            throw new Error("Patient Source does not support Is operation for localId: ".concat(this.localId));
+                        }
+                        return [2 /*return*/, ctx.matchesTypeSpecifier(arg, this.isTypeSpecifier)];
+                }
+            });
+        });
     };
     return Is;
 }(expression_1.Expression));
@@ -8957,6 +11696,42 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.UnfilteredContext = exports.PatientContext = exports.Context = void 0;
 var exception_1 = require("../datatypes/exception");
@@ -9015,7 +11790,11 @@ var Context = /** @class */ (function () {
         }
     };
     Context.prototype.findRecords = function (profile) {
-        return this.parent && this.parent.findRecords(profile);
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.parent && this.parent.findRecords(profile)];
+            });
+        });
     };
     Context.prototype.childContext = function (context_values) {
         if (context_values === void 0) { context_values = {}; }
@@ -9361,7 +12140,11 @@ var PatientContext = /** @class */ (function (_super) {
         return this.localId_context[localId];
     };
     PatientContext.prototype.findRecords = function (profile) {
-        return this.patient && this.patient.findRecords(profile);
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2 /*return*/, this.patient && this.patient.findRecords(profile)];
+            });
+        });
     };
     return PatientContext;
 }(Context));
@@ -9380,7 +12163,11 @@ var UnfilteredContext = /** @class */ (function (_super) {
         return this;
     };
     UnfilteredContext.prototype.findRecords = function (_template) {
-        throw new exception_1.Exception('Retreives are not currently supported in Unfiltered Context');
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                throw new exception_1.Exception('Retreives are not currently supported in Unfiltered Context');
+            });
+        });
     };
     UnfilteredContext.prototype.getLibraryContext = function (_library) {
         throw new exception_1.Exception('Library expressions are not currently supported in Unfiltered Context');
@@ -9404,6 +12191,42 @@ exports.UnfilteredContext = UnfilteredContext;
 
 },{"../datatypes/datatypes":6,"../datatypes/exception":8,"../util/util":55,"./messageListeners":44}],43:[function(require,module,exports){
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Executor = void 0;
 var messageListeners_1 = require("./messageListeners");
@@ -9434,46 +12257,98 @@ var Executor = /** @class */ (function () {
         return this;
     };
     Executor.prototype.exec_expression = function (expression, patientSource, executionDateTime) {
-        var _a;
-        var r = new results_1.Results();
-        var expr = this.library.expressions[expression];
-        if (expr != null) {
-            while (patientSource.currentPatient()) {
-                var patient_ctx = new context_1.PatientContext(this.library, patientSource.currentPatient(), this.codeService, this.parameters, executionDateTime, this.messageListener);
-                r.recordPatientResults(patient_ctx, (_a = {}, _a[expression] = expr.execute(patient_ctx), _a));
-                patientSource.nextPatient();
-            }
-        }
-        return r;
+        return __awaiter(this, void 0, void 0, function () {
+            var r, expr, patient_ctx;
+            var _a;
+            return __generator(this, function (_b) {
+                r = new results_1.Results();
+                expr = this.library.expressions[expression];
+                if (expr != null) {
+                    while (patientSource.currentPatient()) {
+                        patient_ctx = new context_1.PatientContext(this.library, patientSource.currentPatient(), this.codeService, this.parameters, executionDateTime, this.messageListener);
+                        r.recordPatientResults(patient_ctx, (_a = {}, _a[expression] = expr.execute(patient_ctx), _a));
+                        patientSource.nextPatient();
+                    }
+                }
+                return [2 /*return*/, r];
+            });
+        });
     };
     Executor.prototype.exec = function (patientSource, executionDateTime) {
-        var r = this.exec_patient_context(patientSource, executionDateTime);
-        var unfilteredContext = new context_1.UnfilteredContext(this.library, r, this.codeService, this.parameters, executionDateTime, this.messageListener);
-        var resultMap = {};
-        for (var key in this.library.expressions) {
-            var expr = this.library.expressions[key];
-            if (expr.context === 'Unfiltered') {
-                resultMap[key] = expr.exec(unfilteredContext);
-            }
-        }
-        r.recordUnfilteredResults(resultMap);
-        return r;
+        return __awaiter(this, void 0, void 0, function () {
+            var r, unfilteredContext, resultMap, _a, _b, _i, key, expr, _c, _d;
+            return __generator(this, function (_e) {
+                switch (_e.label) {
+                    case 0: return [4 /*yield*/, this.exec_patient_context(patientSource, executionDateTime)];
+                    case 1:
+                        r = _e.sent();
+                        unfilteredContext = new context_1.UnfilteredContext(this.library, r, this.codeService, this.parameters, executionDateTime, this.messageListener);
+                        resultMap = {};
+                        _a = [];
+                        for (_b in this.library.expressions)
+                            _a.push(_b);
+                        _i = 0;
+                        _e.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3 /*break*/, 5];
+                        key = _a[_i];
+                        expr = this.library.expressions[key];
+                        if (!(expr.context === 'Unfiltered')) return [3 /*break*/, 4];
+                        _c = resultMap;
+                        _d = key;
+                        return [4 /*yield*/, expr.exec(unfilteredContext)];
+                    case 3:
+                        _c[_d] = _e.sent();
+                        _e.label = 4;
+                    case 4:
+                        _i++;
+                        return [3 /*break*/, 2];
+                    case 5:
+                        r.recordUnfilteredResults(resultMap);
+                        return [2 /*return*/, r];
+                }
+            });
+        });
     };
     Executor.prototype.exec_patient_context = function (patientSource, executionDateTime) {
-        var r = new results_1.Results();
-        while (patientSource.currentPatient()) {
-            var patient_ctx = new context_1.PatientContext(this.library, patientSource.currentPatient(), this.codeService, this.parameters, executionDateTime, this.messageListener);
-            var resultMap = {};
-            for (var key in this.library.expressions) {
-                var expr = this.library.expressions[key];
-                if (expr.context === 'Patient') {
-                    resultMap[key] = expr.execute(patient_ctx);
+        return __awaiter(this, void 0, void 0, function () {
+            var r, patient_ctx, resultMap, _a, _b, _i, key, expr, _c, _d;
+            return __generator(this, function (_e) {
+                switch (_e.label) {
+                    case 0:
+                        r = new results_1.Results();
+                        _e.label = 1;
+                    case 1:
+                        if (!patientSource.currentPatient()) return [3 /*break*/, 6];
+                        patient_ctx = new context_1.PatientContext(this.library, patientSource.currentPatient(), this.codeService, this.parameters, executionDateTime, this.messageListener);
+                        resultMap = {};
+                        _a = [];
+                        for (_b in this.library.expressions)
+                            _a.push(_b);
+                        _i = 0;
+                        _e.label = 2;
+                    case 2:
+                        if (!(_i < _a.length)) return [3 /*break*/, 5];
+                        key = _a[_i];
+                        expr = this.library.expressions[key];
+                        if (!(expr.context === 'Patient')) return [3 /*break*/, 4];
+                        _c = resultMap;
+                        _d = key;
+                        return [4 /*yield*/, expr.execute(patient_ctx)];
+                    case 3:
+                        _c[_d] = _e.sent();
+                        _e.label = 4;
+                    case 4:
+                        _i++;
+                        return [3 /*break*/, 2];
+                    case 5:
+                        r.recordPatientResults(patient_ctx, resultMap);
+                        patientSource.nextPatient();
+                        return [3 /*break*/, 1];
+                    case 6: return [2 /*return*/, r];
                 }
-            }
-            r.recordPatientResults(patient_ctx, resultMap);
-            patientSource.nextPatient();
-        }
-        return r;
+            });
+        });
     };
     return Executor;
 }());
@@ -10590,8 +13465,53 @@ function fixUnit(unit) {
 
 },{"./math":53,"@lhncbc/ucum-lhc":66}],55:[function(require,module,exports){
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+    if (pack || arguments.length === 2) for (var i = 0, l = from.length, ar; i < l; i++) {
+        if (ar || !(i in from)) {
+            if (!ar) ar = Array.prototype.slice.call(from, 0, i);
+            ar[i] = from[i];
+        }
+    }
+    return to.concat(ar || Array.prototype.slice.call(from));
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getTimezoneSeparatorFromString = exports.normalizeMillisecondsField = exports.normalizeMillisecondsFieldInString = exports.jsDate = exports.anyTrue = exports.allTrue = exports.typeIsArray = exports.isNull = exports.numerical_sort = exports.removeNulls = void 0;
+exports.asyncMergeSort = exports.getTimezoneSeparatorFromString = exports.normalizeMillisecondsField = exports.normalizeMillisecondsFieldInString = exports.jsDate = exports.anyTrue = exports.allTrue = exports.typeIsArray = exports.isNull = exports.numerical_sort = exports.removeNulls = void 0;
 function removeNulls(things) {
     return things.filter(function (x) { return x != null; });
 }
@@ -10666,6 +13586,51 @@ function getTimezoneSeparatorFromString(string) {
     return '';
 }
 exports.getTimezoneSeparatorFromString = getTimezoneSeparatorFromString;
+function asyncMergeSort(arr, compareFn) {
+    return __awaiter(this, void 0, void 0, function () {
+        var midpoint, left, right;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (arr.length <= 1)
+                        return [2 /*return*/, arr];
+                    midpoint = Math.floor(arr.length / 2);
+                    return [4 /*yield*/, asyncMergeSort(arr.slice(0, midpoint), compareFn)];
+                case 1:
+                    left = _a.sent();
+                    return [4 /*yield*/, asyncMergeSort(arr.slice(midpoint), compareFn)];
+                case 2:
+                    right = _a.sent();
+                    return [2 /*return*/, merge(left, right, compareFn)];
+            }
+        });
+    });
+}
+exports.asyncMergeSort = asyncMergeSort;
+function merge(left, right, compareFn) {
+    return __awaiter(this, void 0, void 0, function () {
+        var sorted;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    sorted = [];
+                    _a.label = 1;
+                case 1:
+                    if (!(left.length > 0 && right.length > 0)) return [3 /*break*/, 3];
+                    return [4 /*yield*/, compareFn(left[0], right[0])];
+                case 2:
+                    if ((_a.sent()) < 0) {
+                        sorted.push(left.shift());
+                    }
+                    else {
+                        sorted.push(right.shift());
+                    }
+                    return [3 /*break*/, 1];
+                case 3: return [2 /*return*/, __spreadArray(__spreadArray(__spreadArray([], sorted, true), left, true), right, true)];
+            }
+        });
+    });
+}
 
 },{}],56:[function(require,module,exports){
 module.exports={"license":"The following data (prefixes and units) was generated by the UCUM LHC code from the UCUM data and selected LOINC combinations of UCUM units.  The license for the UCUM LHC code (demo and library code as well as the combined units) is located at https://github.com/lhncbc/ucum-lhc/blob/LICENSE.md.","prefixes":{"config":["code_","ciCode_","name_","printSymbol_","value_","exp_"],"data":[["E","EX","exa","E",1000000000000000000,"18"],["G","GA","giga","G",1000000000,"9"],["Gi","GIB","gibi","Gi",1073741824,null],["Ki","KIB","kibi","Ki",1024,null],["M","MA","mega","M",1000000,"6"],["Mi","MIB","mebi","Mi",1048576,null],["P","PT","peta","P",1000000000000000,"15"],["T","TR","tera","T",1000000000000,"12"],["Ti","TIB","tebi","Ti",1099511627776,null],["Y","YA","yotta","Y",1e+24,"24"],["Z","ZA","zetta","Z",1e+21,"21"],["a","A","atto","a",1e-18,"-18"],["c","C","centi","c",0.01,"-2"],["d","D","deci","d",0.1,"-1"],["da","DA","deka","da",10,"1"],["f","F","femto","f",1e-15,"-15"],["h","H","hecto","h",100,"2"],["k","K","kilo","k",1000,"3"],["m","M","milli","m",0.001,"-3"],["n","N","nano","n",1e-9,"-9"],["p","P","pico","p",1e-12,"-12"],["u","U","micro","μ",0.000001,"-6"],["y","YO","yocto","y",1.0000000000000001e-24,"-24"],["z","ZO","zepto","z",1e-21,"-21"]]},"units":{"config":["isBase_","name_","csCode_","ciCode_","property_","magnitude_",["dim_","dimVec_"],"printSymbol_","class_","isMetric_","variable_","cnv_","cnvPfx_","isSpecial_","isArbitrary_","moleExp_","synonyms_","source_","loincProperty_","category_","guidance_","csUnitString_","ciUnitString_","baseFactorStr_","baseFactor_","defError_"],"data":[[true,"meter","m","M","length",1,[1,0,0,0,0,0,0],"m",null,false,"L",null,1,false,false,0,"meters; metres; distance","UCUM","Len","Clinical","unit of length = 1.09361 yards",null,null,null,null,false],[true,"second - time","s","S","time",1,[0,1,0,0,0,0,0],"s",null,false,"T",null,1,false,false,0,"seconds","UCUM","Time","Clinical","",null,null,null,null,false],[true,"gram","g","G","mass",1,[0,0,1,0,0,0,0],"g",null,false,"M",null,1,false,false,0,"grams; gm","UCUM","Mass","Clinical","",null,null,null,null,false],[true,"radian","rad","RAD","plane angle",1,[0,0,0,1,0,0,0],"rad",null,false,"A",null,1,false,false,0,"radians","UCUM","Angle","Clinical","unit of angular measure where 1 radian = 1/2π turn =  57.296 degrees. ",null,null,null,null,false],[true,"degree Kelvin","K","K","temperature",1,[0,0,0,0,1,0,0],"K",null,false,"C",null,1,false,false,0,"Kelvin; degrees","UCUM","Temp","Clinical","absolute, thermodynamic temperature scale ",null,null,null,null,false],[true,"coulomb","C","C","electric charge",1,[0,0,0,0,0,1,0],"C",null,false,"Q",null,1,false,false,0,"coulombs","UCUM","","Clinical","defined as amount of 1 electron charge = 6.2415093×10^18 e, and equivalent to 1 Ampere-second",null,null,null,null,false],[true,"candela","cd","CD","luminous intensity",1,[0,0,0,0,0,0,1],"cd",null,false,"F",null,1,false,false,0,"candelas","UCUM","","Clinical","SI base unit of luminous intensity",null,null,null,null,false],[false,"the number ten for arbitrary powers","10*","10*","number",10,[0,0,0,0,0,0,0],"10","dimless",false,null,null,1,false,false,0,"10^; 10 to the arbitrary powers","UCUM","Num","Clinical","10* by itself is the same as 10, but users can add digits after the *. For example, 10*3 = 1000.","1","1","10",10,false],[false,"the number ten for arbitrary powers","10^","10^","number",10,[0,0,0,0,0,0,0],"10","dimless",false,null,null,1,false,false,0,"10*; 10 to the arbitrary power","UCUM","Num","Clinical","10* by itself is the same as 10, but users can add digits after the *. For example, 10*3 = 1000.","1","1","10",10,false],[false,"the number pi","[pi]","[PI]","number",3.141592653589793,[0,0,0,0,0,0,0],"π","dimless",false,null,null,1,false,false,0,"π","UCUM","","Constant","a mathematical constant; the ratio of a circle's circumference to its diameter ≈ 3.14159","1","1","3.1415926535897932384626433832795028841971693993751058209749445923",3.141592653589793,false],[false,"","%","%","fraction",0.01,[0,0,0,0,0,0,0],"%","dimless",false,null,null,1,false,false,0,"percents","UCUM","FR; NFR; MFR; CFR; SFR Rto; etc. ","Clinical","","10*-2","10*-2","1",1,false],[false,"parts per thousand","[ppth]","[PPTH]","fraction",0.001,[0,0,0,0,0,0,0],"ppth","dimless",false,null,null,1,false,false,0,"ppth; 10^-3","UCUM","MCnc; MCnt","Clinical","[ppth] is often used in solution concentrations as 1 g/L or 1 g/kg.\n\nCan be ambigous and would be better if the metric units was used directly. ","10*-3","10*-3","1",1,false],[false,"parts per million","[ppm]","[PPM]","fraction",0.000001,[0,0,0,0,0,0,0],"ppm","dimless",false,null,null,1,false,false,0,"ppm; 10^-6","UCUM","MCnt; MCnc; SFr","Clinical","[ppm] is often used in solution concentrations as 1 mg/L  or 1 mg/kg. Also used to express mole fractions as 1 mmol/mol.\n\n[ppm] is also used in nuclear magnetic resonance (NMR) to represent chemical shift - the difference of a measured frequency in parts per million from the reference frequency.\n\nCan be ambigous and would be better if the metric units was used directly. ","10*-6","10*-6","1",1,false],[false,"parts per billion","[ppb]","[PPB]","fraction",1e-9,[0,0,0,0,0,0,0],"ppb","dimless",false,null,null,1,false,false,0,"ppb; 10^-9","UCUM","MCnt; MCnc; SFr","Clinical","[ppb] is often used in solution concentrations as 1 ug/L  or 1 ug/kg. Also used to express mole fractions as 1 umol/mol.\n\nCan be ambigous and would be better if the metric units was used directly. ","10*-9","10*-9","1",1,false],[false,"parts per trillion","[pptr]","[PPTR]","fraction",1e-12,[0,0,0,0,0,0,0],"pptr","dimless",false,null,null,1,false,false,0,"pptr; 10^-12","UCUM","MCnt; MCnc; SFr","Clinical","[pptr] is often used in solution concentrations as 1 ng/L or 1 ng/kg. Also used to express mole fractions as 1 nmol/mol.\n\nCan be ambigous and would be better if the metric units was used directly. ","10*-12","10*-12","1",1,false],[false,"mole","mol","MOL","amount of substance",6.0221367e+23,[0,0,0,0,0,0,0],"mol","si",true,null,null,1,false,false,1,"moles","UCUM","Sub","Clinical","Measure the number of molecules ","10*23","10*23","6.0221367",6.0221367,false],[false,"steradian - solid angle","sr","SR","solid angle",1,[0,0,0,2,0,0,0],"sr","si",true,null,null,1,false,false,0,"square radian; rad2; rad^2","UCUM","Angle","Clinical","unit of solid angle in three-dimensional geometry analagous to radian; used in photometry which measures the perceived brightness of object by human eye (e.g. radiant intensity = watt/steradian)","rad2","RAD2","1",1,false],[false,"hertz","Hz","HZ","frequency",1,[0,-1,0,0,0,0,0],"Hz","si",true,null,null,1,false,false,0,"Herz; frequency; frequencies","UCUM","Freq; Num","Clinical","equal to one cycle per second","s-1","S-1","1",1,false],[false,"newton","N","N","force",1000,[1,-2,1,0,0,0,0],"N","si",true,null,null,1,false,false,0,"Newtons","UCUM","Force","Clinical","unit of force with base units kg.m/s2","kg.m/s2","KG.M/S2","1",1,false],[false,"pascal","Pa","PAL","pressure",1000,[-1,-2,1,0,0,0,0],"Pa","si",true,null,null,1,false,false,0,"pascals","UCUM","Pres","Clinical","standard unit of pressure equal to 1 newton per square meter (N/m2)","N/m2","N/M2","1",1,false],[false,"joule","J","J","energy",1000,[2,-2,1,0,0,0,0],"J","si",true,null,null,1,false,false,0,"joules","UCUM","Enrg","Clinical","unit of energy defined as the work required to move an object 1 m with a force of 1 N (N.m) or an electric charge of 1 C through 1 V (C.V), or to produce 1 W for 1 s (W.s) ","N.m","N.M","1",1,false],[false,"watt","W","W","power",1000,[2,-3,1,0,0,0,0],"W","si",true,null,null,1,false,false,0,"watts","UCUM","EngRat","Clinical","unit of power equal to 1 Joule per second (J/s) =  kg⋅m2⋅s−3","J/s","J/S","1",1,false],[false,"Ampere","A","A","electric current",1,[0,-1,0,0,0,1,0],"A","si",true,null,null,1,false,false,0,"Amperes","UCUM","ElpotRat","Clinical","unit of electric current equal to flow rate of electrons equal to 16.2415×10^18 elementary charges moving past a boundary in one second or 1 Coulomb/second","C/s","C/S","1",1,false],[false,"volt","V","V","electric potential",1000,[2,-2,1,0,0,-1,0],"V","si",true,null,null,1,false,false,0,"volts","UCUM","Elpot","Clinical","unit of electric potential (voltage) = 1 Joule per Coulomb (J/C)","J/C","J/C","1",1,false],[false,"farad","F","F","electric capacitance",0.001,[-2,2,-1,0,0,2,0],"F","si",true,null,null,1,false,false,0,"farads; electric capacitance","UCUM","","Clinical","CGS unit of electric capacitance with base units C/V (Coulomb per Volt)","C/V","C/V","1",1,false],[false,"ohm","Ohm","OHM","electric resistance",1000,[2,-1,1,0,0,-2,0],"Ω","si",true,null,null,1,false,false,0,"Ω; resistance; ohms","UCUM","","Clinical","unit of electrical resistance with units of Volt per Ampere","V/A","V/A","1",1,false],[false,"siemens","S","SIE","electric conductance",0.001,[-2,1,-1,0,0,2,0],"S","si",true,null,null,1,false,false,0,"Reciprocal ohm; mho; Ω−1; conductance","UCUM","","Clinical","unit of electric conductance (the inverse of electrical resistance) equal to ohm^-1","Ohm-1","OHM-1","1",1,false],[false,"weber","Wb","WB","magnetic flux",1000,[2,-1,1,0,0,-1,0],"Wb","si",true,null,null,1,false,false,0,"magnetic flux; webers","UCUM","","Clinical","unit of magnetic flux equal to Volt second","V.s","V.S","1",1,false],[false,"degree Celsius","Cel","CEL","temperature",1,[0,0,0,0,1,0,0],"°C","si",true,null,"Cel",1,true,false,0,"°C; degrees","UCUM","Temp","Clinical","","K",null,null,1,false],[false,"tesla","T","T","magnetic flux density",1000,[0,-1,1,0,0,-1,0],"T","si",true,null,null,1,false,false,0,"Teslas; magnetic field","UCUM","","Clinical","SI unit of magnetic field strength for magnetic field B equal to 1 Weber/square meter =  1 kg/(s2*A)","Wb/m2","WB/M2","1",1,false],[false,"henry","H","H","inductance",1000,[2,0,1,0,0,-2,0],"H","si",true,null,null,1,false,false,0,"henries; inductance","UCUM","","Clinical","unit of electrical inductance; usually expressed in millihenrys (mH) or microhenrys (uH).","Wb/A","WB/A","1",1,false],[false,"lumen","lm","LM","luminous flux",1,[0,0,0,2,0,0,1],"lm","si",true,null,null,1,false,false,0,"luminous flux; lumens","UCUM","","Clinical","unit of luminous flux defined as 1 lm = 1 cd⋅sr (candela times sphere)","cd.sr","CD.SR","1",1,false],[false,"lux","lx","LX","illuminance",1,[-2,0,0,2,0,0,1],"lx","si",true,null,null,1,false,false,0,"illuminance; luxes","UCUM","","Clinical","unit of illuminance equal to one lumen per square meter. ","lm/m2","LM/M2","1",1,false],[false,"becquerel","Bq","BQ","radioactivity",1,[0,-1,0,0,0,0,0],"Bq","si",true,null,null,1,false,false,0,"activity; radiation; becquerels","UCUM","","Clinical","measure of the atomic radiation rate with units s^-1","s-1","S-1","1",1,false],[false,"gray","Gy","GY","energy dose",1,[2,-2,0,0,0,0,0],"Gy","si",true,null,null,1,false,false,0,"absorbed doses; ionizing radiation doses; kerma; grays","UCUM","EngCnt","Clinical","unit of ionizing radiation dose with base units of 1 joule of radiation energy per kilogram of matter","J/kg","J/KG","1",1,false],[false,"sievert","Sv","SV","dose equivalent",1,[2,-2,0,0,0,0,0],"Sv","si",true,null,null,1,false,false,0,"sieverts; radiation dose quantities; equivalent doses; effective dose; operational dose; committed dose","UCUM","","Clinical","SI unit for radiation dose equivalent equal to 1 Joule/kilogram.","J/kg","J/KG","1",1,false],[false,"degree - plane angle","deg","DEG","plane angle",0.017453292519943295,[0,0,0,1,0,0,0],"°","iso1000",false,null,null,1,false,false,0,"°; degree of arc; arc degree; arcdegree; angle","UCUM","Angle","Clinical","one degree is equivalent to π/180 radians.","[pi].rad/360","[PI].RAD/360","2",2,false],[false,"gon","gon","GON","plane angle",0.015707963267948967,[0,0,0,1,0,0,0],"□<sup>g</sup>","iso1000",false,null,null,1,false,false,0,"gon (grade); gons","UCUM","Angle","Nonclinical","unit of plane angle measurement equal to 1/400 circle","deg","DEG","0.9",0.9,false],[false,"arc minute","'","'","plane angle",0.0002908882086657216,[0,0,0,1,0,0,0],"'","iso1000",false,null,null,1,false,false,0,"arcminutes; arcmin; arc minutes; arc mins","UCUM","Angle","Clinical","equal to 1/60 degree; used in optometry and opthamology (e.g. visual acuity tests)","deg/60","DEG/60","1",1,false],[false,"arc second","''","''","plane angle",0.00000484813681109536,[0,0,0,1,0,0,0],"''","iso1000",false,null,null,1,false,false,0,"arcseconds; arcsecs","UCUM","Angle","Clinical","equal to 1/60 arcminute = 1/3600 degree; used in optometry and opthamology (e.g. visual acuity tests)","'/60","'/60","1",1,false],[false,"Liters","l","L","volume",0.001,[3,0,0,0,0,0,0],"l","iso1000",true,null,null,1,false,false,0,"cubic decimeters; decimeters cubed; decimetres; dm3; dm^3; litres; liters, LT ","UCUM","Vol","Clinical","Because lower case \"l\" can be read as the number \"1\", though this is a valid UCUM units. UCUM strongly reccomends using  \"L\"","dm3","DM3","1",1,false],[false,"Liters","L","L","volume",0.001,[3,0,0,0,0,0,0],"L","iso1000",true,null,null,1,false,false,0,"cubic decimeters; decimeters cubed; decimetres; dm3; dm^3; litres; liters, LT ","UCUM","Vol","Clinical","Because lower case \"l\" can be read as the number \"1\", though this is a valid UCUM units. UCUM strongly reccomends using  \"L\"","l",null,"1",1,false],[false,"are","ar","AR","area",100,[2,0,0,0,0,0,0],"a","iso1000",true,null,null,1,false,false,0,"100 m2; 100 m^2; 100 square meter; meters squared; metres","UCUM","Area","Clinical","metric base unit for area defined as 100 m^2","m2","M2","100",100,false],[false,"minute","min","MIN","time",60,[0,1,0,0,0,0,0],"min","iso1000",false,null,null,1,false,false,0,"minutes","UCUM","Time","Clinical","","s","S","60",60,false],[false,"hour","h","HR","time",3600,[0,1,0,0,0,0,0],"h","iso1000",false,null,null,1,false,false,0,"hours; hrs; age","UCUM","Time","Clinical","","min","MIN","60",60,false],[false,"day","d","D","time",86400,[0,1,0,0,0,0,0],"d","iso1000",false,null,null,1,false,false,0,"days; age; dy; 24 hours; 24 hrs","UCUM","Time","Clinical","","h","HR","24",24,false],[false,"tropical year","a_t","ANN_T","time",31556925.216,[0,1,0,0,0,0,0],"a<sub>t</sub>","iso1000",false,null,null,1,false,false,0,"solar years; a tropical; years","UCUM","Time","Clinical","has an average of 365.242181 days but is constantly changing.","d","D","365.24219",365.24219,false],[false,"mean Julian year","a_j","ANN_J","time",31557600,[0,1,0,0,0,0,0],"a<sub>j</sub>","iso1000",false,null,null,1,false,false,0,"mean Julian yr; a julian; years","UCUM","Time","Clinical","has an average of 365.25 days, and in everyday use, has been replaced by the Gregorian year. However, this unit is used in astronomy to calculate light year. ","d","D","365.25",365.25,false],[false,"mean Gregorian year","a_g","ANN_G","time",31556952,[0,1,0,0,0,0,0],"a<sub>g</sub>","iso1000",false,null,null,1,false,false,0,"mean Gregorian yr; a gregorian; years","UCUM","Time","Clinical","has an average of 365.2425 days and is the most internationally used civil calendar.","d","D","365.2425",365.2425,false],[false,"year","a","ANN","time",31557600,[0,1,0,0,0,0,0],"a","iso1000",false,null,null,1,false,false,0,"years; a; yr, yrs; annum","UCUM","Time","Clinical","","a_j","ANN_J","1",1,false],[false,"week","wk","WK","time",604800,[0,1,0,0,0,0,0],"wk","iso1000",false,null,null,1,false,false,0,"weeks; wks","UCUM","Time","Clinical","","d","D","7",7,false],[false,"synodal month","mo_s","MO_S","time",2551442.976,[0,1,0,0,0,0,0],"mo<sub>s</sub>","iso1000",false,null,null,1,false,false,0,"Moon; synodic month; lunar month; mo-s; mo s; months; moons","UCUM","Time","Nonclinical","has an average of 29.53 days per month, unit used in astronomy","d","D","29.53059",29.53059,false],[false,"mean Julian month","mo_j","MO_J","time",2629800,[0,1,0,0,0,0,0],"mo<sub>j</sub>","iso1000",false,null,null,1,false,false,0,"mo-julian; mo Julian; months","UCUM","Time","Clinical","has an average of 30.435 days per month","a_j/12","ANN_J/12","1",1,false],[false,"mean Gregorian month","mo_g","MO_G","time",2629746,[0,1,0,0,0,0,0],"mo<sub>g</sub>","iso1000",false,null,null,1,false,false,0,"months; month-gregorian; mo-gregorian","UCUM","Time","Clinical","has an average 30.436875 days per month and is from the most internationally used civil calendar.","a_g/12","ANN_G/12","1",1,false],[false,"month","mo","MO","time",2629800,[0,1,0,0,0,0,0],"mo","iso1000",false,null,null,1,false,false,0,"months; duration","UCUM","Time","Clinical","based on Julian calendar which has an average of 30.435 days per month (this unit is used in astronomy but not in everyday life - see mo_g)","mo_j","MO_J","1",1,false],[false,"metric ton","t","TNE","mass",1000000,[0,0,1,0,0,0,0],"t","iso1000",true,null,null,1,false,false,0,"tonnes; megagrams; tons","UCUM","Mass","Nonclinical","equal to 1000 kg used in the US (recognized by NIST as metric ton), and internationally (recognized as tonne)","kg","KG","1e3",1000,false],[false,"bar","bar","BAR","pressure",100000000,[-1,-2,1,0,0,0,0],"bar","iso1000",true,null,null,1,false,false,0,"bars","UCUM","Pres","Nonclinical","unit of pressure equal to 10^5 Pascals, primarily used by meteorologists and in weather forecasting","Pa","PAL","1e5",100000,false],[false,"unified atomic mass unit","u","AMU","mass",1.6605402e-24,[0,0,1,0,0,0,0],"u","iso1000",true,null,null,1,false,false,0,"unified atomic mass units; amu; Dalton; Da","UCUM","Mass","Clinical","the mass of 1/12 of an unbound Carbon-12 atom nuclide equal to 1.6606x10^-27 kg ","g","G","1.6605402e-24",1.6605402e-24,false],[false,"astronomic unit","AU","ASU","length",149597870691,[1,0,0,0,0,0,0],"AU","iso1000",false,null,null,1,false,false,0,"AU; units","UCUM","Len","Clinical","unit of length used in astronomy for measuring distance in Solar system","Mm","MAM","149597.870691",149597.870691,false],[false,"parsec","pc","PRS","length",30856780000000000,[1,0,0,0,0,0,0],"pc","iso1000",true,null,null,1,false,false,0,"parsecs","UCUM","Len","Clinical","unit of length equal to 3.26 light years, nad used to measure large distances to objects outside our Solar System","m","M","3.085678e16",30856780000000000,false],[false,"velocity of light in a vacuum","[c]","[C]","velocity",299792458,[1,-1,0,0,0,0,0],"<i>c</i>","const",true,null,null,1,false,false,0,"speed of light","UCUM","Vel","Constant","equal to 299792458 m/s (approximately 3 x 10^8 m/s)","m/s","M/S","299792458",299792458,false],[false,"Planck constant","[h]","[H]","action",6.6260755e-31,[2,-1,1,0,0,0,0],"<i>h</i>","const",true,null,null,1,false,false,0,"Planck's constant","UCUM","","Constant","constant = 6.62607004 × 10-34 m2.kg/s; defined as quantum of action","J.s","J.S","6.6260755e-34",6.6260755e-34,false],[false,"Boltzmann constant","[k]","[K]","(unclassified)",1.380658e-20,[2,-2,1,0,-1,0,0],"<i>k</i>","const",true,null,null,1,false,false,0,"k; kB","UCUM","","Constant","physical constant relating energy at the individual particle level with temperature = 1.38064852 ×10^−23 J/K","J/K","J/K","1.380658e-23",1.380658e-23,false],[false,"permittivity of vacuum - electric","[eps_0]","[EPS_0]","electric permittivity",8.854187817000001e-15,[-3,2,-1,0,0,2,0],"<i>ε<sub><r>0</r></sub></i>","const",true,null,null,1,false,false,0,"ε0; Electric Constant; vacuum permittivity; permittivity of free space ","UCUM","","Constant","approximately equal to 8.854 × 10^−12 F/m (farads per meter)","F/m","F/M","8.854187817e-12",8.854187817e-12,false],[false,"permeability of vacuum - magnetic","[mu_0]","[MU_0]","magnetic permeability",0.0012566370614359172,[1,0,1,0,0,-2,0],"<i>μ<sub><r>0</r></sub></i>","const",true,null,null,1,false,false,0,"μ0; vacuum permeability; permeability of free space; magnetic constant","UCUM","","Constant","equal to 4π×10^−7 N/A2 (Newtons per square ampere) ≈ 1.2566×10^−6 H/m (Henry per meter)","N/A2","4.[PI].10*-7.N/A2","1",0.0000012566370614359173,false],[false,"elementary charge","[e]","[E]","electric charge",1.60217733e-19,[0,0,0,0,0,1,0],"<i>e</i>","const",true,null,null,1,false,false,0,"e; q; electric charges","UCUM","","Constant","the magnitude of the electric charge carried by a single electron or proton ≈ 1.60217×10^-19 Coulombs","C","C","1.60217733e-19",1.60217733e-19,false],[false,"electronvolt","eV","EV","energy",1.60217733e-16,[2,-2,1,0,0,0,0],"eV","iso1000",true,null,null,1,false,false,0,"Electron Volts; electronvolts","UCUM","Eng","Clinical","unit of kinetic energy = 1 V * 1.602×10^−19 C = 1.6×10−19 Joules","[e].V","[E].V","1",1,false],[false,"electron mass","[m_e]","[M_E]","mass",9.1093897e-28,[0,0,1,0,0,0,0],"<i>m<sub><r>e</r></sub></i>","const",true,null,null,1,false,false,0,"electron rest mass; me","UCUM","Mass","Constant","approximately equal to 9.10938356 × 10-31 kg; defined as the mass of a stationary electron","g","g","9.1093897e-28",9.1093897e-28,false],[false,"proton mass","[m_p]","[M_P]","mass",1.6726231e-24,[0,0,1,0,0,0,0],"<i>m<sub><r>p</r></sub></i>","const",true,null,null,1,false,false,0,"mp; masses","UCUM","Mass","Constant","approximately equal to 1.672622×10−27 kg","g","g","1.6726231e-24",1.6726231e-24,false],[false,"Newtonian constant of gravitation","[G]","[GC]","(unclassified)",6.67259e-14,[3,-2,-1,0,0,0,0],"<i>G</i>","const",true,null,null,1,false,false,0,"G; gravitational constant; Newton's constant","UCUM","","Constant","gravitational constant = 6.674×10−11 N⋅m2/kg2","m3.kg-1.s-2","M3.KG-1.S-2","6.67259e-11",6.67259e-11,false],[false,"standard acceleration of free fall","[g]","[G]","acceleration",9.80665,[1,-2,0,0,0,0,0],"<i>g<sub>n</sub></i>","const",true,null,null,1,false,false,0,"standard gravity; g; ɡ0; ɡn","UCUM","Accel","Constant","defined by standard = 9.80665 m/s2","m/s2","M/S2","980665e-5",9.80665,false],[false,"Torr","Torr","Torr","pressure",133322,[-1,-2,1,0,0,0,0],"Torr","const",false,null,null,1,false,false,0,"torrs","UCUM","Pres","Clinical","1 torr = 1 mmHg; unit used to measure blood pressure","Pa","PAL","133.322",133.322,false],[false,"standard atmosphere","atm","ATM","pressure",101325000,[-1,-2,1,0,0,0,0],"atm","const",false,null,null,1,false,false,0,"reference pressure; atmos; std atmosphere","UCUM","Pres","Clinical","defined as being precisely equal to 101,325 Pa","Pa","PAL","101325",101325,false],[false,"light-year","[ly]","[LY]","length",9460730472580800,[1,0,0,0,0,0,0],"l.y.","const",true,null,null,1,false,false,0,"light years; ly","UCUM","Len","Constant","unit of astronomal distance = 5.88×10^12 mi","[c].a_j","[C].ANN_J","1",1,false],[false,"gram-force","gf","GF","force",9.80665,[1,-2,1,0,0,0,0],"gf","const",true,null,null,1,false,false,0,"Newtons; gram forces","UCUM","Force","Clinical","May be specific to unit related to cardiac output","g.[g]","G.[G]","1",1,false],[false,"Kayser","Ky","KY","lineic number",100,[-1,0,0,0,0,0,0],"K","cgs",true,null,null,1,false,false,0,"wavenumbers; kaysers","UCUM","InvLen","Clinical","unit of wavelength equal to cm^-1","cm-1","CM-1","1",1,false],[false,"Gal","Gal","GL","acceleration",0.01,[1,-2,0,0,0,0,0],"Gal","cgs",true,null,null,1,false,false,0,"galileos; Gals","UCUM","Accel","Clinical","unit of acceleration used in gravimetry; equivalent to cm/s2 ","cm/s2","CM/S2","1",1,false],[false,"dyne","dyn","DYN","force",0.01,[1,-2,1,0,0,0,0],"dyn","cgs",true,null,null,1,false,false,0,"dynes","UCUM","Force","Clinical","unit of force equal to 10^-5 Newtons","g.cm/s2","G.CM/S2","1",1,false],[false,"erg","erg","ERG","energy",0.0001,[2,-2,1,0,0,0,0],"erg","cgs",true,null,null,1,false,false,0,"10^-7 Joules, 10-7 Joules; 100 nJ; 100 nanoJoules; 1 dyne cm; 1 g.cm2/s2","UCUM","Eng","Clinical","unit of energy = 1 dyne centimeter = 10^-7 Joules","dyn.cm","DYN.CM","1",1,false],[false,"Poise","P","P","dynamic viscosity",100,[-1,-1,1,0,0,0,0],"P","cgs",true,null,null,1,false,false,0,"dynamic viscosity; poises","UCUM","Visc","Clinical","unit of dynamic viscosity where 1 Poise = 1/10 Pascal second","dyn.s/cm2","DYN.S/CM2","1",1,false],[false,"Biot","Bi","BI","electric current",10,[0,-1,0,0,0,1,0],"Bi","cgs",true,null,null,1,false,false,0,"Bi; abamperes; abA","UCUM","ElpotRat","Clinical","equal to 10 amperes","A","A","10",10,false],[false,"Stokes","St","ST","kinematic viscosity",0.0001,[2,-1,0,0,0,0,0],"St","cgs",true,null,null,1,false,false,0,"kinematic viscosity","UCUM","Visc","Clinical","unit of kimematic viscosity with units cm2/s","cm2/s","CM2/S","1",1,false],[false,"Maxwell","Mx","MX","flux of magnetic induction",0.00001,[2,-1,1,0,0,-1,0],"Mx","cgs",true,null,null,1,false,false,0,"magnetix flux; Maxwells","UCUM","","Clinical","unit of magnetic flux","Wb","WB","1e-8",1e-8,false],[false,"Gauss","G","GS","magnetic flux density",0.1,[0,-1,1,0,0,-1,0],"Gs","cgs",true,null,null,1,false,false,0,"magnetic fields; magnetic flux density; induction; B","UCUM","magnetic","Clinical","CGS unit of magnetic flux density, known as magnetic field B; defined as one maxwell unit per square centimeter (see Oersted for CGS unit for H field)","T","T","1e-4",0.0001,false],[false,"Oersted","Oe","OE","magnetic field intensity",79.57747154594767,[-1,-1,0,0,0,1,0],"Oe","cgs",true,null,null,1,false,false,0,"H magnetic B field; Oersteds","UCUM","","Clinical","CGS unit of the auxiliary magnetic field H defined as 1 dyne per unit pole = 1000/4π amperes per meter (see Gauss for CGS unit for B field)","A/m","/[PI].A/M","250",79.57747154594767,false],[false,"Gilbert","Gb","GB","magnetic tension",0.7957747154594768,[0,-1,0,0,0,1,0],"Gb","cgs",true,null,null,1,false,false,0,"Gi; magnetomotive force; Gilberts","UCUM","","Clinical","unit of magnetomotive force (magnetic potential)","Oe.cm","OE.CM","1",1,false],[false,"stilb","sb","SB","lum. intensity density",10000,[-2,0,0,0,0,0,1],"sb","cgs",true,null,null,1,false,false,0,"stilbs","UCUM","","Obsolete","unit of luminance; equal to and replaced by unit candela per square centimeter (cd/cm2)","cd/cm2","CD/CM2","1",1,false],[false,"Lambert","Lmb","LMB","brightness",3183.098861837907,[-2,0,0,0,0,0,1],"L","cgs",true,null,null,1,false,false,0,"luminance; lamberts","UCUM","","Clinical","unit of luminance defined as 1 lambert = 1/ π candela per square meter","cd/cm2/[pi]","CD/CM2/[PI]","1",1,false],[false,"phot","ph","PHT","illuminance",0.0001,[-2,0,0,2,0,0,1],"ph","cgs",true,null,null,1,false,false,0,"phots","UCUM","","Clinical","CGS photometric unit of illuminance, or luminous flux through an area equal to 10000 lumens per square meter = 10000 lux","lx","LX","1e-4",0.0001,false],[false,"Curie","Ci","CI","radioactivity",37000000000,[0,-1,0,0,0,0,0],"Ci","cgs",true,null,null,1,false,false,0,"curies","UCUM","","Obsolete","unit for measuring atomic disintegration rate; replaced by the Bequerel (Bq) unit","Bq","BQ","37e9",37000000000,false],[false,"Roentgen","R","ROE","ion dose",2.58e-7,[0,0,-1,0,0,1,0],"R","cgs",true,null,null,1,false,false,0,"röntgen; Roentgens","UCUM","","Clinical","unit of exposure of X-rays and gamma rays in air; unit used primarily in the US but strongly discouraged by NIST","C/kg","C/KG","2.58e-4",0.000258,false],[false,"radiation absorbed dose","RAD","[RAD]","energy dose",0.01,[2,-2,0,0,0,0,0],"RAD","cgs",true,null,null,1,false,false,0,"doses","UCUM","","Clinical","unit of radiation absorbed dose used primarily in the US with base units 100 ergs per gram of material. Also see the SI unit Gray (Gy).","erg/g","ERG/G","100",100,false],[false,"radiation equivalent man","REM","[REM]","dose equivalent",0.01,[2,-2,0,0,0,0,0],"REM","cgs",true,null,null,1,false,false,0,"Roentgen Equivalent in Man; rems; dose equivalents","UCUM","","Clinical","unit of equivalent dose which measures the effect of radiation on humans equal to 0.01 sievert. Used primarily in the US. Also see SI unit Sievert (Sv)","RAD","[RAD]","1",1,false],[false,"inch","[in_i]","[IN_I]","length",0.025400000000000002,[1,0,0,0,0,0,0],"in","intcust",false,null,null,1,false,false,0,"inches; in; international inch; body height","UCUM","Len","Clinical","standard unit for inch in the US and internationally","cm","CM","254e-2",2.54,false],[false,"foot","[ft_i]","[FT_I]","length",0.3048,[1,0,0,0,0,0,0],"ft","intcust",false,null,null,1,false,false,0,"ft; fts; foot; international foot; feet; international feet; height","UCUM","Len","Clinical","unit used in the US and internationally","[in_i]","[IN_I]","12",12,false],[false,"yard","[yd_i]","[YD_I]","length",0.9144000000000001,[1,0,0,0,0,0,0],"yd","intcust",false,null,null,1,false,false,0,"international yards; yds; distance","UCUM","Len","Clinical","standard unit used in the US and internationally","[ft_i]","[FT_I]","3",3,false],[false,"mile","[mi_i]","[MI_I]","length",1609.344,[1,0,0,0,0,0,0],"mi","intcust",false,null,null,1,false,false,0,"international miles; mi I; statute mile","UCUM","Len","Clinical","standard unit used in the US and internationally","[ft_i]","[FT_I]","5280",5280,false],[false,"fathom","[fth_i]","[FTH_I]","depth of water",1.8288000000000002,[1,0,0,0,0,0,0],"fth","intcust",false,null,null,1,false,false,0,"international fathoms","UCUM","Len","Nonclinical","unit used in the US and internationally to measure depth of water; same length as the US fathom","[ft_i]","[FT_I]","6",6,false],[false,"nautical mile","[nmi_i]","[NMI_I]","length",1852,[1,0,0,0,0,0,0],"n.mi","intcust",false,null,null,1,false,false,0,"nautical mile; nautical miles; international nautical mile; international nautical miles; nm; n.m.; nmi","UCUM","Len","Nonclinical","standard unit used in the US and internationally","m","M","1852",1852,false],[false,"knot","[kn_i]","[KN_I]","velocity",0.5144444444444445,[1,-1,0,0,0,0,0],"knot","intcust",false,null,null,1,false,false,0,"kn; kt; international knots","UCUM","Vel","Nonclinical","defined as equal to one nautical mile (1.852 km) per hour","[nmi_i]/h","[NMI_I]/H","1",1,false],[false,"square inch","[sin_i]","[SIN_I]","area",0.0006451600000000001,[2,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,"in2; in^2; inches squared; sq inch; inches squared; international","UCUM","Area","Clinical","standard unit used in the US and internationally","[in_i]2","[IN_I]2","1",1,false],[false,"square foot","[sft_i]","[SFT_I]","area",0.09290304,[2,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,"ft2; ft^2; ft squared; sq ft; feet; international","UCUM","Area","Clinical","standard unit used in the US and internationally","[ft_i]2","[FT_I]2","1",1,false],[false,"square yard","[syd_i]","[SYD_I]","area",0.8361273600000002,[2,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,"yd2; yd^2; sq. yds; yards squared; international","UCUM","Area","Clinical","standard unit used in the US and internationally","[yd_i]2","[YD_I]2","1",1,false],[false,"cubic inch","[cin_i]","[CIN_I]","volume",0.000016387064000000003,[3,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,"in3; in^3; in*3; inches^3; inches*3; cu. in; cu in; cubic inches; inches cubed; cin","UCUM","Vol","Clinical","standard unit used in the US and internationally","[in_i]3","[IN_I]3","1",1,false],[false,"cubic foot","[cft_i]","[CFT_I]","volume",0.028316846592000004,[3,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,"ft3; ft^3; ft*3; cu. ft; cubic feet; cubed; [ft_i]3; international","UCUM","Vol","Clinical","","[ft_i]3","[FT_I]3","1",1,false],[false,"cubic yard","[cyd_i]","[CYD_I]","volume",0.7645548579840002,[3,0,0,0,0,0,0],"cu.yd","intcust",false,null,null,1,false,false,0,"cubic yards; cubic yds; cu yards; CYs; yards^3; yd^3; yds^3; yd3; yds3","UCUM","Vol","Nonclinical","standard unit used in the US and internationally","[yd_i]3","[YD_I]3","1",1,false],[false,"board foot","[bf_i]","[BF_I]","volume",0.002359737216,[3,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,"BDFT; FBM; BF; board feet; international","UCUM","Vol","Nonclinical","unit of volume used to measure lumber","[in_i]3","[IN_I]3","144",144,false],[false,"cord","[cr_i]","[CR_I]","volume",3.6245563637760005,[3,0,0,0,0,0,0],null,"intcust",false,null,null,1,false,false,0,"crd I; international cords","UCUM","Vol","Nonclinical","unit of measure of dry volume used to measure firewood equal 128 ft3","[ft_i]3","[FT_I]3","128",128,false],[false,"mil","[mil_i]","[MIL_I]","length",0.000025400000000000004,[1,0,0,0,0,0,0],"mil","intcust",false,null,null,1,false,false,0,"thou, thousandth; mils; international","UCUM","Len","Clinical","equal to 0.001 international inch","[in_i]","[IN_I]","1e-3",0.001,false],[false,"circular mil","[cml_i]","[CML_I]","area",5.067074790974979e-10,[2,0,0,0,0,0,0],"circ.mil","intcust",false,null,null,1,false,false,0,"circular mils; cml I; international","UCUM","Area","Clinical","","[pi]/4.[mil_i]2","[PI]/4.[MIL_I]2","1",1,false],[false,"hand","[hd_i]","[HD_I]","height of horses",0.10160000000000001,[1,0,0,0,0,0,0],"hd","intcust",false,null,null,1,false,false,0,"hands; international","UCUM","Len","Nonclinical","used to measure horse height","[in_i]","[IN_I]","4",4,false],[false,"foot - US","[ft_us]","[FT_US]","length",0.3048006096012192,[1,0,0,0,0,0,0],"ft<sub>us</sub>","us-lengths",false,null,null,1,false,false,0,"US foot; foot US; us ft; ft us; height; visual distance; feet","UCUM","Len","Obsolete","Better to use [ft_i] which refers to the length used worldwide, including in the US;  [ft_us] may be confused with land survey units. ","m/3937","M/3937","1200",1200,false],[false,"yard - US","[yd_us]","[YD_US]","length",0.9144018288036575,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"US yards; us yds; distance","UCUM","Len; Nrat","Obsolete","Better to use [yd_i] which refers to the length used worldwide, including in the US; [yd_us] refers to unit used in land surveys in the US","[ft_us]","[FT_US]","3",3,false],[false,"inch - US","[in_us]","[IN_US]","length",0.0254000508001016,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"US inches; in us; us in; inch US","UCUM","Len","Obsolete","Better to use [in_i] which refers to the length used worldwide, including in the US","[ft_us]/12","[FT_US]/12","1",1,false],[false,"rod - US","[rd_us]","[RD_US]","length",5.029210058420117,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"US rod; US rods; rd US; US rd","UCUM","Len","Obsolete","","[ft_us]","[FT_US]","16.5",16.5,false],[false,"Gunter's chain - US","[ch_us]","[CH_US]","length",20.116840233680467,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"surveyor's chain; Surveyor's chain USA; Gunter’s measurement; surveyor’s measurement; Gunter's Chain USA","UCUM","Len","Obsolete","historical unit used for land survey used only in the US","[rd_us]","[RD_US]","4",4,false],[false,"link for Gunter's chain - US","[lk_us]","[LK_US]","length",0.20116840233680466,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"Links for Gunter's Chain USA","UCUM","Len","Obsolete","","[ch_us]/100","[CH_US]/100","1",1,false],[false,"Ramden's chain - US","[rch_us]","[RCH_US]","length",30.480060960121918,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"Ramsden's chain; engineer's chains","UCUM","Len","Obsolete","distance measuring device used for land survey","[ft_us]","[FT_US]","100",100,false],[false,"link for Ramden's chain - US","[rlk_us]","[RLK_US]","length",0.3048006096012192,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"links for Ramsden's chain","UCUM","Len","Obsolete","","[rch_us]/100","[RCH_US]/100","1",1,false],[false,"fathom - US","[fth_us]","[FTH_US]","length",1.828803657607315,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"US fathoms; fathom USA; fth us","UCUM","Len","Obsolete","same length as the international fathom - better to use international fathom ([fth_i])","[ft_us]","[FT_US]","6",6,false],[false,"furlong - US","[fur_us]","[FUR_US]","length",201.16840233680466,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"US furlongs; fur us","UCUM","Len","Nonclinical","distance unit in horse racing","[rd_us]","[RD_US]","40",40,false],[false,"mile - US","[mi_us]","[MI_US]","length",1609.3472186944373,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"U.S. Survey Miles; US statute miles; survey mi; US mi; distance","UCUM","Len","Nonclinical","Better to use [mi_i] which refers to the length used worldwide, including in the US","[fur_us]","[FUR_US]","8",8,false],[false,"acre - US","[acr_us]","[ACR_US]","area",4046.872609874252,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"Acre USA Survey; Acre USA; survey acres","UCUM","Area","Nonclinical","an older unit based on pre 1959 US statute lengths that is still sometimes used in the US only for land survey purposes. ","[rd_us]2","[RD_US]2","160",160,false],[false,"square rod - US","[srd_us]","[SRD_US]","area",25.292953811714074,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"rod2; rod^2; sq. rod; rods squared","UCUM","Area","Nonclinical","Used only in the US to measure land area, based on US statute land survey length units","[rd_us]2","[RD_US]2","1",1,false],[false,"square mile - US","[smi_us]","[SMI_US]","area",2589998.470319521,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"mi2; mi^2; sq mi; miles squared","UCUM","Area","Nonclinical","historical unit used only in the US for land survey purposes (based on the US survey mile), not the internationally recognized [mi_i]","[mi_us]2","[MI_US]2","1",1,false],[false,"section","[sct]","[SCT]","area",2589998.470319521,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"sct; sections","UCUM","Area","Nonclinical","tract of land approximately equal to 1 mile square containing 640 acres","[mi_us]2","[MI_US]2","1",1,false],[false,"township","[twp]","[TWP]","area",93239944.93150276,[2,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"twp; townships","UCUM","Area","Nonclinical","land measurement equal to 6 mile square","[sct]","[SCT]","36",36,false],[false,"mil - US","[mil_us]","[MIL_US]","length",0.0000254000508001016,[1,0,0,0,0,0,0],null,"us-lengths",false,null,null,1,false,false,0,"thou, thousandth; mils","UCUM","Len","Obsolete","better to use [mil_i] which is based on the internationally recognized inch","[in_us]","[IN_US]","1e-3",0.001,false],[false,"inch - British","[in_br]","[IN_BR]","length",0.025399980000000003,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"imperial inches; imp in; br in; british inches","UCUM","Len","Obsolete","","cm","CM","2.539998",2.539998,false],[false,"foot - British","[ft_br]","[FT_BR]","length",0.30479976000000003,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"British Foot; Imperial Foot; feet; imp fts; br fts","UCUM","Len","Obsolete","","[in_br]","[IN_BR]","12",12,false],[false,"rod - British","[rd_br]","[RD_BR]","length",5.02919604,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"British rods; br rd","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","16.5",16.5,false],[false,"Gunter's chain - British","[ch_br]","[CH_BR]","length",20.11678416,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"Gunter's Chain British; Gunters Chain British; Surveyor's Chain British","UCUM","Len","Obsolete","historical unit used for land survey used only in Great Britain","[rd_br]","[RD_BR]","4",4,false],[false,"link for Gunter's chain - British","[lk_br]","[LK_BR]","length",0.2011678416,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"Links for Gunter's Chain British","UCUM","Len","Obsolete","","[ch_br]/100","[CH_BR]/100","1",1,false],[false,"fathom - British","[fth_br]","[FTH_BR]","length",1.82879856,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"British fathoms; imperial fathoms; br fth; imp fth","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","6",6,false],[false,"pace - British","[pc_br]","[PC_BR]","length",0.7619994000000001,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"British paces; br pc","UCUM","Len","Nonclinical","traditional unit of length equal to 152.4 centimeters, or 1.52 meter. ","[ft_br]","[FT_BR]","2.5",2.5,false],[false,"yard - British","[yd_br]","[YD_BR]","length",0.91439928,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"British yards; Br yds; distance","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","3",3,false],[false,"mile - British","[mi_br]","[MI_BR]","length",1609.3427328000002,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"imperial miles; British miles; English statute miles; imp mi, br mi","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","5280",5280,false],[false,"nautical mile - British","[nmi_br]","[NMI_BR]","length",1853.1825408000002,[1,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"British nautical miles; Imperial nautical miles; Admiralty miles; n.m. br; imp nm","UCUM","Len","Obsolete","","[ft_br]","[FT_BR]","6080",6080,false],[false,"knot - British","[kn_br]","[KN_BR]","velocity",0.5147729280000001,[1,-1,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"British knots; kn br; kt","UCUM","Vel","Obsolete","based on obsolete British nautical mile ","[nmi_br]/h","[NMI_BR]/H","1",1,false],[false,"acre","[acr_br]","[ACR_BR]","area",4046.850049400269,[2,0,0,0,0,0,0],null,"brit-length",false,null,null,1,false,false,0,"Imperial acres; British; a; ac; ar; acr","UCUM","Area","Nonclinical","the standard unit for acre used in the US and internationally","[yd_br]2","[YD_BR]2","4840",4840,false],[false,"gallon - US","[gal_us]","[GAL_US]","fluid volume",0.0037854117840000006,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"US gallons; US liquid gallon; gal us; Queen Anne's wine gallon","UCUM","Vol","Nonclinical","only gallon unit used in the US; [gal_us] is only used in some other countries in South American and Africa to measure gasoline volume","[in_i]3","[IN_I]3","231",231,false],[false,"barrel - US","[bbl_us]","[BBL_US]","fluid volume",0.158987294928,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"bbl","UCUM","Vol","Nonclinical","[bbl_us] is the standard unit for oil barrel, which is a unit only used in the US to measure the volume oil. ","[gal_us]","[GAL_US]","42",42,false],[false,"quart - US","[qt_us]","[QT_US]","fluid volume",0.0009463529460000001,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"US quarts; us qts","UCUM","Vol","Clinical","Used only in the US","[gal_us]/4","[GAL_US]/4","1",1,false],[false,"pint - US","[pt_us]","[PT_US]","fluid volume",0.00047317647300000007,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"US pints; pint US; liquid pint; pt us; us pt","UCUM","Vol","Clinical","Used only in the US","[qt_us]/2","[QT_US]/2","1",1,false],[false,"gill - US","[gil_us]","[GIL_US]","fluid volume",0.00011829411825000002,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"US gills; gil us","UCUM","Vol","Nonclinical","only used in the context of alcohol volume in the US","[pt_us]/4","[PT_US]/4","1",1,false],[false,"fluid ounce - US","[foz_us]","[FOZ_US]","fluid volume",0.000029573529562500005,[3,0,0,0,0,0,0],"oz fl","us-volumes",false,null,null,1,false,false,0,"US fluid ounces; fl ozs; FO; fl. oz.; foz us","UCUM","Vol","Clinical","unit used only in the US","[gil_us]/4","[GIL_US]/4","1",1,false],[false,"fluid dram - US","[fdr_us]","[FDR_US]","fluid volume",0.0000036966911953125006,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"US fluid drams; fdr us","UCUM","Vol","Nonclinical","equal to 1/8 US fluid ounce = 3.69 mL; used informally to mean small amount of liquor, especially Scotch whiskey","[foz_us]/8","[FOZ_US]/8","1",1,false],[false,"minim - US","[min_us]","[MIN_US]","fluid volume",6.1611519921875e-8,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"min US; US min; ♏ US","UCUM","Vol","Obsolete","","[fdr_us]/60","[FDR_US]/60","1",1,false],[false,"cord - US","[crd_us]","[CRD_US]","fluid volume",3.6245563637760005,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"US cord; US cords; crd us; us crd","UCUM","Vol","Nonclinical","unit of measure of dry volume used to measure firewood equal 128 ft3 (the same as international cord [cr_i])","[ft_i]3","[FT_I]3","128",128,false],[false,"bushel - US","[bu_us]","[BU_US]","dry volume",0.03523907016688001,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"US bushels; US bsh; US bu","UCUM","Vol","Obsolete","Historical unit of dry volume that is rarely used today","[in_i]3","[IN_I]3","2150.42",2150.42,false],[false,"gallon - historical","[gal_wi]","[GAL_WI]","dry volume",0.004404883770860001,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"Corn Gallon British; Dry Gallon US; Gallons Historical; Grain Gallon British; Winchester Corn Gallon; historical winchester gallons; wi gal","UCUM","Vol","Obsolete","historical unit of dry volume no longer used","[bu_us]/8","[BU_US]/8","1",1,false],[false,"peck - US","[pk_us]","[PK_US]","dry volume",0.008809767541720002,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"US pecks; US pk","UCUM","Vol","Nonclinical","unit of dry volume rarely used today (can be used to measure volume of apples)","[bu_us]/4","[BU_US]/4","1",1,false],[false,"dry quart - US","[dqt_us]","[DQT_US]","dry volume",0.0011012209427150002,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"dry quarts; dry quart US; US dry quart; dry qt; us dry qt; dqt; dqt us","UCUM","Vol","Nonclinical","historical unit of dry volume only in the US, but is rarely used today","[pk_us]/8","[PK_US]/8","1",1,false],[false,"dry pint - US","[dpt_us]","[DPT_US]","dry volume",0.0005506104713575001,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"dry pints; dry pint US; US dry pint; dry pt; dpt; dpt us","UCUM","Vol","Nonclinical","historical unit of dry volume only in the US, but is rarely used today","[dqt_us]/2","[DQT_US]/2","1",1,false],[false,"tablespoon - US","[tbs_us]","[TBS_US]","volume",0.000014786764781250002,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"Tbs; tbsp; tbs us; US tablespoons","UCUM","Vol","Clinical","unit defined as 0.5 US fluid ounces or 3 teaspoons - used only in the US. See [tbs_m] for the unit used internationally and in the US for nutrional labelling. ","[foz_us]/2","[FOZ_US]/2","1",1,false],[false,"teaspoon - US","[tsp_us]","[TSP_US]","volume",0.0000049289215937500005,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"tsp; t; US teaspoons","UCUM","Vol","Nonclinical","unit defined as 1/6 US fluid ounces - used only in the US. See [tsp_m] for the unit used internationally and in the US for nutrional labelling. ","[tbs_us]/3","[TBS_US]/3","1",1,false],[false,"cup - US customary","[cup_us]","[CUP_US]","volume",0.00023658823650000004,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"cup us; us cups","UCUM","Vol","Nonclinical","Unit defined as 1/2 US pint or 16 US tablespoons ≈ 236.59 mL, which is not the standard unit defined by the FDA of 240 mL - see [cup_m] (metric cup)","[tbs_us]","[TBS_US]","16",16,false],[false,"fluid ounce - metric","[foz_m]","[FOZ_M]","fluid volume",0.000029999999999999997,[3,0,0,0,0,0,0],"oz fl","us-volumes",false,null,null,1,false,false,0,"metric fluid ounces; fozs m; fl ozs m","UCUM","Vol","Clinical","unit used only in the US for nutritional labelling, as set by the FDA","mL","ML","30",30,false],[false,"cup - US legal","[cup_m]","[CUP_M]","volume",0.00023999999999999998,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"cup m; metric cups","UCUM","Vol","Clinical","standard unit equal to 240 mL used in the US for nutritional labelling, as defined by the FDA. Note that this is different from the US customary cup (236.59 mL) and the metric cup used in Commonwealth nations (250 mL).","mL","ML","240",240,false],[false,"teaspoon - metric","[tsp_m]","[TSP_M]","volume",0.0000049999999999999996,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"tsp; t; metric teaspoons","UCUM","Vol","Clinical","standard unit used in the US and internationally","mL","mL","5",5,false],[false,"tablespoon - metric","[tbs_m]","[TBS_M]","volume",0.000014999999999999999,[3,0,0,0,0,0,0],null,"us-volumes",false,null,null,1,false,false,0,"metric tablespoons; Tbs; tbsp; T; tbs m","UCUM","Vol","Clinical","standard unit used in the US and internationally","mL","mL","15",15,false],[false,"gallon- British","[gal_br]","[GAL_BR]","volume",0.004546090000000001,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"imperial gallons, UK gallons; British gallons; br gal; imp gal","UCUM","Vol","Nonclinical","Used only in Great Britain and other Commonwealth countries","l","L","4.54609",4.54609,false],[false,"peck - British","[pk_br]","[PK_BR]","volume",0.009092180000000002,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"imperial pecks; British pecks; br pk; imp pk","UCUM","Vol","Nonclinical","unit of dry volume rarely used today (can be used to measure volume of apples)","[gal_br]","[GAL_BR]","2",2,false],[false,"bushel - British","[bu_br]","[BU_BR]","volume",0.03636872000000001,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"British bushels; imperial; br bsh; br bu; imp","UCUM","Vol","Obsolete","Historical unit of dry volume that is rarely used today","[pk_br]","[PK_BR]","4",4,false],[false,"quart - British","[qt_br]","[QT_BR]","volume",0.0011365225000000002,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"British quarts; imperial quarts; br qts","UCUM","Vol","Clinical","Used only in Great Britain and other Commonwealth countries","[gal_br]/4","[GAL_BR]/4","1",1,false],[false,"pint - British","[pt_br]","[PT_BR]","volume",0.0005682612500000001,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"British pints; imperial pints; pt br; br pt; imp pt; pt imp","UCUM","Vol","Clinical","Used only in Great Britain and other Commonwealth countries","[qt_br]/2","[QT_BR]/2","1",1,false],[false,"gill - British","[gil_br]","[GIL_BR]","volume",0.00014206531250000003,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"imperial gills; British gills; imp gill, br gill","UCUM","Vol","Nonclinical","only used in the context of alcohol volume in Great Britain","[pt_br]/4","[PT_BR]/4","1",1,false],[false,"fluid ounce - British","[foz_br]","[FOZ_BR]","volume",0.000028413062500000005,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"British fluid ounces; Imperial fluid ounces; br fozs; imp fozs; br fl ozs","UCUM","Vol","Clinical","Used only in Great Britain and other Commonwealth countries","[gil_br]/5","[GIL_BR]/5","1",1,false],[false,"fluid dram - British","[fdr_br]","[FDR_BR]","volume",0.0000035516328125000006,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"British fluid drams; fdr br","UCUM","Vol","Nonclinical","equal to 1/8 Imperial fluid ounce = 3.55 mL; used informally to mean small amount of liquor, especially Scotch whiskey","[foz_br]/8","[FOZ_BR]/8","1",1,false],[false,"minim - British","[min_br]","[MIN_BR]","volume",5.919388020833334e-8,[3,0,0,0,0,0,0],null,"brit-volumes",false,null,null,1,false,false,0,"min br; br min; ♏ br","UCUM","Vol","Obsolete","","[fdr_br]/60","[FDR_BR]/60","1",1,false],[false,"grain","[gr]","[GR]","mass",0.06479891,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,"gr; grains","UCUM","Mass","Nonclinical","an apothecary measure of mass rarely used today","mg","MG","64.79891",64.79891,false],[false,"pound","[lb_av]","[LB_AV]","mass",453.59237,[0,0,1,0,0,0,0],"lb","avoirdupois",false,null,null,1,false,false,0,"avoirdupois pounds, international pounds; av lbs; pounds","UCUM","Mass","Clinical","standard unit used in the US and internationally","[gr]","[GR]","7000",7000,false],[false,"pound force - US","[lbf_av]","[LBF_AV]","force",4448.2216152605,[1,-2,1,0,0,0,0],"lbf","const",false,null,null,1,false,false,0,"lbfs; US lbf; US pound forces","UCUM","Force","Clinical","only rarely needed in health care - see [lb_av] which is the more common unit to express weight","[lb_av].[g]","[LB_AV].[G]","1",1,false],[false,"ounce","[oz_av]","[OZ_AV]","mass",28.349523125,[0,0,1,0,0,0,0],"oz","avoirdupois",false,null,null,1,false,false,0,"ounces; international ounces; avoirdupois ounces; av ozs","UCUM","Mass","Clinical","standard unit used in the US and internationally","[lb_av]/16","[LB_AV]/16","1",1,false],[false,"Dram mass unit","[dr_av]","[DR_AV]","mass",1.7718451953125,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,"Dram; drams avoirdupois; avoidupois dram; international dram","UCUM","Mass","Clinical","unit from the avoirdupois system, which is used in the US and internationally","[oz_av]/16","[OZ_AV]/16","1",1,false],[false,"short hundredweight","[scwt_av]","[SCWT_AV]","mass",45359.237,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,"hundredweights; s cwt; scwt; avoirdupois","UCUM","Mass","Nonclinical","Used only in the US to equal 100 pounds","[lb_av]","[LB_AV]","100",100,false],[false,"long hundredweight","[lcwt_av]","[LCWT_AV]","mass",50802.345440000005,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,"imperial hundredweights; imp cwt; lcwt; avoirdupois","UCUM","Mass","Obsolete","","[lb_av]","[LB_AV]","112",112,false],[false,"short ton - US","[ston_av]","[STON_AV]","mass",907184.74,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,"ton; US tons; avoirdupois tons","UCUM","Mass","Clinical","Used only in the US","[scwt_av]","[SCWT_AV]","20",20,false],[false,"long ton - British","[lton_av]","[LTON_AV]","mass",1016046.9088000001,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,"imperial tons; weight tons; British long tons; long ton avoirdupois","UCUM","Mass","Nonclinical","Used only in Great Britain and other Commonwealth countries","[lcwt_av]","[LCWT_AV]","20",20,false],[false,"stone - British","[stone_av]","[STONE_AV]","mass",6350.293180000001,[0,0,1,0,0,0,0],null,"avoirdupois",false,null,null,1,false,false,0,"British stones; avoirdupois","UCUM","Mass","Nonclinical","Used primarily in the UK and Ireland to measure body weight","[lb_av]","[LB_AV]","14",14,false],[false,"pennyweight - troy","[pwt_tr]","[PWT_TR]","mass",1.5551738400000001,[0,0,1,0,0,0,0],null,"troy",false,null,null,1,false,false,0,"dwt; denarius weights","UCUM","Mass","Obsolete","historical unit used to measure mass and cost of precious metals","[gr]","[GR]","24",24,false],[false,"ounce - troy","[oz_tr]","[OZ_TR]","mass",31.103476800000003,[0,0,1,0,0,0,0],null,"troy",false,null,null,1,false,false,0,"troy ounces; tr ozs","UCUM","Mass","Nonclinical","unit of mass for precious metals and gemstones only","[pwt_tr]","[PWT_TR]","20",20,false],[false,"pound - troy","[lb_tr]","[LB_TR]","mass",373.2417216,[0,0,1,0,0,0,0],null,"troy",false,null,null,1,false,false,0,"troy pounds; tr lbs","UCUM","Mass","Nonclinical","only used for weighing precious metals","[oz_tr]","[OZ_TR]","12",12,false],[false,"scruple","[sc_ap]","[SC_AP]","mass",1.2959782,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,"scruples; sc ap","UCUM","Mass","Obsolete","","[gr]","[GR]","20",20,false],[false,"dram - apothecary","[dr_ap]","[DR_AP]","mass",3.8879346,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,"ʒ; drachm; apothecaries drams; dr ap; dram ap","UCUM","Mass","Nonclinical","unit still used in the US occasionally to measure amount of drugs in pharmacies","[sc_ap]","[SC_AP]","3",3,false],[false,"ounce - apothecary","[oz_ap]","[OZ_AP]","mass",31.1034768,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,"apothecary ounces; oz ap; ap ozs; ozs ap","UCUM","Mass","Obsolete","","[dr_ap]","[DR_AP]","8",8,false],[false,"pound - apothecary","[lb_ap]","[LB_AP]","mass",373.2417216,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,"apothecary pounds; apothecaries pounds; ap lb; lb ap; ap lbs; lbs ap","UCUM","Mass","Obsolete","","[oz_ap]","[OZ_AP]","12",12,false],[false,"ounce - metric","[oz_m]","[OZ_M]","mass",28,[0,0,1,0,0,0,0],null,"apoth",false,null,null,1,false,false,0,"metric ounces; m ozs","UCUM","Mass","Clinical","see [oz_av] (the avoirdupois ounce) for the standard ounce used internationally; [oz_m] is equal to 28 grams and is based on the apothecaries' system of mass units which is used in some US pharmacies. ","g","g","28",28,false],[false,"line","[lne]","[LNE]","length",0.002116666666666667,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"British lines; br L; L; l","UCUM","Len","Obsolete","","[in_i]/12","[IN_I]/12","1",1,false],[false,"point (typography)","[pnt]","[PNT]","length",0.0003527777777777778,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"DTP points; desktop publishing point; pt; pnt","UCUM","Len","Nonclinical","typography unit for typesetter's length","[lne]/6","[LNE]/6","1",1,false],[false,"pica (typography)","[pca]","[PCA]","length",0.004233333333333334,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"picas","UCUM","Len","Nonclinical","typography unit for typesetter's length","[pnt]","[PNT]","12",12,false],[false,"Printer's point (typography)","[pnt_pr]","[PNT_PR]","length",0.00035145980000000004,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"pnt pr","UCUM","Len","Nonclinical","typography unit for typesetter's length","[in_i]","[IN_I]","0.013837",0.013837,false],[false,"Printer's pica  (typography)","[pca_pr]","[PCA_PR]","length",0.004217517600000001,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"pca pr; Printer's picas","UCUM","Len","Nonclinical","typography unit for typesetter's length","[pnt_pr]","[PNT_PR]","12",12,false],[false,"pied","[pied]","[PIED]","length",0.3248,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"pieds du roi; Paris foot; royal; French; feet","UCUM","Len","Obsolete","","cm","CM","32.48",32.48,false],[false,"pouce","[pouce]","[POUCE]","length",0.027066666666666666,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"historical French inches; French royal inches","UCUM","Len","Obsolete","","[pied]/12","[PIED]/12","1",1,false],[false,"ligne","[ligne]","[LIGNE]","length",0.0022555555555555554,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"Paris lines; lignes","UCUM","Len","Obsolete","","[pouce]/12","[POUCE]/12","1",1,false],[false,"didot","[didot]","[DIDOT]","length",0.0003759259259259259,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"Didot point; dd; Didots Point; didots; points","UCUM","Len","Obsolete","typography unit for typesetter's length","[ligne]/6","[LIGNE]/6","1",1,false],[false,"cicero","[cicero]","[CICERO]","length",0.004511111111111111,[1,0,0,0,0,0,0],null,"typeset",false,null,null,1,false,false,0,"Didot's pica; ciceros; picas","UCUM","Len","Obsolete","typography unit for typesetter's length","[didot]","[DIDOT]","12",12,false],[false,"degrees Fahrenheit","[degF]","[DEGF]","temperature",0.5555555555555556,[0,0,0,0,1,0,0],"°F","heat",false,null,"degF",1,true,false,0,"°F; deg F","UCUM","Temp","Clinical","","K",null,null,0.5555555555555556,false],[false,"degrees Rankine","[degR]","[degR]","temperature",0.5555555555555556,[0,0,0,0,1,0,0],"°R","heat",false,null,null,1,false,false,0,"°R; °Ra; Rankine","UCUM","Temp","Obsolete","Replaced by Kelvin","K/9","K/9","5",5,false],[false,"degrees Réaumur","[degRe]","[degRe]","temperature",1.25,[0,0,0,0,1,0,0],"°Ré","heat",false,null,"degRe",1,true,false,0,"°Ré, °Re, °r; Réaumur; degree Reaumur; Reaumur","UCUM","Temp","Obsolete","replaced by Celsius","K",null,null,1.25,false],[false,"calorie at 15°C","cal_[15]","CAL_[15]","energy",4185.8,[2,-2,1,0,0,0,0],"cal<sub>15°C</sub>","heat",true,null,null,1,false,false,0,"calorie 15 C; cals 15 C; calories at 15 C","UCUM","Enrg","Nonclinical","equal to 4.1855 joules; calorie most often used in engineering","J","J","4.18580",4.1858,false],[false,"calorie at 20°C","cal_[20]","CAL_[20]","energy",4181.9,[2,-2,1,0,0,0,0],"cal<sub>20°C</sub>","heat",true,null,null,1,false,false,0,"calorie 20 C; cal 20 C; calories at 20 C","UCUM","Enrg","Clinical","equal to 4.18190  joules. ","J","J","4.18190",4.1819,false],[false,"mean calorie","cal_m","CAL_M","energy",4190.0199999999995,[2,-2,1,0,0,0,0],"cal<sub>m</sub>","heat",true,null,null,1,false,false,0,"mean cals; mean calories","UCUM","Enrg","Clinical","equal to 4.19002 joules. ","J","J","4.19002",4.19002,false],[false,"international table calorie","cal_IT","CAL_IT","energy",4186.8,[2,-2,1,0,0,0,0],"cal<sub>IT</sub>","heat",true,null,null,1,false,false,0,"calories IT; IT cals; international steam table calories","UCUM","Enrg","Nonclinical","used in engineering steam tables and defined as 1/860 international watt-hour; equal to 4.1868 joules","J","J","4.1868",4.1868,false],[false,"thermochemical calorie","cal_th","CAL_TH","energy",4184,[2,-2,1,0,0,0,0],"cal<sub>th</sub>","heat",true,null,null,1,false,false,0,"thermochemical calories; th cals","UCUM","Enrg","Clinical","equal to 4.184 joules; used as the unit in medicine and biochemistry (equal to cal)","J","J","4.184",4.184,false],[false,"calorie","cal","CAL","energy",4184,[2,-2,1,0,0,0,0],"cal","heat",true,null,null,1,false,false,0,"gram calories; small calories","UCUM","Enrg","Clinical","equal to 4.184 joules (the same value as the thermochemical calorie, which is the most common calorie used in medicine and biochemistry)","cal_th","CAL_TH","1",1,false],[false,"nutrition label Calories","[Cal]","[CAL]","energy",4184000,[2,-2,1,0,0,0,0],"Cal","heat",false,null,null,1,false,false,0,"food calories; Cal; kcal","UCUM","Eng","Clinical","","kcal_th","KCAL_TH","1",1,false],[false,"British thermal unit at 39°F","[Btu_39]","[BTU_39]","energy",1059670,[2,-2,1,0,0,0,0],"Btu<sub>39°F</sub>","heat",false,null,null,1,false,false,0,"BTU 39F; BTU 39 F; B.T.U. 39 F; B.Th.U. 39 F; BThU 39 F; British thermal units","UCUM","Eng","Nonclinical","equal to 1.05967 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05967",1.05967,false],[false,"British thermal unit at 59°F","[Btu_59]","[BTU_59]","energy",1054800,[2,-2,1,0,0,0,0],"Btu<sub>59°F</sub>","heat",false,null,null,1,false,false,0,"BTU 59 F; BTU 59F; B.T.U. 59 F; B.Th.U. 59 F; BThU 59F; British thermal units","UCUM","Eng","Nonclinical","equal to  1.05480 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05480",1.0548,false],[false,"British thermal unit at 60°F","[Btu_60]","[BTU_60]","energy",1054680,[2,-2,1,0,0,0,0],"Btu<sub>60°F</sub>","heat",false,null,null,1,false,false,0,"BTU 60 F; BTU 60F; B.T.U. 60 F; B.Th.U. 60 F; BThU 60 F; British thermal units 60 F","UCUM","Eng","Nonclinical","equal to 1.05468 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05468",1.05468,false],[false,"mean British thermal unit","[Btu_m]","[BTU_M]","energy",1055870,[2,-2,1,0,0,0,0],"Btu<sub>m</sub>","heat",false,null,null,1,false,false,0,"BTU mean; B.T.U. mean; B.Th.U. mean; BThU mean; British thermal units mean; ","UCUM","Eng","Nonclinical","equal to 1.05587 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05587",1.05587,false],[false,"international table British thermal unit","[Btu_IT]","[BTU_IT]","energy",1055055.85262,[2,-2,1,0,0,0,0],"Btu<sub>IT</sub>","heat",false,null,null,1,false,false,0,"BTU IT; B.T.U. IT; B.Th.U. IT; BThU IT; British thermal units IT","UCUM","Eng","Nonclinical","equal to 1.055 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.05505585262",1.05505585262,false],[false,"thermochemical British thermal unit","[Btu_th]","[BTU_TH]","energy",1054350,[2,-2,1,0,0,0,0],"Btu<sub>th</sub>","heat",false,null,null,1,false,false,0,"BTU Th; B.T.U. Th; B.Th.U. Th; BThU Th; thermochemical British thermal units","UCUM","Eng","Nonclinical","equal to 1.054350 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","kJ","kJ","1.054350",1.05435,false],[false,"British thermal unit","[Btu]","[BTU]","energy",1054350,[2,-2,1,0,0,0,0],"btu","heat",false,null,null,1,false,false,0,"BTU; B.T.U. ; B.Th.U.; BThU; British thermal units","UCUM","Eng","Nonclinical","equal to the thermochemical British thermal unit equal to 1.054350 kJ; used as a measure of power in the electric power, steam generation, heating, and air conditioning industries","[Btu_th]","[BTU_TH]","1",1,false],[false,"horsepower - mechanical","[HP]","[HP]","power",745699.8715822703,[2,-3,1,0,0,0,0],null,"heat",false,null,null,1,false,false,0,"imperial horsepowers","UCUM","EngRat","Nonclinical","refers to mechanical horsepower, which is unit used to measure engine power primarily in the US. ","[ft_i].[lbf_av]/s","[FT_I].[LBF_AV]/S","550",550,false],[false,"tex","tex","TEX","linear mass density (of textile thread)",0.001,[-1,0,1,0,0,0,0],"tex","heat",true,null,null,1,false,false,0,"linear mass density; texes","UCUM","","Clinical","unit of linear mass density for fibers equal to gram per 1000 meters","g/km","G/KM","1",1,false],[false,"Denier (linear mass density)","[den]","[DEN]","linear mass density (of textile thread)",0.0001111111111111111,[-1,0,1,0,0,0,0],"den","heat",false,null,null,1,false,false,0,"den; deniers","UCUM","","Nonclinical","equal to the mass in grams per 9000 meters of the fiber (1 denier = 1 strand of silk)","g/9/km","G/9/KM","1",1,false],[false,"meter of water column","m[H2O]","M[H2O]","pressure",9806650,[-1,-2,1,0,0,0,0],"m HO<sub><r>2</r></sub>","clinical",true,null,null,1,false,false,0,"mH2O; m H2O; meters of water column; metres; pressure","UCUM","Pres","Clinical","","kPa","KPAL","980665e-5",9.80665,false],[false,"meter of mercury column","m[Hg]","M[HG]","pressure",133322000,[-1,-2,1,0,0,0,0],"m Hg","clinical",true,null,null,1,false,false,0,"mHg; m Hg; meters of mercury column; metres; pressure","UCUM","Pres","Clinical","","kPa","KPAL","133.3220",133.322,false],[false,"inch of water column","[in_i'H2O]","[IN_I'H2O]","pressure",249088.91000000003,[-1,-2,1,0,0,0,0],"in HO<sub><r>2</r></sub>","clinical",false,null,null,1,false,false,0,"inches WC; inAq; in H2O; inch of water gauge; iwg; pressure","UCUM","Pres","Clinical","unit of pressure, especially in respiratory and ventilation care","m[H2O].[in_i]/m","M[H2O].[IN_I]/M","1",1,false],[false,"inch of mercury column","[in_i'Hg]","[IN_I'HG]","pressure",3386378.8000000003,[-1,-2,1,0,0,0,0],"in Hg","clinical",false,null,null,1,false,false,0,"inHg; in Hg; pressure; inches","UCUM","Pres","Clinical","unit of pressure used in US to measure barometric pressure and occasionally blood pressure (see mm[Hg] for unit used internationally)","m[Hg].[in_i]/m","M[HG].[IN_I]/M","1",1,false],[false,"peripheral vascular resistance unit","[PRU]","[PRU]","fluid resistance",133322000000,[-4,-1,1,0,0,0,0],"P.R.U.","clinical",false,null,null,1,false,false,0,"peripheral vascular resistance units; peripheral resistance unit; peripheral resistance units; PRU","UCUM","FldResist","Clinical","used to assess blood flow in the capillaries; equal to 1 mmH.min/mL = 133.3 Pa·min/mL","mm[Hg].s/ml","MM[HG].S/ML","1",1,false],[false,"Wood unit","[wood'U]","[WOOD'U]","fluid resistance",7999320000,[-4,-1,1,0,0,0,0],"Wood U.","clinical",false,null,null,1,false,false,0,"hybrid reference units; HRU; mmHg.min/L; vascular resistance","UCUM","Pres","Clinical","simplified unit of measurement for for measuring pulmonary vascular resistance that uses pressure; equal to mmHg.min/L","mm[Hg].min/L","MM[HG].MIN/L","1",1,false],[false,"diopter (lens)","[diop]","[DIOP]","refraction of a lens",1,[1,0,0,0,0,0,0],"dpt","clinical",false,null,"inv",1,false,false,0,"diopters; diop; dioptre; dpt; refractive power","UCUM","InvLen","Clinical","unit of optical power of lens represented by inverse meters (m^-1)","m","/M","1",1,false],[false,"prism diopter (magnifying power)","[p'diop]","[P'DIOP]","refraction of a prism",1,[0,0,0,1,0,0,0],"PD","clinical",false,null,"tanTimes100",1,true,false,0,"diopters; dioptres; p diops; pdiop; dpt; pdptr; Δ; cm/m; centimeter per meter; centimetre; metre","UCUM","Angle","Clinical","unit for prism correction in eyeglass prescriptions","rad",null,null,1,false],[false,"percent of slope","%[slope]","%[SLOPE]","slope",0.017453292519943295,[0,0,0,1,0,0,0],"%","clinical",false,null,"100tan",1,true,false,0,"% slope; %slope; percents slopes","UCUM","VelFr; ElpotRatFr; VelRtoFr; AccelFr","Clinical","","deg",null,null,1,false],[false,"mesh","[mesh_i]","[MESH_I]","lineic number",0.025400000000000002,[1,0,0,0,0,0,0],null,"clinical",false,null,"inv",1,false,false,0,"meshes","UCUM","NLen (lineic number)","Clinical","traditional unit of length defined as the number of strands or particles per inch","[in_i]","/[IN_I]","1",1,false],[false,"French (catheter gauge) ","[Ch]","[CH]","gauge of catheters",0.0003333333333333333,[1,0,0,0,0,0,0],"Ch","clinical",false,null,null,1,false,false,0,"Charrières, French scales; French gauges; Fr, Fg, Ga, FR, Ch","UCUM","Len; Circ; Diam","Clinical","","mm/3","MM/3","1",1,false],[false,"drop - metric (1/20 mL)","[drp]","[DRP]","volume",5e-8,[3,0,0,0,0,0,0],"drp","clinical",false,null,null,1,false,false,0,"drop dosing units; metric drops; gtt","UCUM","Vol","Clinical","standard unit used in the US and internationally for clinical medicine but note that although [drp] is defined as 1/20 milliliter, in practice, drop sizes will vary due to external factors","ml/20","ML/20","1",1,false],[false,"Hounsfield unit","[hnsf'U]","[HNSF'U]","x-ray attenuation",1,[0,0,0,0,0,0,0],"HF","clinical",false,null,null,1,false,false,0,"HU; units","UCUM","","Clinical","used to measure X-ray attenuation, especially in CT scans.","1","1","1",1,false],[false,"Metabolic Equivalent of Task ","[MET]","[MET]","metabolic cost of physical activity",5.833333333333334e-11,[3,-1,-1,0,0,0,0],"MET","clinical",false,null,null,1,false,false,0,"metabolic equivalents","UCUM","RelEngRat","Clinical","unit used to measure rate of energy expenditure per power in treadmill and other functional tests","mL/min/kg","ML/MIN/KG","3.5",3.5,false],[false,"homeopathic potency of decimal series (retired)","[hp'_X]","[HP'_X]","homeopathic potency (retired)",1,[0,0,0,0,0,0,0],"X","clinical",false,null,"hpX",1,true,false,0,null,"UCUM",null,null,null,"1",null,null,1,false],[false,"homeopathic potency of centesimal series (retired)","[hp'_C]","[HP'_C]","homeopathic potency (retired)",1,[0,0,0,0,0,0,0],"C","clinical",false,null,"hpC",1,true,false,0,null,"UCUM",null,null,null,"1",null,null,1,false],[false,"homeopathic potency of millesimal series (retired)","[hp'_M]","[HP'_M]","homeopathic potency (retired)",1,[0,0,0,0,0,0,0],"M","clinical",false,null,"hpM",1,true,false,0,null,"UCUM",null,null,null,"1",null,null,1,false],[false,"homeopathic potency of quintamillesimal series (retired)","[hp'_Q]","[HP'_Q]","homeopathic potency (retired)",1,[0,0,0,0,0,0,0],"Q","clinical",false,null,"hpQ",1,true,false,0,null,"UCUM",null,null,null,"1",null,null,1,false],[false,"homeopathic potency of decimal hahnemannian series","[hp_X]","[HP_X]","homeopathic potency (Hahnemann)",1,[0,0,0,0,0,0,0],"X","clinical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of centesimal hahnemannian series","[hp_C]","[HP_C]","homeopathic potency (Hahnemann)",1,[0,0,0,0,0,0,0],"C","clinical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of millesimal hahnemannian series","[hp_M]","[HP_M]","homeopathic potency (Hahnemann)",1,[0,0,0,0,0,0,0],"M","clinical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of quintamillesimal hahnemannian series","[hp_Q]","[HP_Q]","homeopathic potency (Hahnemann)",1,[0,0,0,0,0,0,0],"Q","clinical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of decimal korsakovian series","[kp_X]","[KP_X]","homeopathic potency (Korsakov)",1,[0,0,0,0,0,0,0],"X","clinical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of centesimal korsakovian series","[kp_C]","[KP_C]","homeopathic potency (Korsakov)",1,[0,0,0,0,0,0,0],"C","clinical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of millesimal korsakovian series","[kp_M]","[KP_M]","homeopathic potency (Korsakov)",1,[0,0,0,0,0,0,0],"M","clinical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"homeopathic potency of quintamillesimal korsakovian series","[kp_Q]","[KP_Q]","homeopathic potency (Korsakov)",1,[0,0,0,0,0,0,0],"Q","clinical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"equivalent","eq","EQ","amount of substance",6.0221367e+23,[0,0,0,0,0,0,0],"eq","chemical",true,null,null,1,false,false,1,"equivalents","UCUM","Sub","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"osmole","osm","OSM","amount of substance (dissolved particles)",6.0221367e+23,[0,0,0,0,0,0,0],"osm","chemical",true,null,null,1,false,false,1,"osmoles; osmols","UCUM","Osmol","Clinical","the number of moles of solute that contribute to the osmotic pressure of a solution","mol","MOL","1",1,false],[false,"pH","[pH]","[PH]","acidity",6.0221366999999994e+26,[-3,0,0,0,0,0,0],"pH","chemical",false,null,"pH",1,true,false,0,"pH scale","UCUM","LogCnc","Clinical","Log concentration of H+","mol/l",null,null,1,false],[false,"gram percent","g%","G%","mass concentration",10000,[-3,0,1,0,0,0,0],"g%","chemical",true,null,null,1,false,false,0,"gram %; gram%; grams per deciliter; g/dL; gm per dL; gram percents","UCUM","MCnc","Clinical","equivalent to unit gram per deciliter (g/dL), a unit often used in medical tests to represent solution concentrations","g/dl","G/DL","1",1,false],[false,"Svedberg unit","[S]","[S]","sedimentation coefficient",1e-13,[0,1,0,0,0,0,0],"S","chemical",false,null,null,1,false,false,0,"Sv; 10^-13 seconds; 100 fs; 100 femtoseconds","UCUM","Time","Clinical","unit of time used in measuring particle's sedimentation rate, usually after centrifugation. ","s","10*-13.S","1",1e-13,false],[false,"high power field (microscope)","[HPF]","[HPF]","view area in microscope",1,[0,0,0,0,0,0,0],"HPF","chemical",false,null,null,1,false,false,0,"HPF","UCUM","Area","Clinical","area visible under the maximum magnification power of the objective in microscopy (usually 400x)\n","1","1","1",1,false],[false,"low power field (microscope)","[LPF]","[LPF]","view area in microscope",1,[0,0,0,0,0,0,0],"LPF","chemical",false,null,null,1,false,false,0,"LPF; fields","UCUM","Area","Clinical","area visible under the low magnification of the objective in microscopy (usually 100 x)\n","1","1","100",100,false],[false,"katal","kat","KAT","catalytic activity",6.0221367e+23,[0,-1,0,0,0,0,0],"kat","chemical",true,null,null,1,false,false,1,"mol/secs; moles per second; mol*sec-1; mol*s-1; mol.s-1; katals; catalytic activity; enzymatic; enzyme units; activities","UCUM","CAct","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"enzyme unit","U","U","catalytic activity",10036894500000000,[0,-1,0,0,0,0,0],"U","chemical",true,null,null,1,false,false,1,"micromoles per minute; umol/min; umol per minute; umol min-1; enzymatic activity; enzyme activity","UCUM","CAct","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"international unit - arbitrary","[iU]","[IU]","arbitrary",1,[0,0,0,0,0,0,0],"IU","chemical",true,null,null,1,false,true,0,"international units; IE; F2","UCUM","Arb","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","1","1","1",1,false],[false,"international unit - arbitrary","[IU]","[IU]","arbitrary",1,[0,0,0,0,0,0,0],"i.U.","chemical",true,null,null,1,false,true,0,"international units; IE; F2","UCUM","Arb","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"arbitary unit","[arb'U]","[ARB'U]","arbitrary",1,[0,0,0,0,0,0,0],"arb. U","chemical",false,null,null,1,false,true,0,"arbitary units; arb units; arbU","UCUM","Arb","Clinical","relative unit of measurement to show the ratio of test measurement to reference measurement","1","1","1",1,false],[false,"United States Pharmacopeia unit","[USP'U]","[USP'U]","arbitrary",1,[0,0,0,0,0,0,0],"U.S.P.","chemical",false,null,null,1,false,true,0,"USP U; USP'U","UCUM","Arb","Clinical","a dose unit to express potency of drugs and vitamins defined by the United States Pharmacopoeia; usually 1 USP = 1 IU","1","1","1",1,false],[false,"GPL unit","[GPL'U]","[GPL'U]","biologic activity of anticardiolipin IgG",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"GPL Units; GPL U; IgG anticardiolipin units; IgG Phospholipid","UCUM","ACnc; AMass","Clinical","Units for an antiphospholipid test","1","1","1",1,false],[false,"MPL unit","[MPL'U]","[MPL'U]","biologic activity of anticardiolipin IgM",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"MPL units; MPL U; MPL'U; IgM anticardiolipin units; IgM Phospholipid Units ","UCUM","ACnc","Clinical","units for antiphospholipid test","1","1","1",1,false],[false,"APL unit","[APL'U]","[APL'U]","biologic activity of anticardiolipin IgA",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"APL units; APL U; IgA anticardiolipin; IgA Phospholipid; biologic activity of","UCUM","AMass; ACnc","Clinical","Units for an anti phospholipid syndrome test","1","1","1",1,false],[false,"Bethesda unit","[beth'U]","[BETH'U]","biologic activity of factor VIII inhibitor",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"BU","UCUM","ACnc","Clinical","measures of blood coagulation inhibitior for many blood factors","1","1","1",1,false],[false,"anti factor Xa unit","[anti'Xa'U]","[ANTI'XA'U]","biologic activity of factor Xa inhibitor (heparin)",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"units","UCUM","ACnc","Clinical","[anti'Xa'U] unit is equivalent to and can be converted to IU/mL. ","1","1","1",1,false],[false,"Todd unit","[todd'U]","[TODD'U]","biologic activity antistreptolysin O",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"units","UCUM","InvThres; RtoThres","Clinical","the unit for the results of the testing for antistreptolysin O (ASO)","1","1","1",1,false],[false,"Dye unit","[dye'U]","[DYE'U]","biologic activity of amylase",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"units","UCUM","CCnc","Obsolete","equivalent to the Somogyi unit, which is an enzyme unit for amylase but better to use U, the standard enzyme unit for measuring catalytic activity","1","1","1",1,false],[false,"Somogyi unit","[smgy'U]","[SMGY'U]","biologic activity of amylase",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"Somogyi units; smgy U","UCUM","CAct","Clinical","measures the enzymatic activity of amylase in blood serum - better to use base units mg/mL ","1","1","1",1,false],[false,"Bodansky unit","[bdsk'U]","[BDSK'U]","biologic activity of phosphatase",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"","UCUM","ACnc","Obsolete","Enzyme unit specific to alkaline phosphatase - better to use standard enzyme unit of U","1","1","1",1,false],[false,"King-Armstrong unit","[ka'U]","[KA'U]","biologic activity of phosphatase",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"King-Armstrong Units; King units","UCUM","AMass","Obsolete","enzyme units for acid phosphatase - better to use enzyme unit [U]","1","1","1",1,false],[false,"Kunkel unit","[knk'U]","[KNK'U]","arbitrary biologic activity",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,null,"UCUM",null,null,null,"1","1","1",1,false],[false,"Mac Lagan unit","[mclg'U]","[MCLG'U]","arbitrary biologic activity",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"galactose index; galactose tolerance test; thymol turbidity test unit; mclg U; units; indexes","UCUM","ACnc","Obsolete","unit for liver tests - previously used in thymol turbidity tests for liver disease diagnoses, and now is sometimes referred to in the oral galactose tolerance test","1","1","1",1,false],[false,"tuberculin unit","[tb'U]","[TB'U]","biologic activity of tuberculin",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"TU; units","UCUM","Arb","Clinical","amount of tuberculin antigen -usually in reference to a TB skin test ","1","1","1",1,false],[false,"50% cell culture infectious dose","[CCID_50]","[CCID_50]","biologic activity (infectivity) of an infectious agent preparation",1,[0,0,0,0,0,0,0],"CCID<sub>50</sub>","chemical",false,null,null,1,false,true,0,"CCID50; 50% cell culture infective doses","UCUM","NumThres","Clinical","","1","1","1",1,false],[false,"50% tissue culture infectious dose","[TCID_50]","[TCID_50]","biologic activity (infectivity) of an infectious agent preparation",1,[0,0,0,0,0,0,0],"TCID<sub>50</sub>","chemical",false,null,null,1,false,true,0,"TCID50; 50% tissue culture infective dose","UCUM","NumThres","Clinical","","1","1","1",1,false],[false,"50% embryo infectious dose","[EID_50]","[EID_50]","biologic activity (infectivity) of an infectious agent preparation",1,[0,0,0,0,0,0,0],"EID<sub>50</sub>","chemical",false,null,null,1,false,true,0,"EID50; 50% embryo infective doses; EID50 Egg Infective Dosage","UCUM","thresNum","Clinical","","1","1","1",1,false],[false,"plaque forming units","[PFU]","[PFU]","amount of an infectious agent",1,[0,0,0,0,0,0,0],"PFU","chemical",false,null,null,1,false,true,0,"PFU","UCUM","ACnc","Clinical","tests usually report unit as number of PFU per unit volume","1","1","1",1,false],[false,"focus forming units (cells)","[FFU]","[FFU]","amount of an infectious agent",1,[0,0,0,0,0,0,0],"FFU","chemical",false,null,null,1,false,true,0,"FFU","UCUM","EntNum","Clinical","","1","1","1",1,false],[false,"colony forming units","[CFU]","[CFU]","amount of a proliferating organism",1,[0,0,0,0,0,0,0],"CFU","chemical",false,null,null,1,false,true,0,"CFU","UCUM","Num","Clinical","","1","1","1",1,false],[false,"index of reactivity (allergen)","[IR]","[IR]","amount of an allergen callibrated through in-vivo testing using the Stallergenes® method.",1,[0,0,0,0,0,0,0],"IR","chemical",false,null,null,1,false,true,0,"IR; indexes","UCUM","Acnc","Clinical","amount of an allergen callibrated through in-vivo testing using the Stallergenes method. Usually reported in tests as IR/mL","1","1","1",1,false],[false,"bioequivalent allergen unit","[BAU]","[BAU]","amount of an allergen callibrated through in-vivo testing based on the ID50EAL method of (intradermal dilution for 50mm sum of erythema diameters",1,[0,0,0,0,0,0,0],"BAU","chemical",false,null,null,1,false,true,0,"BAU; Bioequivalent Allergy Units; bioequivalent allergen units","UCUM","Arb","Clinical","","1","1","1",1,false],[false,"allergy unit","[AU]","[AU]","procedure defined amount of an allergen using some reference standard",1,[0,0,0,0,0,0,0],"AU","chemical",false,null,null,1,false,true,0,"allergy units; allergen units; AU","UCUM","Arb","Clinical","Most standard test allergy units are reported as [IU] or as %. ","1","1","1",1,false],[false,"allergen unit for Ambrosia artemisiifolia","[Amb'a'1'U]","[AMB'A'1'U]","procedure defined amount of the major allergen of ragweed.",1,[0,0,0,0,0,0,0],"Amb a 1 U","chemical",false,null,null,1,false,true,0,"Amb a 1 unit; Antigen E; AgE U; allergen units","UCUM","Arb","Clinical","Amb a 1 is the major allergen in short ragweed, and can be converted Bioequivalent allergen units (BAU) where 350 Amb a 1 U/mL = 100,000 BAU/mL","1","1","1",1,false],[false,"protein nitrogen unit (allergen testing)","[PNU]","[PNU]","procedure defined amount of a protein substance",1,[0,0,0,0,0,0,0],"PNU","chemical",false,null,null,1,false,true,0,"protein nitrogen units; PNU","UCUM","Mass","Clinical","defined as 0.01 ug of phosphotungstic acid-precipitable protein nitrogen. Being replaced by bioequivalent allergy units (BAU).","1","1","1",1,false],[false,"Limit of flocculation","[Lf]","[LF]","procedure defined amount of an antigen substance",1,[0,0,0,0,0,0,0],"Lf","chemical",false,null,null,1,false,true,0,"Lf doses","UCUM","Arb","Clinical","the antigen content  forming 1:1 ratio against 1 unit of antitoxin","1","1","1",1,false],[false,"D-antigen unit (polio)","[D'ag'U]","[D'AG'U]","procedure defined amount of a poliomyelitis d-antigen substance",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"DAgU; units","UCUM","Acnc","Clinical","unit of potency of poliovirus vaccine used for poliomyelitis prevention reported as D antigen units/mL. The unit is poliovirus type-specific.","1","1","1",1,false],[false,"fibrinogen equivalent units","[FEU]","[FEU]","amount of fibrinogen broken down into the measured d-dimers",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"FEU","UCUM","MCnc","Clinical","Note both the FEU and DDU units are used to report D-dimer measurements. 1 DDU = 1/2 FFU","1","1","1",1,false],[false,"ELISA unit","[ELU]","[ELU]","arbitrary ELISA unit",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"Enzyme-Linked Immunosorbent Assay Units; ELU; EL. U","UCUM","ACnc","Clinical","","1","1","1",1,false],[false,"Ehrlich units (urobilinogen)","[EU]","[EU]","Ehrlich unit",1,[0,0,0,0,0,0,0],null,"chemical",false,null,null,1,false,true,0,"EU/dL; mg{urobilinogen}/dL","UCUM","ACnc","Clinical","","1","1","1",1,false],[false,"neper","Np","NEP","level",1,[0,0,0,0,0,0,0],"Np","levels",true,null,"ln",1,true,false,0,"nepers","UCUM","LogRto","Clinical","logarithmic unit for ratios of measurements of physical field and power quantities, such as gain and loss of electronic signals","1",null,null,1,false],[false,"bel","B","B","level",1,[0,0,0,0,0,0,0],"B","levels",true,null,"lg",1,true,false,0,"bels","UCUM","LogRto","Clinical","Logarithm of the ratio of power- or field-type quantities; usually expressed in decibels ","1",null,null,1,false],[false,"bel sound pressure","B[SPL]","B[SPL]","pressure level",0.02,[-1,-2,1,0,0,0,0],"B(SPL)","levels",true,null,"lgTimes2",1,true,false,0,"bel SPL; B SPL; sound pressure bels","UCUM","LogRto","Clinical","used to measure sound level in acoustics","Pa",null,null,0.00002,false],[false,"bel volt","B[V]","B[V]","electric potential level",1000,[2,-2,1,0,0,-1,0],"B(V)","levels",true,null,"lgTimes2",1,true,false,0,"bel V; B V; volts bels","UCUM","LogRtoElp","Clinical","used to express power gain in electrical circuits","V",null,null,1,false],[false,"bel millivolt","B[mV]","B[MV]","electric potential level",1,[2,-2,1,0,0,-1,0],"B(mV)","levels",true,null,"lgTimes2",1,true,false,0,"bel mV; B mV; millivolt bels; 10^-3V bels; 10*-3V ","UCUM","LogRtoElp","Clinical","used to express power gain in electrical circuits","mV",null,null,1,false],[false,"bel microvolt","B[uV]","B[UV]","electric potential level",0.001,[2,-2,1,0,0,-1,0],"B(μV)","levels",true,null,"lgTimes2",1,true,false,0,"bel uV; B uV; microvolts bels; 10^-6V bel; 10*-6V bel","UCUM","LogRto","Clinical","used to express power gain in electrical circuits","uV",null,null,1,false],[false,"bel 10 nanovolt","B[10.nV]","B[10.NV]","electric potential level",0.000010000000000000003,[2,-2,1,0,0,-1,0],"B(10 nV)","levels",true,null,"lgTimes2",1,true,false,0,"bel 10 nV; B 10 nV; 10 nanovolts bels","UCUM","LogRtoElp","Clinical","used to express power gain in electrical circuits","nV",null,null,10,false],[false,"bel watt","B[W]","B[W]","power level",1000,[2,-3,1,0,0,0,0],"B(W)","levels",true,null,"lg",1,true,false,0,"bel W; b W; b Watt; Watts bels","UCUM","LogRto","Clinical","used to express power","W",null,null,1,false],[false,"bel kilowatt","B[kW]","B[KW]","power level",1000000,[2,-3,1,0,0,0,0],"B(kW)","levels",true,null,"lg",1,true,false,0,"bel kW; B kW; kilowatt bel; kW bel; kW B","UCUM","LogRto","Clinical","used to express power","kW",null,null,1,false],[false,"stere","st","STR","volume",1,[3,0,0,0,0,0,0],"st","misc",true,null,null,1,false,false,0,"stère; m3; cubic meter; m^3; meters cubed; metre","UCUM","Vol","Nonclinical","equal to one cubic meter, usually used for measuring firewoord","m3","M3","1",1,false],[false,"Ångström","Ao","AO","length",1.0000000000000002e-10,[1,0,0,0,0,0,0],"Å","misc",false,null,null,1,false,false,0,"Å; Angstroms; Ao; Ångströms","UCUM","Len","Clinical","equal to 10^-10 meters; used to express wave lengths and atom scaled differences ","nm","NM","0.1",0.1,false],[false,"barn","b","BRN","action area",9.999999999999999e-29,[2,0,0,0,0,0,0],"b","misc",false,null,null,1,false,false,0,"barns","UCUM","Area","Clinical","used in high-energy physics to express cross-sectional areas","fm2","FM2","100",100,false],[false,"technical atmosphere","att","ATT","pressure",98066499.99999999,[-1,-2,1,0,0,0,0],"at","misc",false,null,null,1,false,false,0,"at; tech atm; tech atmosphere; kgf/cm2; atms; atmospheres","UCUM","Pres","Obsolete","non-SI unit of pressure equal to one kilogram-force per square centimeter","kgf/cm2","KGF/CM2","1",1,false],[false,"mho","mho","MHO","electric conductance",0.001,[-2,1,-1,0,0,2,0],"mho","misc",true,null,null,1,false,false,0,"siemens; ohm reciprocals; Ω^−1; Ω-1 ","UCUM","","Obsolete","unit of electric conductance (the inverse of electrical resistance) equal to ohm^-1","S","S","1",1,false],[false,"pound per square inch","[psi]","[PSI]","pressure",6894757.293168359,[-1,-2,1,0,0,0,0],"psi","misc",false,null,null,1,false,false,0,"psi; lb/in2; lb per in2","UCUM","Pres","Clinical","","[lbf_av]/[in_i]2","[LBF_AV]/[IN_I]2","1",1,false],[false,"circle - plane angle","circ","CIRC","plane angle",6.283185307179586,[0,0,0,1,0,0,0],"circ","misc",false,null,null,1,false,false,0,"angles; circles","UCUM","Angle","Clinical","","[pi].rad","[PI].RAD","2",2,false],[false,"spere - solid angle","sph","SPH","solid angle",12.566370614359172,[0,0,0,2,0,0,0],"sph","misc",false,null,null,1,false,false,0,"speres","UCUM","Angle","Clinical","equal to the solid angle of an entire sphere = 4πsr (sr = steradian) ","[pi].sr","[PI].SR","4",4,false],[false,"metric carat","[car_m]","[CAR_M]","mass",0.2,[0,0,1,0,0,0,0],"ct<sub>m</sub>","misc",false,null,null,1,false,false,0,"carats; ct; car m","UCUM","Mass","Nonclinical","unit of mass for gemstones","g","G","2e-1",0.2,false],[false,"carat of gold alloys","[car_Au]","[CAR_AU]","mass fraction",0.041666666666666664,[0,0,0,0,0,0,0],"ct<sub><r>Au</r></sub>","misc",false,null,null,1,false,false,0,"karats; k; kt; car au; carats","UCUM","MFr","Nonclinical","unit of purity for gold alloys","/24","/24","1",1,false],[false,"Smoot","[smoot]","[SMOOT]","length",1.7018000000000002,[1,0,0,0,0,0,0],null,"misc",false,null,null,1,false,false,0,"","UCUM","Len","Nonclinical","prank unit of length from MIT","[in_i]","[IN_I]","67",67,false],[false,"meter per square seconds per square root of hertz","[m/s2/Hz^(1/2)]","[M/S2/HZ^(1/2)]","amplitude spectral density",1,[2,-3,0,0,0,0,0],null,"misc",false,null,"sqrt",1,true,false,0,"m/s2/(Hz^.5); m/s2/(Hz^(1/2)); m per s2 per Hz^1/2","UCUM","","Constant","measures amplitude spectral density, and is equal to the square root of power spectral density\n ","m2/s4/Hz",null,null,1,false],[false,"bit - logarithmic","bit_s","BIT_S","amount of information",1,[0,0,0,0,0,0,0],"bit<sub>s</sub>","infotech",false,null,"ld",1,true,false,0,"bit-s; bit s; bit logarithmic","UCUM","LogA","Nonclinical","defined as the log base 2 of the number of distinct signals; cannot practically be used to express more than 1000 bits\n\nIn information theory, the definition of the amount of self-information and information entropy is often expressed with the binary logarithm (log base 2)","1",null,null,1,false],[false,"bit","bit","BIT","amount of information",1,[0,0,0,0,0,0,0],"bit","infotech",true,null,null,1,false,false,0,"bits","UCUM","","Nonclinical","dimensionless information unit of 1 used in computing and digital communications","1","1","1",1,false],[false,"byte","By","BY","amount of information",8,[0,0,0,0,0,0,0],"B","infotech",true,null,null,1,false,false,0,"bytes","UCUM","","Nonclinical","equal to 8 bits","bit","bit","8",8,false],[false,"baud","Bd","BD","signal transmission rate",1,[0,1,0,0,0,0,0],"Bd","infotech",true,null,"inv",1,false,false,0,"Bd; bauds","UCUM","Freq","Nonclinical","unit to express rate in symbols per second or pulses per second. ","s","/s","1",1,false],[false,"per twelve hour","/(12.h)","/HR","",0.000023148148148148147,[0,-1,0,0,0,0,0],"/h",null,false,null,null,1,false,false,0,"per 12 hours; 12hrs; 12 hrs; /12hrs","LOINC","Rat","Clinical","",null,null,null,null,false],[false,"per arbitrary unit","/[arb'U]","/[ARB'U]","",1,[0,0,0,0,0,0,0],"/arb/ U",null,false,null,null,1,false,true,0,"/arbU","LOINC","InvA ","Clinical","",null,null,null,null,false],[false,"per high power field","/[HPF]","/[HPF]","",1,[0,0,0,0,0,0,0],"/HPF",null,false,null,null,1,false,false,0,"/HPF; per HPF","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"per international unit","/[IU]","/[IU]","",1,[0,0,0,0,0,0,0],"/i/U.",null,false,null,null,1,false,true,0,"international units; /IU; per IU","LOINC","InvA","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)",null,null,null,null,false],[false,"per low power field","/[LPF]","/[LPF]","",1,[0,0,0,0,0,0,0],"/LPF",null,false,null,null,1,false,false,0,"/LPF; per LPF","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"per 10 billion  ","/10*10","/10*10","",1e-10,[0,0,0,0,0,0,0],"/10<sup>10<.sup>",null,false,null,null,1,false,false,0,"/10^10; per 10*10","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per trillion ","/10*12","/10*12","",1e-12,[0,0,0,0,0,0,0],"/10<sup>12<.sup>",null,false,null,null,1,false,false,0,"/10^12; per 10*12","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per thousand","/10*3","/10*3","",0.001,[0,0,0,0,0,0,0],"/10<sup>3<.sup>",null,false,null,null,1,false,false,0,"/10^3; per 10*3","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per million","/10*6","/10*6","",0.000001,[0,0,0,0,0,0,0],"/10<sup>6<.sup>",null,false,null,null,1,false,false,0,"/10^6; per 10*6;","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per billion","/10*9","/10*9","",1e-9,[0,0,0,0,0,0,0],"/10<sup>9<.sup>",null,false,null,null,1,false,false,0,"/10^9; per 10*9","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per 100","/100","","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"per hundred; 10^2; 10*2","LOINC","NFr","Clinical","used for counting entities, e.g. blood cells; usually these kinds of terms have numerators such as moles or milligrams, and counting that amount per the number in the denominator",null,null,null,null,false],[false,"per 100 cells","/100{cells}","","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"/100 cells; /100cells; per hundred","LOINC","EntMass; EntNum; NFr","Clinical","",null,null,null,null,false],[false,"per 100 neutrophils","/100{neutrophils}","","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"/100 neutrophils; /100neutrophils; per hundred","LOINC","EntMass; EntNum; NFr","Clinical","",null,null,null,null,false],[false,"per 100 spermatozoa","/100{spermatozoa}","","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"/100 spermatozoa; /100spermatozoa; per hundred","LOINC","NFr","Clinical","",null,null,null,null,false],[false,"per 100 white blood cells","/100{WBCs}","","",0.01,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"/100 WBCs; /100WBCs; per hundred","LOINC","Ratio; NFr","Clinical","",null,null,null,null,false],[false,"per year","/a","/ANN","",3.168808781402895e-8,[0,-1,0,0,0,0,0],"/a",null,false,null,null,1,false,false,0,"/Years; /yrs; yearly","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per centimeter of water","/cm[H2O]","/CM[H2O]","",0.000010197162129779282,[1,2,-1,0,0,0,0],"/cm HO<sub><r>2<.r></sub>",null,false,null,null,1,false,false,0,"/cmH2O; /cm H2O; centimeters; centimetres","LOINC","InvPress","Clinical","",null,null,null,null,false],[false,"per day","/d","/D","",0.000011574074074074073,[0,-1,0,0,0,0,0],"/d",null,false,null,null,1,false,false,0,"/dy; per day","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per deciliter","/dL","/DL","",10000,[-3,0,0,0,0,0,0],"/dL",null,false,null,null,1,false,false,0,"per dL; /deciliter; decilitre","LOINC","NCnc","Clinical","",null,null,null,null,false],[false,"per gram","/g","/G","",1,[0,0,-1,0,0,0,0],"/g",null,false,null,null,1,false,false,0,"/gm; /gram; per g","LOINC","NCnt","Clinical","",null,null,null,null,false],[false,"per hour","/h","/HR","",0.0002777777777777778,[0,-1,0,0,0,0,0],"/h",null,false,null,null,1,false,false,0,"/hr; /hour; per hr","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per kilogram","/kg","/KG","",0.001,[0,0,-1,0,0,0,0],"/kg",null,false,null,null,1,false,false,0,"per kg; per kilogram","LOINC","NCnt","Clinical","",null,null,null,null,false],[false,"per liter","/L","/L","",1000,[-3,0,0,0,0,0,0],"/L",null,false,null,null,1,false,false,0,"/liter; litre","LOINC","NCnc","Clinical","",null,null,null,null,false],[false,"per square meter","/m2","/M2","",1,[-2,0,0,0,0,0,0],"/m<sup>2<.sup>",null,false,null,null,1,false,false,0,"/m^2; /m*2; /sq. m; per square meter; meter squared; metre","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"per cubic meter","/m3","/M3","",1,[-3,0,0,0,0,0,0],"/m<sup>3<.sup>",null,false,null,null,1,false,false,0,"/m^3; /m*3; /cu. m; per cubic meter; meter cubed; per m3; metre","LOINC","NCncn","Clinical","",null,null,null,null,false],[false,"per milligram","/mg","/MG","",1000,[0,0,-1,0,0,0,0],"/mg",null,false,null,null,1,false,false,0,"/milligram; per mg","LOINC","NCnt","Clinical","",null,null,null,null,false],[false,"per minute","/min","/MIN","",0.016666666666666666,[0,-1,0,0,0,0,0],"/min",null,false,null,null,1,false,false,0,"/minute; per mins; breaths beats per minute","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per milliliter","/mL","/ML","",1000000,[-3,0,0,0,0,0,0],"/mL",null,false,null,null,1,false,false,0,"/milliliter; per mL; millilitre","LOINC","NCncn","Clinical","",null,null,null,null,false],[false,"per millimeter","/mm","/MM","",1000,[-1,0,0,0,0,0,0],"/mm",null,false,null,null,1,false,false,0,"/millimeter; per mm; millimetre","LOINC","InvLen","Clinical","",null,null,null,null,false],[false,"per month","/mo","/MO","",3.802570537683474e-7,[0,-1,0,0,0,0,0],"/mo",null,false,null,null,1,false,false,0,"/month; per mo; monthly; month","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per second","/s","/S","",1,[0,-1,0,0,0,0,0],"/s",null,false,null,null,1,false,false,0,"/second; /sec; per sec; frequency; Hertz; Herz; Hz; becquerels; Bq; s-1; s^-1","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"per enzyme unit","/U","/U","",9.963241120049633e-17,[0,1,0,0,0,0,0],"/U",null,false,null,null,1,false,false,-1,"/enzyme units; per U","LOINC","InvC; NCat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)",null,null,null,null,false],[false,"per microliter","/uL","/UL","",999999999.9999999,[-3,0,0,0,0,0,0],"/μL",null,false,null,null,1,false,false,0,"/microliter; microlitre; /mcl; per uL","LOINC","ACnc","Clinical","",null,null,null,null,false],[false,"per week","/wk","/WK","",0.0000016534391534391535,[0,-1,0,0,0,0,0],"/wk",null,false,null,null,1,false,false,0,"/week; per wk; weekly, weeks","LOINC","NRat","Clinical","",null,null,null,null,false],[false,"APL unit per milliliter","[APL'U]/mL","[APL'U]/ML","biologic activity of anticardiolipin IgA",1000000,[-3,0,0,0,0,0,0],"/mL","chemical",false,null,null,1,false,true,0,"APL/mL; APL'U/mL; APL U/mL; APL/milliliter; IgA anticardiolipin units per milliliter; IgA Phospholipid Units; millilitre; biologic activity of","LOINC","ACnc","Clinical","Units for an anti phospholipid syndrome test","1","1","1",1,false],[false,"arbitrary unit per milliliter","[arb'U]/mL","[ARB'U]/ML","arbitrary",1000000,[-3,0,0,0,0,0,0],"(arb. U)/mL","chemical",false,null,null,1,false,true,0,"arb'U/mL; arbU/mL; arb U/mL; arbitrary units per milliliter; millilitre","LOINC","ACnc","Clinical","relative unit of measurement to show the ratio of test measurement to reference measurement","1","1","1",1,false],[false,"colony forming units per liter","[CFU]/L","[CFU]/L","amount of a proliferating organism",1000,[-3,0,0,0,0,0,0],"CFU/L","chemical",false,null,null,1,false,true,0,"CFU per Liter; CFU/L","LOINC","NCnc","Clinical","","1","1","1",1,false],[false,"colony forming units per milliliter","[CFU]/mL","[CFU]/ML","amount of a proliferating organism",1000000,[-3,0,0,0,0,0,0],"CFU/mL","chemical",false,null,null,1,false,true,0,"CFU per mL; CFU/mL","LOINC","NCnc","Clinical","","1","1","1",1,false],[false,"foot per foot - US","[ft_us]/[ft_us]","[FT_US]/[FT_US]","length",1,[0,0,0,0,0,0,0],"(ft<sub>us</sub>)/(ft<sub>us</sub>)","us-lengths",false,null,null,1,false,false,0,"ft/ft; ft per ft; feet per feet; visual acuity","","LenRto","Clinical","distance ratio to measure 20:20 vision","m/3937","M/3937","1200",1200,false],[false,"GPL unit per milliliter","[GPL'U]/mL","[GPL'U]/ML","biologic activity of anticardiolipin IgG",1000000,[-3,0,0,0,0,0,0],"/mL","chemical",false,null,null,1,false,true,0,"GPL U/mL; GPL'U/mL; GPL/mL; GPL U per mL; IgG Phospholipid Units per milliliters; IgG anticardiolipin units; millilitres ","LOINC","ACnc; AMass","Clinical","Units for an antiphospholipid test","1","1","1",1,false],[false,"international unit per 2 hour","[IU]/(2.h)","[IU]/HR","arbitrary",0.0001388888888888889,[0,-1,0,0,0,0,0],"(i.U.)/h","chemical",true,null,null,1,false,true,0,"IU/2hrs; IU/2 hours; IU per 2 hrs; international units per 2 hours","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per 24 hour","[IU]/(24.h)","[IU]/HR","arbitrary",0.000011574074074074073,[0,-1,0,0,0,0,0],"(i.U.)/h","chemical",true,null,null,1,false,true,0,"IU/24hr; IU/24 hours; IU per 24 hrs; international units per 24 hours","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per day","[IU]/d","[IU]/D","arbitrary",0.000011574074074074073,[0,-1,0,0,0,0,0],"(i.U.)/d","chemical",true,null,null,1,false,true,0,"IU/dy; IU/days; IU per dys; international units per day","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per deciliter","[IU]/dL","[IU]/DL","arbitrary",10000,[-3,0,0,0,0,0,0],"(i.U.)/dL","chemical",true,null,null,1,false,true,0,"IU/dL; IU per dL; international units per deciliters; decilitres","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per gram","[IU]/g","[IU]/G","arbitrary",1,[0,0,-1,0,0,0,0],"(i.U.)/g","chemical",true,null,null,1,false,true,0,"IU/gm; IU/gram; IU per gm; IU per g; international units per gram","LOINC","ACnt","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per hour","[IU]/h","[IU]/HR","arbitrary",0.0002777777777777778,[0,-1,0,0,0,0,0],"(i.U.)/h","chemical",true,null,null,1,false,true,0,"IU/hrs; IU per hours; international units per hour","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per kilogram","[IU]/kg","[IU]/KG","arbitrary",0.001,[0,0,-1,0,0,0,0],"(i.U.)/kg","chemical",true,null,null,1,false,true,0,"IU/kg; IU/kilogram; IU per kg; units","LOINC","ACnt","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per kilogram per day","[IU]/kg/d","[IU]/KG/D","arbitrary",1.1574074074074074e-8,[0,-1,-1,0,0,0,0],"(i.U.)/kg/d","chemical",true,null,null,1,false,true,0,"IU/kg/dy; IU/kg/day; IU/kilogram/day; IU per kg per day; units","LOINC","ACntRat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per liter","[IU]/L","[IU]/L","arbitrary",1000,[-3,0,0,0,0,0,0],"(i.U.)/L","chemical",true,null,null,1,false,true,0,"IU/L; IU/liter; IU per liter; units; litre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per minute","[IU]/min","[IU]/MIN","arbitrary",0.016666666666666666,[0,-1,0,0,0,0,0],"(i.U.)/min","chemical",true,null,null,1,false,true,0,"IU/min; IU/minute; IU per minute; international units","LOINC","ARat","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"international unit per milliliter","[IU]/mL","[IU]/ML","arbitrary",1000000,[-3,0,0,0,0,0,0],"(i.U.)/mL","chemical",true,null,null,1,false,true,0,"IU/mL; IU per mL; international units per milliliter; millilitre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"MPL unit per milliliter","[MPL'U]/mL","[MPL'U]/ML","biologic activity of anticardiolipin IgM",1000000,[-3,0,0,0,0,0,0],"/mL","chemical",false,null,null,1,false,true,0,"MPL/mL; MPL U/mL; MPL'U/mL; IgM anticardiolipin units; IgM Phospholipid Units; millilitre ","LOINC","ACnc","Clinical","units for antiphospholipid test\n","1","1","1",1,false],[false,"number per high power field","{#}/[HPF]","/[HPF]","",1,[0,0,0,0,0,0,0],"/HPF",null,false,null,null,1,false,false,0,"#/HPF; # per HPF; number/HPF; numbers per high power field","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"number per low power field","{#}/[LPF]","/[LPF]","",1,[0,0,0,0,0,0,0],"/LPF",null,false,null,null,1,false,false,0,"#/LPF; # per LPF; number/LPF; numbers per low power field","LOINC","Naric","Clinical","",null,null,null,null,false],[false,"IgA antiphosphatidylserine unit ","{APS'U}","","",1,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"APS Unit; Phosphatidylserine Antibody IgA Units","LOINC","ACnc","Clinical","unit for antiphospholipid test",null,null,null,null,false],[false,"EIA index","{EIA_index}","","",1,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"enzyme immunoassay index","LOINC","ACnc","Clinical","",null,null,null,null,false],[false,"kaolin clotting time","{KCT'U}","","",1,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"KCT","LOINC","Time","Clinical","sensitive test to detect lupus anticoagulants; measured in seconds",null,null,null,null,false],[false,"IgM antiphosphatidylserine unit","{MPS'U}","","",1,[0,0,0,0,0,0,0],null,null,false,null,null,1,false,false,0,"Phosphatidylserine Antibody IgM Measurement ","LOINC","ACnc","Clinical","",null,null,null,null,false],[false,"trillion per liter","10*12/L","(10*12)/L","number",1000000000000000,[-3,0,0,0,0,0,0],"(10<sup>12</sup>)/L","dimless",false,null,null,1,false,false,0,"10^12/L; 10*12 per Liter; trillion per liter; litre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10^3 (used for cell count)","10*3","10*3","number",1000,[0,0,0,0,0,0,0],"10<sup>3</sup>","dimless",false,null,null,1,false,false,0,"10^3; thousand","LOINC","Num","Clinical","usually used for counting entities (e.g. blood cells) per volume","1","1","10",10,false],[false,"thousand per liter","10*3/L","(10*3)/L","number",1000000,[-3,0,0,0,0,0,0],"(10<sup>3</sup>)/L","dimless",false,null,null,1,false,false,0,"10^3/L; 10*3 per liter; litre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"thousand per milliliter","10*3/mL","(10*3)/ML","number",1000000000,[-3,0,0,0,0,0,0],"(10<sup>3</sup>)/mL","dimless",false,null,null,1,false,false,0,"10^3/mL; 10*3 per mL; thousand per milliliter; millilitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"thousand per microliter","10*3/uL","(10*3)/UL","number",999999999999.9999,[-3,0,0,0,0,0,0],"(10<sup>3</sup>)/μL","dimless",false,null,null,1,false,false,0,"10^3/uL; 10*3 per uL; thousand per microliter; microlitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10 thousand per microliter","10*4/uL","(10*4)/UL","number",10000000000000,[-3,0,0,0,0,0,0],"(10<sup>4</sup>)/μL","dimless",false,null,null,1,false,false,0,"10^4/uL; 10*4 per uL; microlitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10^5 ","10*5","10*5","number",100000,[0,0,0,0,0,0,0],"10<sup>5</sup>","dimless",false,null,null,1,false,false,0,"one hundred thousand","LOINC","Num","Clinical","","1","1","10",10,false],[false,"10^6","10*6","10*6","number",1000000,[0,0,0,0,0,0,0],"10<sup>6</sup>","dimless",false,null,null,1,false,false,0,"","LOINC","Num","Clinical","","1","1","10",10,false],[false,"million colony forming unit per liter","10*6.[CFU]/L","(10*6).[CFU]/L","number",1000000000,[-3,0,0,0,0,0,0],"(10<sup>6</sup>).CFU/L","dimless",false,null,null,1,false,true,0,"10*6 CFU/L; 10^6 CFU/L; 10^6CFU; 10^6 CFU per liter; million colony forming units; litre","LOINC","ACnc","Clinical","","1","1","10",10,false],[false,"million international unit","10*6.[IU]","(10*6).[IU]","number",1000000,[0,0,0,0,0,0,0],"(10<sup>6</sup>).(i.U.)","dimless",false,null,null,1,false,true,0,"10*6 IU; 10^6 IU; international units","LOINC","arb","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","1","1","10",10,false],[false,"million per 24 hour","10*6/(24.h)","(10*6)/HR","number",11.574074074074074,[0,-1,0,0,0,0,0],"(10<sup>6</sup>)/h","dimless",false,null,null,1,false,false,0,"10*6/24hrs; 10^6/24 hrs; 10*6 per 24 hrs; 10^6 per 24 hours","LOINC","NRat","Clinical","","1","1","10",10,false],[false,"million per kilogram","10*6/kg","(10*6)/KG","number",1000,[0,0,-1,0,0,0,0],"(10<sup>6</sup>)/kg","dimless",false,null,null,1,false,false,0,"10^6/kg; 10*6 per kg; 10*6 per kilogram; millions","LOINC","NCnt","Clinical","","1","1","10",10,false],[false,"million per liter","10*6/L","(10*6)/L","number",1000000000,[-3,0,0,0,0,0,0],"(10<sup>6</sup>)/L","dimless",false,null,null,1,false,false,0,"10^6/L; 10*6 per Liter; 10^6 per Liter; litre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"million per milliliter","10*6/mL","(10*6)/ML","number",1000000000000,[-3,0,0,0,0,0,0],"(10<sup>6</sup>)/mL","dimless",false,null,null,1,false,false,0,"10^6/mL; 10*6 per mL; 10*6 per milliliter; millilitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"million per microliter","10*6/uL","(10*6)/UL","number",1000000000000000,[-3,0,0,0,0,0,0],"(10<sup>6</sup>)/μL","dimless",false,null,null,1,false,false,0,"10^6/uL; 10^6 per uL; 10^6/mcl; 10^6 per mcl; 10^6 per microliter; microlitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10^8","10*8","10*8","number",100000000,[0,0,0,0,0,0,0],"10<sup>8</sup>","dimless",false,null,null,1,false,false,0,"100 million; one hundred million; 10^8","LOINC","Num","Clinical","","1","1","10",10,false],[false,"billion per liter","10*9/L","(10*9)/L","number",1000000000000,[-3,0,0,0,0,0,0],"(10<sup>9</sup>)/L","dimless",false,null,null,1,false,false,0,"10^9/L; 10*9 per Liter; litre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"billion per milliliter","10*9/mL","(10*9)/ML","number",1000000000000000,[-3,0,0,0,0,0,0],"(10<sup>9</sup>)/mL","dimless",false,null,null,1,false,false,0,"10^9/mL; 10*9 per mL; 10^9 per mL; 10*9 per milliliter; millilitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"billion per microliter","10*9/uL","(10*9)/UL","number",1000000000000000000,[-3,0,0,0,0,0,0],"(10<sup>9</sup>)/μL","dimless",false,null,null,1,false,false,0,"10^9/uL; 10^9 per uL; 10^9/mcl; 10^9 per mcl; 10*9 per uL; 10*9 per mcl; 10*9/mcl; 10^9 per microliter; microlitre","LOINC","NCncn","Clinical","","1","1","10",10,false],[false,"10 liter per minute per square meter","10.L/(min.m2)","L/(MIN.M2)","",0.00016666666666666666,[1,-1,0,0,0,0,0],"L/(min.(m<sup>2</sup>))",null,false,null,null,1,false,false,0,"10 liters per minutes per square meter; 10 L per min per m2; m^2; 10 L/(min*m2); 10L/(min*m^2); litres; sq. meter; metre; meters squared","LOINC","ArVRat","Clinical","",null,null,null,null,false],[false,"10 liter per minute","10.L/min","L/MIN","",0.00016666666666666666,[3,-1,0,0,0,0,0],"L/min",null,false,null,null,1,false,false,0,"10 liters per minute; 10 L per min; 10L; 10 L/min; litre","LOINC","VRat","Clinical","",null,null,null,null,false],[false,"10 micronewton second per centimeter to the fifth power per square meter","10.uN.s/(cm5.m2)","(UN.S)/(CM5.M2)","",100000000,[-6,-1,1,0,0,0,0],"(μN.s)/(cm<sup>5</sup>).(m<sup>2</sup>)",null,false,null,null,1,false,false,0,"dyne seconds per centimeter5 and square meter; dyn.s/(cm5.m2); dyn.s/cm5/m2; cm^5; m^2","LOINC","","Clinical","unit to measure systemic vascular resistance per body surface area",null,null,null,null,false],[false,"24 hour","24.h","HR","",86400,[0,1,0,0,0,0,0],"h",null,false,null,null,1,false,false,0,"24hrs; 24 hrs; 24 hours; days; dy","LOINC","Time","Clinical","",null,null,null,null,false],[false,"ampere per meter","A/m","A/M","electric current",1,[-1,-1,0,0,0,1,0],"A/m","si",true,null,null,1,false,false,0,"A/m; amp/meter; magnetic field strength; H; B; amperes per meter; metre","LOINC","","Clinical","unit of magnetic field strength","C/s","C/S","1",1,false],[true,"centigram","cg","CG","mass",0.01,[0,0,1,0,0,0,0],"cg",null,false,"M",null,1,false,false,0,"centigrams; cg; cgm","LOINC","Mass","Clinical","",null,null,null,null,false],[false,"centiliter","cL","CL","volume",0.00001,[3,0,0,0,0,0,0],"cL","iso1000",true,null,null,1,false,false,0,"centiliters; centilitres","LOINC","Vol","Clinical","","l",null,"1",1,false],[true,"centimeter","cm","CM","length",0.01,[1,0,0,0,0,0,0],"cm",null,false,"L",null,1,false,false,0,"centimeters; centimetres","LOINC","Len","Clinical","",null,null,null,null,false],[false,"centimeter of water","cm[H2O]","CM[H2O]","pressure",98066.5,[-1,-2,1,0,0,0,0],"cm HO<sub><r>2</r></sub>","clinical",true,null,null,1,false,false,0,"cm H2O; cmH2O; centimetres; pressure","LOINC","Pres","Clinical","unit of pressure mostly applies to blood pressure","kPa","KPAL","980665e-5",9.80665,false],[false,"centimeter of water per liter per second","cm[H2O]/L/s","(CM[H2O]/L)/S","pressure",98066500,[-4,-3,1,0,0,0,0],"(cm HO<sub><r>2</r></sub>)/L/s","clinical",true,null,null,1,false,false,0,"cm[H2O]/(L/s); cm[H2O].s/L; cm H2O/L/sec; cmH2O/L/sec; cmH2O/Liter; cmH2O per L per secs; centimeters of water per liters per second; centimetres; litres; cm[H2O]/(L/s)","LOINC","PresRat","Clinical","unit used to measure mean pulmonary resistance","kPa","KPAL","980665e-5",9.80665,false],[false,"centimeter of water per second per meter","cm[H2O]/s/m","(CM[H2O]/S)/M","pressure",98066.5,[-2,-3,1,0,0,0,0],"(cm HO<sub><r>2</r></sub>)/s/m","clinical",true,null,null,1,false,false,0,"cm[H2O]/(s.m); cm H2O/s/m; cmH2O; cmH2O/sec/m; cmH2O per secs per meters; centimeters of water per seconds per meter; centimetres; metre","LOINC","PresRat","Clinical","unit used to measure pulmonary pressure time product","kPa","KPAL","980665e-5",9.80665,false],[false,"centimeter of mercury","cm[Hg]","CM[HG]","pressure",1333220,[-1,-2,1,0,0,0,0],"cm Hg","clinical",true,null,null,1,false,false,0,"centimeters of mercury; centimetres; cmHg; cm Hg","LOINC","Pres","Clinical","unit of pressure where 1 cmHg = 10 torr","kPa","KPAL","133.3220",133.322,false],[true,"square centimeter","cm2","CM2","length",0.0001,[2,0,0,0,0,0,0],"cm<sup>2</sup>",null,false,"L",null,1,false,false,0,"cm^2; sq cm; centimeters squared; square centimeters; centimetre; area","LOINC","Area","Clinical","",null,null,null,null,false],[true,"square centimeter per second","cm2/s","CM2/S","length",0.0001,[2,-1,0,0,0,0,0],"(cm<sup>2</sup>)/s",null,false,"L",null,1,false,false,0,"cm^2/sec; square centimeters per second; sq cm per sec; cm2; centimeters squared; centimetres","LOINC","AreaRat","Clinical","",null,null,null,null,false],[false,"centipoise","cP","CP","dynamic viscosity",1,[-1,-1,1,0,0,0,0],"cP","cgs",true,null,null,1,false,false,0,"cps; centiposes","LOINC","Visc","Clinical","unit of dynamic viscosity in the CGS system with base units: 10^−3 Pa.s = 1 mPa·.s (1 millipascal second)","dyn.s/cm2","DYN.S/CM2","1",1,false],[false,"centistoke","cSt","CST","kinematic viscosity",0.0000010000000000000002,[2,-1,0,0,0,0,0],"cSt","cgs",true,null,null,1,false,false,0,"centistokes","LOINC","Visc","Clinical","unit for kinematic viscosity with base units of mm^2/s (square millimeter per second)","cm2/s","CM2/S","1",1,false],[false,"dekaliter per minute","daL/min","DAL/MIN","volume",0.00016666666666666666,[3,-1,0,0,0,0,0],"daL/min","iso1000",true,null,null,1,false,false,0,"dekalitres; dekaliters per minute; per min","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"dekaliter per minute per square meter","daL/min/m2","(DAL/MIN)/M2","volume",0.00016666666666666666,[1,-1,0,0,0,0,0],"(daL/min)/(m<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,"daL/min/m^2; daL/minute/m2; sq. meter; dekaliters per minutes per square meter; meter squared; dekalitres; metre","LOINC","ArVRat","Clinical","The area usually is the body surface area used to normalize cardiovascular measures for patient's size","l",null,"1",1,false],[false,"decibel","dB","DB","level",1,[0,0,0,0,0,0,0],"dB","levels",true,null,"lg",0.1,true,false,0,"decibels","LOINC","LogRto","Clinical","unit most commonly used in acoustics as unit of sound pressure level. (also see B[SPL] or bel sound pressure level). ","1",null,null,1,false],[false,"degree per second","deg/s","DEG/S","plane angle",0.017453292519943295,[0,-1,0,1,0,0,0],"°/s","iso1000",false,null,null,1,false,false,0,"deg/sec; deg per sec; °/sec; twist rate; angular speed; rotational speed","LOINC","ARat","Clinical","unit of angular (rotational) speed used to express turning rate","[pi].rad/360","[PI].RAD/360","2",2,false],[true,"decigram","dg","DG","mass",0.1,[0,0,1,0,0,0,0],"dg",null,false,"M",null,1,false,false,0,"decigrams; dgm; 0.1 grams; 1/10 gm","LOINC","Mass","Clinical","equal to 1/10 gram",null,null,null,null,false],[false,"deciliter","dL","DL","volume",0.0001,[3,0,0,0,0,0,0],"dL","iso1000",true,null,null,1,false,false,0,"deciliters; decilitres; 0.1 liters; 1/10 L","LOINC","Vol","Clinical","equal to 1/10 liter","l",null,"1",1,false],[true,"decimeter","dm","DM","length",0.1,[1,0,0,0,0,0,0],"dm",null,false,"L",null,1,false,false,0,"decimeters; decimetres; 0.1 meters; 1/10 m; 10 cm; centimeters","LOINC","Len","Clinical","equal to 1/10 meter or 10 centimeters",null,null,null,null,false],[true,"square decimeter per square second","dm2/s2","DM2/S2","length",0.010000000000000002,[2,-2,0,0,0,0,0],"(dm<sup>2</sup>)/(s<sup>2</sup>)",null,false,"L",null,1,false,false,0,"dm2 per s2; dm^2/s^2; decimeters squared per second squared; sq dm; sq sec","LOINC","EngMass (massic energy)","Clinical","units for energy per unit mass or Joules per kilogram (J/kg = kg.m2/s2/kg = m2/s2) ",null,null,null,null,false],[false,"dyne second per centimeter per square meter","dyn.s/(cm.m2)","(DYN.S)/(CM.M2)","force",1,[-2,-1,1,0,0,0,0],"(dyn.s)/(cm.(m<sup>2</sup>))","cgs",true,null,null,1,false,false,0,"(dyn*s)/(cm*m2); (dyn*s)/(cm*m^2); dyn s per cm per m2; m^2; dyne seconds per centimeters per square meter; centimetres; sq. meter; squared","LOINC","","Clinical","","g.cm/s2","G.CM/S2","1",1,false],[false,"dyne second per centimeter","dyn.s/cm","(DYN.S)/CM","force",1,[0,-1,1,0,0,0,0],"(dyn.s)/cm","cgs",true,null,null,1,false,false,0,"(dyn*s)/cm; dyn sec per cm; seconds; centimetre; dyne seconds","LOINC","","Clinical","","g.cm/s2","G.CM/S2","1",1,false],[false,"equivalent per liter","eq/L","EQ/L","amount of substance",6.0221366999999994e+26,[-3,0,0,0,0,0,0],"eq/L","chemical",true,null,null,1,false,false,1,"eq/liter; eq/litre; eqs; equivalents per liter; litre","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"equivalent per milliliter","eq/mL","EQ/ML","amount of substance",6.0221367e+29,[-3,0,0,0,0,0,0],"eq/mL","chemical",true,null,null,1,false,false,1,"equivalent/milliliter; equivalents per milliliter; eq per mL; millilitre","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"equivalent per millimole","eq/mmol","EQ/MMOL","amount of substance",1000,[0,0,0,0,0,0,0],"eq/mmol","chemical",true,null,null,1,false,false,0,"equivalent/millimole; equivalents per millimole; eq per mmol","LOINC","SRto","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"equivalent per micromole","eq/umol","EQ/UMOL","amount of substance",1000000,[0,0,0,0,0,0,0],"eq/μmol","chemical",true,null,null,1,false,false,0,"equivalent/micromole; equivalents per micromole; eq per umol","LOINC","SRto","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[true,"femtogram","fg","FG","mass",1e-15,[0,0,1,0,0,0,0],"fg",null,false,"M",null,1,false,false,0,"fg; fgm; femtograms; weight","LOINC","Mass","Clinical","equal to 10^-15 grams",null,null,null,null,false],[false,"femtoliter","fL","FL","volume",1e-18,[3,0,0,0,0,0,0],"fL","iso1000",true,null,null,1,false,false,0,"femtolitres; femtoliters","LOINC","Vol; EntVol","Clinical","equal to 10^-15 liters","l",null,"1",1,false],[true,"femtometer","fm","FM","length",1e-15,[1,0,0,0,0,0,0],"fm",null,false,"L",null,1,false,false,0,"femtometres; femtometers","LOINC","Len","Clinical","equal to 10^-15 meters",null,null,null,null,false],[false,"femtomole","fmol","FMOL","amount of substance",602213670,[0,0,0,0,0,0,0],"fmol","si",true,null,null,1,false,false,1,"femtomoles","LOINC","EntSub","Clinical","equal to 10^-15 moles","10*23","10*23","6.0221367",6.0221367,false],[false,"femtomole per gram","fmol/g","FMOL/G","amount of substance",602213670,[0,0,-1,0,0,0,0],"fmol/g","si",true,null,null,1,false,false,1,"femtomoles; fmol/gm; fmol per gm","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"femtomole per liter","fmol/L","FMOL/L","amount of substance",602213670000,[-3,0,0,0,0,0,0],"fmol/L","si",true,null,null,1,false,false,1,"femtomoles; fmol per liter; litre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"femtomole per milligram","fmol/mg","FMOL/MG","amount of substance",602213670000,[0,0,-1,0,0,0,0],"fmol/mg","si",true,null,null,1,false,false,1,"fmol per mg; femtomoles","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"femtomole per milliliter","fmol/mL","FMOL/ML","amount of substance",602213670000000,[-3,0,0,0,0,0,0],"fmol/mL","si",true,null,null,1,false,false,1,"femtomoles; millilitre; fmol per mL; fmol per milliliter","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[true,"gram meter","g.m","G.M","mass",1,[1,0,1,0,0,0,0],"g.m",null,false,"M",null,1,false,false,0,"g*m; gxm; meters; metres","LOINC","Enrg","Clinical","Unit for measuring stroke work (heart work)",null,null,null,null,false],[true,"gram per 100 gram","g/(100.g)","G/G","mass",0.01,[0,0,0,0,0,0,0],"g/g",null,false,"M",null,1,false,false,0,"g/100 gm; 100gm; grams per 100 grams; gm per 100 gm","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"gram per 12 hour","g/(12.h)","G/HR","mass",0.000023148148148148147,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,"gm/12hrs; 12 hrs; gm per 12 hrs; 12hrs; grams per 12 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per 24 hour","g/(24.h)","G/HR","mass",0.000011574074074074073,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,"gm/24hrs; gm/24 hrs; gm per 24 hrs; 24hrs; grams per 24 hours; gm/dy; gm per dy; grams per day","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per 3 days","g/(3.d)","G/D","mass",0.000003858024691358025,[0,-1,1,0,0,0,0],"g/d",null,false,"M",null,1,false,false,0,"gm/3dy; gm/3 dy; gm per 3 days; grams","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per 4 hour","g/(4.h)","G/HR","mass",0.00006944444444444444,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,"gm/4hrs; gm/4 hrs; gm per 4 hrs; 4hrs; grams per 4 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per 48 hour","g/(48.h)","G/HR","mass",0.000005787037037037037,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,"gm/48hrs; gm/48 hrs; gm per 48 hrs; 48hrs; grams per 48 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per 5 hour","g/(5.h)","G/HR","mass",0.00005555555555555556,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,"gm/5hrs; gm/5 hrs; gm per 5 hrs; 5hrs; grams per 5 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per 6 hour","g/(6.h)","G/HR","mass",0.000046296296296296294,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,"gm/6hrs; gm/6 hrs; gm per 6 hrs; 6hrs; grams per 6 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per 72 hour","g/(72.h)","G/HR","mass",0.000003858024691358025,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,"gm/72hrs; gm/72 hrs; gm per 72 hrs; 72hrs; grams per 72 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per cubic centimeter","g/cm3","G/CM3","mass",999999.9999999999,[-3,0,1,0,0,0,0],"g/(cm<sup>3</sup>)",null,false,"M",null,1,false,false,0,"g/cm^3; gm per cm3; g per cm^3; grams per centimeter cubed; cu. cm; centimetre; g/mL; gram per milliliter; millilitre","LOINC","MCnc","Clinical","g/cm3 = g/mL",null,null,null,null,false],[true,"gram per day","g/d","G/D","mass",0.000011574074074074073,[0,-1,1,0,0,0,0],"g/d",null,false,"M",null,1,false,false,0,"gm/dy; gm per dy; grams per day; gm/24hrs; gm/24 hrs; gm per 24 hrs; 24hrs; grams per 24 hours; serving","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per deciliter","g/dL","G/DL","mass",10000,[-3,0,1,0,0,0,0],"g/dL",null,false,"M",null,1,false,false,0,"gm/dL; gm per dL; grams per deciliter; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"gram per gram","g/g","G/G","mass",1,[0,0,0,0,0,0,0],"g/g",null,false,"M",null,1,false,false,0,"gm; grams","LOINC","MRto ","Clinical","",null,null,null,null,false],[true,"gram per hour","g/h","G/HR","mass",0.0002777777777777778,[0,-1,1,0,0,0,0],"g/h",null,false,"M",null,1,false,false,0,"gm/hr; gm per hr; grams; intake; output","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per hour per square meter","g/h/m2","(G/HR)/M2","mass",0.0002777777777777778,[-2,-1,1,0,0,0,0],"(g/h)/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,"gm/hr/m2; gm/h/m2; /m^2; sq. m; g per hr per m2; grams per hours per square meter; meter squared; metre","LOINC","ArMRat","Clinical","",null,null,null,null,false],[true,"gram per kilogram","g/kg ","G/KG","mass",0.001,[0,0,0,0,0,0,0],"g/kg",null,false,"M",null,1,false,false,0,"g per kg; gram per kilograms","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"gram per kilogram per 8 hour ","g/kg/(8.h)","(G/KG)/HR","mass",3.472222222222222e-8,[0,-1,0,0,0,0,0],"(g/kg)/h",null,false,"M",null,1,false,false,0,"g/(8.kg.h); gm/kg/8hrs; 8 hrs; g per kg per 8 hrs; 8hrs; grams per kilograms per 8 hours; shift","LOINC","MCntRat; RelMRat","Clinical","unit often used to describe mass in grams of protein consumed in a 8 hours, divided by the subject's body weight in kilograms. Also used to measure mass dose rate per body mass",null,null,null,null,false],[true,"gram per kilogram per day","g/kg/d","(G/KG)/D","mass",1.1574074074074074e-8,[0,-1,0,0,0,0,0],"(g/kg)/d",null,false,"M",null,1,false,false,0,"g/(kg.d); gm/kg/dy; gm per kg per dy; grams per kilograms per day","LOINC","RelMRat","Clinical","unit often used to describe mass in grams of protein consumed in a day, divided by the subject's body weight in kilograms. Also used to measure mass dose rate per body mass",null,null,null,null,false],[true,"gram per kilogram per hour","g/kg/h","(G/KG)/HR","mass",2.7777777777777776e-7,[0,-1,0,0,0,0,0],"(g/kg)/h",null,false,"M",null,1,false,false,0,"g/(kg.h); g/kg/hr; g per kg per hrs; grams per kilograms per hour","LOINC","MCntRat; RelMRat","Clinical","unit used to measure mass dose rate per body mass",null,null,null,null,false],[true,"gram per kilogram per minute","g/kg/min","(G/KG)/MIN","mass",0.000016666666666666667,[0,-1,0,0,0,0,0],"(g/kg)/min",null,false,"M",null,1,false,false,0,"g/(kg.min); g/kg/min; g per kg per min; grams per kilograms per minute","LOINC","MCntRat; RelMRat","Clinical","unit used to measure mass dose rate per body mass",null,null,null,null,false],[true,"gram per liter","g/L","G/L","mass",1000,[-3,0,1,0,0,0,0],"g/L",null,false,"M",null,1,false,false,0,"gm per liter; g/liter; grams per liter; litre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"gram per square meter","g/m2","G/M2","mass",1,[-2,0,1,0,0,0,0],"g/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,"g/m^2; gram/square meter; g/sq m; g per m2; g per m^2; grams per square meter; meters squared; metre","LOINC","ArMass","Clinical","Tests measure myocardial mass (heart ventricle system) per body surface area; unit used to measure mass dose per body surface area",null,null,null,null,false],[true,"gram per milligram","g/mg","G/MG","mass",1000,[0,0,0,0,0,0,0],"g/mg",null,false,"M",null,1,false,false,0,"g per mg; grams per milligram","LOINC","MCnt; MRto","Clinical","",null,null,null,null,false],[true,"gram per minute","g/min","G/MIN","mass",0.016666666666666666,[0,-1,1,0,0,0,0],"g/min",null,false,"M",null,1,false,false,0,"g per min; grams per minute; gram/minute","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"gram per milliliter","g/mL","G/ML","mass",1000000,[-3,0,1,0,0,0,0],"g/mL",null,false,"M",null,1,false,false,0,"g per mL; grams per milliliter; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"gram per millimole","g/mmol","G/MMOL","mass",1.6605401866749388e-21,[0,0,1,0,0,0,0],"g/mmol",null,false,"M",null,1,false,false,-1,"grams per millimole; g per mmol","LOINC","Ratio","Clinical","",null,null,null,null,false],[false,"joule per liter","J/L","J/L","energy",1000000,[-1,-2,1,0,0,0,0],"J/L","si",true,null,null,1,false,false,0,"joules per liter; litre; J per L","LOINC","EngCnc","Clinical","","N.m","N.M","1",1,false],[true,"degree Kelvin per Watt","K/W","K/W","temperature",0.001,[-2,3,-1,0,1,0,0],"K/W",null,false,"C",null,1,false,false,0,"degree Kelvin/Watt; K per W; thermal ohm; thermal resistance; degrees","LOINC","TempEngRat","Clinical","unit for absolute thermal resistance equal to the reciprocal of thermal conductance. Unit used for tests to measure work of breathing",null,null,null,null,false],[false,"kilo international unit per liter","k[IU]/L","K[IU]/L","arbitrary",1000000,[-3,0,0,0,0,0,0],"(ki.U.)/L","chemical",true,null,null,1,false,true,0,"kIU/L; kIU per L; kIU per liter; kilo international units; litre; allergens; allergy units","LOINC","ACnc","Clinical","IgE has an WHO reference standard so IgE allergen testing can be reported as k[IU]/L","[iU]","[IU]","1",1,false],[false,"kilo international unit per milliliter","k[IU]/mL","K[IU]/ML","arbitrary",1000000000,[-3,0,0,0,0,0,0],"(ki.U.)/mL","chemical",true,null,null,1,false,true,0,"kIU/mL; kIU per mL; kIU per milliliter; kilo international units; millilitre; allergens; allergy units","LOINC","ACnc","Clinical","IgE has an WHO reference standard so IgE allergen testing can be reported as k[IU]/mL","[iU]","[IU]","1",1,false],[false,"katal per kilogram","kat/kg","KAT/KG","catalytic activity",602213670000000000000,[0,-1,-1,0,0,0,0],"kat/kg","chemical",true,null,null,1,false,false,1,"kat per kg; katals per kilogram; mol/s/kg; moles per seconds per kilogram","LOINC","CCnt","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"katal per liter","kat/L","KAT/L","catalytic activity",6.0221366999999994e+26,[-3,-1,0,0,0,0,0],"kat/L","chemical",true,null,null,1,false,false,1,"kat per L; katals per liter; litre; mol/s/L; moles per seconds per liter","LOINC","CCnc","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"kilocalorie","kcal","KCAL","energy",4184000,[2,-2,1,0,0,0,0],"kcal","heat",true,null,null,1,false,false,0,"kilogram calories; large calories; food calories; kcals","LOINC","EngRat","Clinical","It is equal to 1000 calories (equal to 4.184 kJ). But in practical usage, kcal refers to food calories which excludes caloric content in fiber and other constitutes that is not digestible by humans. Also see nutrition label Calories ([Cal])","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per 24 hour","kcal/(24.h)","KCAL/HR","energy",48.425925925925924,[2,-3,1,0,0,0,0],"kcal/h","heat",true,null,null,1,false,false,0,"kcal/24hrs; kcal/24 hrs; kcal per 24hrs; kilocalories per 24 hours; kilojoules; kJ/24hr; kJ/(24.h); kJ/dy; kilojoules per days; intake; calories burned; metabolic rate; food calories","","EngRat","Clinical","","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per ounce","kcal/[oz_av]","KCAL/[OZ_AV]","energy",147586.25679704445,[2,-2,0,0,0,0,0],"kcal/oz","heat",true,null,null,1,false,false,0,"kcal/oz; kcal per ozs; large calories per ounces; food calories; servings; international","LOINC","EngCnt","Clinical","used in nutrition to represent calorie of food","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per day","kcal/d","KCAL/D","energy",48.425925925925924,[2,-3,1,0,0,0,0],"kcal/d","heat",true,null,null,1,false,false,0,"kcal/dy; kcal per day; kilocalories per days; kilojoules; kJ/dy; kilojoules per days; intake; calories burned; metabolic rate; food calories","LOINC","EngRat","Clinical","unit in nutrition for food intake (measured in calories) in a day","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per hour","kcal/h","KCAL/HR","energy",1162.2222222222222,[2,-3,1,0,0,0,0],"kcal/h","heat",true,null,null,1,false,false,0,"kcal/hrs; kcals per hr; intake; kilocalories per hours; kilojoules","LOINC","EngRat","Clinical","used in nutrition to represent caloric requirement or consumption","cal_th","CAL_TH","1",1,false],[false,"kilocalorie per kilogram per 24 hour","kcal/kg/(24.h)","(KCAL/KG)/HR","energy",0.04842592592592593,[2,-3,0,0,0,0,0],"(kcal/kg)/h","heat",true,null,null,1,false,false,0,"kcal/kg/24hrs; 24 hrs; kcal per kg per 24hrs; kilocalories per kilograms per 24 hours; kilojoules","LOINC","EngCntRat","Clinical","used in nutrition to represent caloric requirement per day based on subject's body weight in kilograms","cal_th","CAL_TH","1",1,false],[true,"kilogram","kg","KG","mass",1000,[0,0,1,0,0,0,0],"kg",null,false,"M",null,1,false,false,0,"kilograms; kgs","LOINC","Mass","Clinical","",null,null,null,null,false],[true,"kilogram meter per second","kg.m/s","(KG.M)/S","mass",1000,[1,-1,1,0,0,0,0],"(kg.m)/s",null,false,"M",null,1,false,false,0,"kg*m/s; kg.m per sec; kg*m per sec; p; momentum","LOINC","","Clinical","unit for momentum =  mass times velocity",null,null,null,null,false],[true,"kilogram per second per square meter","kg/(s.m2)","KG/(S.M2)","mass",1000,[-2,-1,1,0,0,0,0],"kg/(s.(m<sup>2</sup>))",null,false,"M",null,1,false,false,0,"kg/(s*m2); kg/(s*m^2); kg per s per m2; per sec; per m^2; kilograms per seconds per square meter; meter squared; metre","LOINC","ArMRat","Clinical","",null,null,null,null,false],[true,"kilogram per hour","kg/h","KG/HR","mass",0.2777777777777778,[0,-1,1,0,0,0,0],"kg/h",null,false,"M",null,1,false,false,0,"kg/hr; kg per hr; kilograms per hour","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"kilogram per liter","kg/L","KG/L","mass",1000000,[-3,0,1,0,0,0,0],"kg/L",null,false,"M",null,1,false,false,0,"kg per liter; litre; kilograms","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"kilogram per square meter","kg/m2","KG/M2","mass",1000,[-2,0,1,0,0,0,0],"kg/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,"kg/m^2; kg/sq. m; kg per m2; per m^2; per sq. m; kilograms; meter squared; metre; BMI","LOINC","Ratio","Clinical","units for body mass index (BMI)",null,null,null,null,false],[true,"kilogram per cubic meter","kg/m3","KG/M3","mass",1000,[-3,0,1,0,0,0,0],"kg/(m<sup>3</sup>)",null,false,"M",null,1,false,false,0,"kg/m^3; kg/cu. m; kg per m3; per m^3; per cu. m; kilograms; meters cubed; metre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"kilogram per minute","kg/min","KG/MIN","mass",16.666666666666668,[0,-1,1,0,0,0,0],"kg/min",null,false,"M",null,1,false,false,0,"kilogram/minute; kg per min; kilograms per minute","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"kilogram per mole","kg/mol","KG/MOL","mass",1.6605401866749388e-21,[0,0,1,0,0,0,0],"kg/mol",null,false,"M",null,1,false,false,-1,"kilogram/mole; kg per mol; kilograms per mole","LOINC","SCnt","Clinical","",null,null,null,null,false],[true,"kilogram per second","kg/s","KG/S","mass",1000,[0,-1,1,0,0,0,0],"kg/s",null,false,"M",null,1,false,false,0,"kg/sec; kilogram/second; kg per sec; kilograms; second","LOINC","MRat","Clinical","",null,null,null,null,false],[false,"kiloliter","kL","KL","volume",1,[3,0,0,0,0,0,0],"kL","iso1000",true,null,null,1,false,false,0,"kiloliters; kilolitres; m3; m^3; meters cubed; metre","LOINC","Vol","Clinical","","l",null,"1",1,false],[true,"kilometer","km","KM","length",1000,[1,0,0,0,0,0,0],"km",null,false,"L",null,1,false,false,0,"kilometers; kilometres; distance","LOINC","Len","Clinical","",null,null,null,null,false],[false,"kilopascal","kPa","KPAL","pressure",1000000,[-1,-2,1,0,0,0,0],"kPa","si",true,null,null,1,false,false,0,"kilopascals; pressure","LOINC","Pres; PPresDiff","Clinical","","N/m2","N/M2","1",1,false],[true,"kilosecond","ks","KS","time",1000,[0,1,0,0,0,0,0],"ks",null,false,"T",null,1,false,false,0,"kiloseconds; ksec","LOINC","Time","Clinical","",null,null,null,null,false],[false,"kilo enzyme unit","kU","KU","catalytic activity",10036894500000000000,[0,-1,0,0,0,0,0],"kU","chemical",true,null,null,1,false,false,1,"units; mmol/min; millimoles per minute","LOINC","CAct","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 kU = 1 mmol/min","umol/min","UMOL/MIN","1",1,false],[false,"kilo enzyme unit per gram","kU/g","KU/G","catalytic activity",10036894500000000000,[0,-1,-1,0,0,0,0],"kU/g","chemical",true,null,null,1,false,false,1,"units per grams; kU per gm","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 kU = 1 mmol/min","umol/min","UMOL/MIN","1",1,false],[false,"kilo enzyme unit per liter","kU/L","KU/L","catalytic activity",1.00368945e+22,[-3,-1,0,0,0,0,0],"kU/L","chemical",true,null,null,1,false,false,1,"units per liter; litre; enzymatic activity; enzyme activity per volume; activities","LOINC","ACnc; CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 kU = 1 mmol/min","umol/min","UMOL/MIN","1",1,false],[false,"kilo enzyme unit per milliliter","kU/mL","KU/ML","catalytic activity",1.00368945e+25,[-3,-1,0,0,0,0,0],"kU/mL","chemical",true,null,null,1,false,false,1,"kU per mL; units per milliliter; millilitre; enzymatic activity per volume; enzyme activities","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 kU = 1 mmol/min","umol/min","UMOL/MIN","1",1,false],[false,"Liters per 24 hour","L/(24.h)","L/HR","volume",1.1574074074074074e-8,[3,-1,0,0,0,0,0],"L/h","iso1000",true,null,null,1,false,false,0,"L/24hrs; L/24 hrs; L per 24hrs; liters per 24 hours; day; dy; litres; volume flow rate","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per 8 hour","L/(8.h)","L/HR","volume",3.472222222222222e-8,[3,-1,0,0,0,0,0],"L/h","iso1000",true,null,null,1,false,false,0,"L/8hrs; L/8 hrs; L per 8hrs; liters per 8 hours; litres; volume flow rate; shift","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per minute per square meter","L/(min.m2) ","L/(MIN.M2)","volume",0.000016666666666666667,[1,-1,0,0,0,0,0],"L/(min.(m<sup>2</sup>))","iso1000",true,null,null,1,false,false,0,"L/(min.m2); L/min/m^2; L/min/sq. meter; L per min per m2; m^2; liters per minutes per square meter; meter squared; litres; metre ","LOINC","ArVRat","Clinical","unit for tests that measure cardiac output per body surface area (cardiac index)","l",null,"1",1,false],[false,"Liters per day","L/d","L/D","volume",1.1574074074074074e-8,[3,-1,0,0,0,0,0],"L/d","iso1000",true,null,null,1,false,false,0,"L/dy; L per day; 24hrs; 24 hrs; 24 hours; liters; litres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per hour","L/h","L/HR","volume",2.7777777777777776e-7,[3,-1,0,0,0,0,0],"L/h","iso1000",true,null,null,1,false,false,0,"L/hr; L per hr; litres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per kilogram","L/kg","L/KG","volume",0.000001,[3,0,-1,0,0,0,0],"L/kg","iso1000",true,null,null,1,false,false,0,"L per kg; litre","LOINC","VCnt","Clinical","","l",null,"1",1,false],[false,"Liters per liter","L/L","L/L","volume",1,[0,0,0,0,0,0,0],"L/L","iso1000",true,null,null,1,false,false,0,"L per L; liter/liter; litre","LOINC","VFr","Clinical","","l",null,"1",1,false],[false,"Liters per minute","L/min","L/MIN","volume",0.000016666666666666667,[3,-1,0,0,0,0,0],"L/min","iso1000",true,null,null,1,false,false,0,"liters per minute; litre","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"Liters per minute per square meter","L/min/m2","(L/MIN)/M2","volume",0.000016666666666666667,[1,-1,0,0,0,0,0],"(L/min)/(m<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,"L/(min.m2); L/min/m^2; L/min/sq. meter; L per min per m2; m^2; liters per minutes per square meter; meter squared; litres; metre ","","ArVRat","Clinical","unit for tests that measure cardiac output per body surface area (cardiac index)","l",null,"1",1,false],[false,"Liters per second","L/s","L/S","volume",0.001,[3,-1,0,0,0,0,0],"L/s","iso1000",true,null,null,1,false,false,0,"L per sec; litres","LOINC","VRat","Clinical","unit used often to measure gas flow and peak expiratory flow","l",null,"1",1,false],[false,"Liters per second per square second","L/s/s2","(L/S)/S2","volume",0.001,[3,-3,0,0,0,0,0],"(L/s)/(s<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,"L/s/s^2; L/sec/sec2; L/sec/sec^2; L/sec/sq. sec; L per s per s2; L per sec per sec2; s^2; sec^2; liters per seconds per square second; second squared; litres ","LOINC","ArVRat","Clinical","unit for tests that measure cardiac output/body surface area","l",null,"1",1,false],[false,"lumen square meter","lm.m2","LM.M2","luminous flux",1,[2,0,0,2,0,0,1],"lm.(m<sup>2</sup>)","si",true,null,null,1,false,false,0,"lm*m2; lm*m^2; lumen meters squared; lumen sq. meters; metres","LOINC","","Clinical","","cd.sr","CD.SR","1",1,false],[true,"meter per second","m/s","M/S","length",1,[1,-1,0,0,0,0,0],"m/s",null,false,"L",null,1,false,false,0,"meter/second; m per sec; meters per second; metres; velocity; speed","LOINC","Vel","Clinical","unit of velocity",null,null,null,null,false],[true,"meter per square second","m/s2","M/S2","length",1,[1,-2,0,0,0,0,0],"m/(s<sup>2</sup>)",null,false,"L",null,1,false,false,0,"m/s^2; m/sq. sec; m per s2; per s^2; meters per square second; second squared; sq second; metres; acceleration","LOINC","Accel","Clinical","unit of acceleration",null,null,null,null,false],[false,"milli international unit per liter","m[IU]/L","M[IU]/L","arbitrary",1,[-3,0,0,0,0,0,0],"(mi.U.)/L","chemical",true,null,null,1,false,true,0,"mIU/L; m IU/L; mIU per liter; units; litre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"milli  international unit per milliliter","m[IU]/mL","M[IU]/ML","arbitrary",1000.0000000000001,[-3,0,0,0,0,0,0],"(mi.U.)/mL","chemical",true,null,null,1,false,true,0,"mIU/mL; m IU/mL; mIU per mL; milli international units per milliliter; millilitre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[true,"square meter","m2","M2","length",1,[2,0,0,0,0,0,0],"m<sup>2</sup>",null,false,"L",null,1,false,false,0,"m^2; sq m; square meters; meters squared; metres","LOINC","Area","Clinical","unit often used to represent body surface area",null,null,null,null,false],[true,"square meter per second","m2/s","M2/S","length",1,[2,-1,0,0,0,0,0],"(m<sup>2</sup>)/s",null,false,"L",null,1,false,false,0,"m^2/sec; m2 per sec; m^2 per sec; sq m/sec; meters squared/seconds; sq m per sec; meters squared; metres","LOINC","ArRat","Clinical","",null,null,null,null,false],[true,"cubic meter per second","m3/s","M3/S","length",1,[3,-1,0,0,0,0,0],"(m<sup>3</sup>)/s",null,false,"L",null,1,false,false,0,"m^3/sec; m3 per sec; m^3 per sec; cu m/sec; cubic meters per seconds; meters cubed; metres","LOINC","VRat","Clinical","",null,null,null,null,false],[false,"milliampere","mA","MA","electric current",0.001,[0,-1,0,0,0,1,0],"mA","si",true,null,null,1,false,false,0,"mamp; milliamperes","LOINC","ElpotRat","Clinical","unit of electric current","C/s","C/S","1",1,false],[false,"millibar","mbar","MBAR","pressure",100000,[-1,-2,1,0,0,0,0],"mbar","iso1000",true,null,null,1,false,false,0,"millibars","LOINC","Pres","Clinical","unit of pressure","Pa","PAL","1e5",100000,false],[false,"millibar second per liter","mbar.s/L","(MBAR.S)/L","pressure",100000000,[-4,-1,1,0,0,0,0],"(mbar.s)/L","iso1000",true,null,null,1,false,false,0,"mbar*s/L; mbar.s per L; mbar*s per L; millibar seconds per liter; millibar second per litre","LOINC","","Clinical","unit to measure expiratory resistance","Pa","PAL","1e5",100000,false],[false,"millibar per liter per second","mbar/L/s","(MBAR/L)/S","pressure",100000000,[-4,-3,1,0,0,0,0],"(mbar/L)/s","iso1000",true,null,null,1,false,false,0,"mbar/(L.s); mbar/L/sec; mbar/liter/second; mbar per L per sec; mbar per liter per second; millibars per liters per seconds; litres","LOINC","PresCncRat","Clinical","unit to measure expiratory resistance","Pa","PAL","1e5",100000,false],[false,"milliequivalent","meq","MEQ","amount of substance",602213670000000000000,[0,0,0,0,0,0,0],"meq","chemical",true,null,null,1,false,false,1,"milliequivalents; meqs","LOINC","Sub","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per 2 hour","meq/(2.h)","MEQ/HR","amount of substance",83640787500000000,[0,-1,0,0,0,0,0],"meq/h","chemical",true,null,null,1,false,false,1,"meq/2hrs; meq/2 hrs; meq per 2 hrs; milliequivalents per 2 hours","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per 24 hour","meq/(24.h)","MEQ/HR","amount of substance",6970065625000000,[0,-1,0,0,0,0,0],"meq/h","chemical",true,null,null,1,false,false,1,"meq/24hrs; meq/24 hrs; meq per 24 hrs; milliequivalents per 24 hours","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per 8 hour","meq/(8.h)","MEQ/HR","amount of substance",20910196875000000,[0,-1,0,0,0,0,0],"meq/h","chemical",true,null,null,1,false,false,1,"meq/8hrs; meq/8 hrs; meq per 8 hrs; milliequivalents per 8 hours; shift","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per day","meq/d","MEQ/D","amount of substance",6970065625000000,[0,-1,0,0,0,0,0],"meq/d","chemical",true,null,null,1,false,false,1,"meq/dy; meq per day; milliquivalents per days; meq/24hrs; meq/24 hrs; meq per 24 hrs; milliequivalents per 24 hours","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per deciliter","meq/dL","MEQ/DL","amount of substance",6.022136699999999e+24,[-3,0,0,0,0,0,0],"meq/dL","chemical",true,null,null,1,false,false,1,"meq per dL; milliequivalents per deciliter; decilitre","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per gram","meq/g","MEQ/G","amount of substance",602213670000000000000,[0,0,-1,0,0,0,0],"meq/g","chemical",true,null,null,1,false,false,1,"mgq/gm; meq per gm; milliequivalents per gram","LOINC","MCnt","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per hour","meq/h","MEQ/HR","amount of substance",167281575000000000,[0,-1,0,0,0,0,0],"meq/h","chemical",true,null,null,1,false,false,1,"meq/hrs; meq per hrs; milliequivalents per hour","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per kilogram","meq/kg","MEQ/KG","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"meq/kg","chemical",true,null,null,1,false,false,1,"meq per kg; milliequivalents per kilogram","LOINC","SCnt","Clinical","equivalence equals moles per valence; used to measure dose per patient body mass","mol","MOL","1",1,false],[false,"milliequivalent per kilogram per hour","meq/kg/h","(MEQ/KG)/HR","amount of substance",167281575000000,[0,-1,-1,0,0,0,0],"(meq/kg)/h","chemical",true,null,null,1,false,false,1,"meq/(kg.h); meq/kg/hr; meq per kg per hr; milliequivalents per kilograms per hour","LOINC","SCntRat","Clinical","equivalence equals moles per valence; unit used to measure dose rate per patient body mass","mol","MOL","1",1,false],[false,"milliequivalent per liter","meq/L","MEQ/L","amount of substance",6.0221367e+23,[-3,0,0,0,0,0,0],"meq/L","chemical",true,null,null,1,false,false,1,"milliequivalents per liter; litre; meq per l; acidity","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per square meter","meq/m2","MEQ/M2","amount of substance",602213670000000000000,[-2,0,0,0,0,0,0],"meq/(m<sup>2</sup>)","chemical",true,null,null,1,false,false,1,"meq/m^2; meq/sq. m; milliequivalents per square meter; meter squared; metre","LOINC","ArSub","Clinical","equivalence equals moles per valence; note that the use of m2 in clinical units ofter refers to body surface area","mol","MOL","1",1,false],[false,"milliequivalent per minute","meq/min","MEQ/MIN","amount of substance",10036894500000000000,[0,-1,0,0,0,0,0],"meq/min","chemical",true,null,null,1,false,false,1,"meq per min; milliequivalents per minute","LOINC","SRat","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[false,"milliequivalent per milliliter","meq/mL","MEQ/ML","amount of substance",6.0221367e+26,[-3,0,0,0,0,0,0],"meq/mL","chemical",true,null,null,1,false,false,1,"meq per mL; milliequivalents per milliliter; millilitre","LOINC","SCnc","Clinical","equivalence equals moles per valence","mol","MOL","1",1,false],[true,"milligram","mg","MG","mass",0.001,[0,0,1,0,0,0,0],"mg",null,false,"M",null,1,false,false,0,"milligrams","LOINC","Mass","Clinical","",null,null,null,null,false],[true,"milligram per 10 hour","mg/(10.h)","MG/HR","mass",2.7777777777777777e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,"mg/10hrs; mg/10 hrs; mg per 10 hrs; milligrams per 10 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"milligram per 12 hour","mg/(12.h)","MG/HR","mass",2.3148148148148148e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,"mg/12hrs; mg/12 hrs; per 12 hrs; 12hrs; milligrams per 12 hours","LOINC","MRat","Clinical","units used for tests in urine",null,null,null,null,false],[true,"milligram per 2 hour","mg/(2.h)","MG/HR","mass",1.3888888888888888e-7,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,"mg/2hrs; mg/2 hrs; mg per 2 hrs; 2hrs; milligrams per 2 hours","LOINC","MRat","Clinical","units used for tests in urine",null,null,null,null,false],[true,"milligram per 24 hour","mg/(24.h)","MG/HR","mass",1.1574074074074074e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,"mg/24hrs; mg/24 hrs; milligrams per 24 hours; mg/kg/dy; mg per kg per day; milligrams per kilograms per days","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"milligram per 6 hour","mg/(6.h)","MG/HR","mass",4.6296296296296295e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,"mg/6hrs; mg/6 hrs; mg per 6 hrs; 6hrs; milligrams per 6 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"milligram per 72 hour","mg/(72.h)","MG/HR","mass",3.858024691358025e-9,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,"mg/72hrs; mg/72 hrs; 72 hrs; 72hrs; milligrams per 72 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"milligram per 8 hour","mg/(8.h)","MG/HR","mass",3.472222222222222e-8,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,"mg/8hrs; mg/8 hrs; milligrams per 8 hours; shift","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"milligram per day","mg/d","MG/D","mass",1.1574074074074074e-8,[0,-1,1,0,0,0,0],"mg/d",null,false,"M",null,1,false,false,0,"mg/24hrs; mg/24 hrs; milligrams per 24 hours; mg/dy; mg per day; milligrams","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"milligram per deciliter","mg/dL","MG/DL","mass",10,[-3,0,1,0,0,0,0],"mg/dL",null,false,"M",null,1,false,false,0,"mg per dL; milligrams per deciliter; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"milligram per gram","mg/g","MG/G","mass",0.001,[0,0,0,0,0,0,0],"mg/g",null,false,"M",null,1,false,false,0,"mg per gm; milligrams per gram","LOINC","MCnt; MRto","Clinical","",null,null,null,null,false],[true,"milligram per hour","mg/h","MG/HR","mass",2.7777777777777776e-7,[0,-1,1,0,0,0,0],"mg/h",null,false,"M",null,1,false,false,0,"mg/hr; mg per hr; milligrams","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"milligram per kilogram","mg/kg","MG/KG","mass",0.000001,[0,0,0,0,0,0,0],"mg/kg",null,false,"M",null,1,false,false,0,"mg per kg; milligrams per kilograms","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"milligram per kilogram per 8 hour","mg/kg/(8.h)","(MG/KG)/HR","mass",3.472222222222222e-11,[0,-1,0,0,0,0,0],"(mg/kg)/h",null,false,"M",null,1,false,false,0,"mg/(8.h.kg); mg/kg/8hrs; mg/kg/8 hrs; mg per kg per 8hrs; 8 hrs; milligrams per kilograms per 8 hours; shift","LOINC","RelMRat; MCntRat","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"milligram per kilogram per day","mg/kg/d","(MG/KG)/D","mass",1.1574074074074074e-11,[0,-1,0,0,0,0,0],"(mg/kg)/d",null,false,"M",null,1,false,false,0,"mg/(kg.d); mg/(kg.24.h)mg/kg/dy; mg per kg per day; milligrams per kilograms per days; mg/kg/(24.h); mg/kg/24hrs; 24 hrs; 24 hours","LOINC","RelMRat ","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"milligram per kilogram per hour","mg/kg/h","(MG/KG)/HR","mass",2.7777777777777777e-10,[0,-1,0,0,0,0,0],"(mg/kg)/h",null,false,"M",null,1,false,false,0,"mg/(kg.h); mg/kg/hr; mg per kg per hr; milligrams per kilograms per hour","LOINC","RelMRat; MCntRat","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"milligram per kilogram per minute","mg/kg/min","(MG/KG)/MIN","mass",1.6666666666666667e-8,[0,-1,0,0,0,0,0],"(mg/kg)/min",null,false,"M",null,1,false,false,0,"mg/(kg.min); mg per kg per min; milligrams per kilograms per minute","LOINC","RelMRat; MCntRat","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"milligram per liter","mg/L","MG/L","mass",1,[-3,0,1,0,0,0,0],"mg/L",null,false,"M",null,1,false,false,0,"mg per l; milligrams per liter; litre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"milligram per square meter","mg/m2","MG/M2","mass",0.001,[-2,0,1,0,0,0,0],"mg/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,"mg/m^2; mg/sq. m; mg per m2; mg per m^2; mg per sq. milligrams; meter squared; metre","LOINC","ArMass","Clinical","",null,null,null,null,false],[true,"milligram per cubic meter","mg/m3","MG/M3","mass",0.001,[-3,0,1,0,0,0,0],"mg/(m<sup>3</sup>)",null,false,"M",null,1,false,false,0,"mg/m^3; mg/cu. m; mg per m3; milligrams per cubic meter; meter cubed; metre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"milligram per milligram","mg/mg","MG/MG","mass",1,[0,0,0,0,0,0,0],"mg/mg",null,false,"M",null,1,false,false,0,"mg per mg; milligrams; milligram/milligram","LOINC","MRto","Clinical","",null,null,null,null,false],[true,"milligram per minute","mg/min","MG/MIN","mass",0.000016666666666666667,[0,-1,1,0,0,0,0],"mg/min",null,false,"M",null,1,false,false,0,"mg per min; milligrams per minutes; milligram/minute","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"milligram per milliliter","mg/mL","MG/ML","mass",1000.0000000000001,[-3,0,1,0,0,0,0],"mg/mL",null,false,"M",null,1,false,false,0,"mg per mL; milligrams per milliliters; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"milligram per millimole","mg/mmol","MG/MMOL","mass",1.660540186674939e-24,[0,0,1,0,0,0,0],"mg/mmol",null,false,"M",null,1,false,false,-1,"mg per mmol; milligrams per millimole; ","LOINC","Ratio","Clinical","",null,null,null,null,false],[true,"milligram per week","mg/wk","MG/WK","mass",1.6534391534391535e-9,[0,-1,1,0,0,0,0],"mg/wk",null,false,"M",null,1,false,false,0,"mg/week; mg per wk; milligrams per weeks; milligram/week","LOINC","Mrat","Clinical","",null,null,null,null,false],[false,"milliliter","mL","ML","volume",0.000001,[3,0,0,0,0,0,0],"mL","iso1000",true,null,null,1,false,false,0,"milliliters; millilitres","LOINC","Vol","Clinical","","l",null,"1",1,false],[false,"milliliter per 10 hour","mL/(10.h)","ML/HR","volume",2.7777777777777777e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/10hrs; ml/10 hrs; mL per 10hrs; 10 hrs; milliliters per 10 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 12 hour","mL/(12.h)","ML/HR","volume",2.3148148148148147e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/12hrs; ml/12 hrs; mL per 12hrs; 12 hrs; milliliters per 12 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 2 hour","mL/(2.h)","ML/HR","volume",1.3888888888888888e-10,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/2hrs; ml/2 hrs; mL per 2hrs; 2 hrs; milliliters per 2 hours; millilitres ","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 24 hour","mL/(24.h)","ML/HR","volume",1.1574074074074074e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/24hrs; ml/24 hrs; mL per 24hrs; 24 hrs; milliliters per 24 hours; millilitres; ml/dy; /day; ml per dy; days; fluid outputs; fluid inputs; flow rate","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 4 hour","mL/(4.h)","ML/HR","volume",6.944444444444444e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/4hrs; ml/4 hrs; mL per 4hrs; 4 hrs; milliliters per 4 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 5 hour","mL/(5.h)","ML/HR","volume",5.5555555555555553e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/5hrs; ml/5 hrs; mL per 5hrs; 5 hrs; milliliters per 5 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 6 hour","mL/(6.h)","ML/HR","volume",4.6296296296296294e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/6hrs; ml/6 hrs; mL per 6hrs; 6 hrs; milliliters per 6 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 72 hour","mL/(72.h)","ML/HR","volume",3.8580246913580245e-12,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/72hrs; ml/72 hrs; mL per 72hrs; 72 hrs; milliliters per 72 hours; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 8 hour","mL/(8.h)","ML/HR","volume",3.472222222222222e-11,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"ml/8hrs; ml/8 hrs; mL per 8hrs; 8 hrs; milliliters per 8 hours; millilitres; shift","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per 8 hour per kilogram","mL/(8.h)/kg","(ML/HR)/KG","volume",3.472222222222222e-14,[3,-1,-1,0,0,0,0],"(mL/h)/kg","iso1000",true,null,null,1,false,false,0,"mL/kg/(8.h); ml/8h/kg; ml/8 h/kg; ml/8hr/kg; ml/8 hr/kgr; mL per 8h per kg; 8 h; 8hr; 8 hr; milliliters per 8 hours per kilogram; millilitres; shift","LOINC","VRatCnt","Clinical","unit used to measure renal excretion volume rate per body mass","l",null,"1",1,false],[false,"milliliter per square inch (international)","mL/[sin_i]","ML/[SIN_I]","volume",0.0015500031000061998,[1,0,0,0,0,0,0],"mL","iso1000",true,null,null,1,false,false,0,"mL/sin; mL/in2; mL/in^2; mL per sin; in2; in^2; sq. in; milliliters per square inch; inch squared","LOINC","ArVol","Clinical","","l",null,"1",1,false],[false,"milliliter per centimeter of water","mL/cm[H2O]","ML/CM[H2O]","volume",1.0197162129779282e-11,[4,2,-1,0,0,0,0],"mL/(cm HO<sub><r>2</r></sub>)","iso1000",true,null,null,1,false,false,0,"milliliters per centimeter of water; millilitre per centimetre of water; millilitres per centimetre of water; mL/cmH2O; mL/cm H2O; mL per cmH2O; mL per cm H2O","LOINC","Compli","Clinical","unit used to measure dynamic lung compliance","l",null,"1",1,false],[false,"milliliter per day","mL/d","ML/D","volume",1.1574074074074074e-11,[3,-1,0,0,0,0,0],"mL/d","iso1000",true,null,null,1,false,false,0,"ml/day; ml per day; milliliters per day; 24 hours; 24hrs; millilitre;","LOINC","VRat","Clinical","usually used to measure fluid output or input; flow rate","l",null,"1",1,false],[false,"milliliter per deciliter","mL/dL","ML/DL","volume",0.009999999999999998,[0,0,0,0,0,0,0],"mL/dL","iso1000",true,null,null,1,false,false,0,"mL per dL; millilitres; decilitre; milliliters","LOINC","VFr; VFrDiff","Clinical","","l",null,"1",1,false],[false,"milliliter per hour","mL/h","ML/HR","volume",2.7777777777777777e-10,[3,-1,0,0,0,0,0],"mL/h","iso1000",true,null,null,1,false,false,0,"mL/hr; mL per hr; milliliters per hour; millilitres; fluid intake; fluid output","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per kilogram","mL/kg","ML/KG","volume",9.999999999999999e-10,[3,0,-1,0,0,0,0],"mL/kg","iso1000",true,null,null,1,false,false,0,"mL per kg; milliliters per kilogram; millilitres","LOINC","VCnt","Clinical","","l",null,"1",1,false],[false,"milliliter per kilogram per 8 hour","mL/kg/(8.h)","(ML/KG)/HR","volume",3.472222222222222e-14,[3,-1,-1,0,0,0,0],"(mL/kg)/h","iso1000",true,null,null,1,false,false,0,"mL/(8.h.kg); mL/kg/8hrs; mL/kg/8 hrs; mL per kg per 8hrs; 8 hrs; milliliters per kilograms per 8 hours; millilitres; shift","LOINC","VCntRat; RelEngRat","Clinical","unit used to measure renal excretion volume rate per body mass","l",null,"1",1,false],[false,"milliliter per kilogram per day","mL/kg/d","(ML/KG)/D","volume",1.1574074074074072e-14,[3,-1,-1,0,0,0,0],"(mL/kg)/d","iso1000",true,null,null,1,false,false,0,"mL/(kg.d); mL/kg/dy; mL per kg per day; milliliters per kilograms per day; mg/kg/24hrs; 24 hrs; per 24 hours millilitres","LOINC","VCntRat; RelEngRat","Clinical","unit used to measure renal excretion volume rate per body mass","l",null,"1",1,false],[false,"milliliter per kilogram per hour","mL/kg/h","(ML/KG)/HR","volume",2.7777777777777774e-13,[3,-1,-1,0,0,0,0],"(mL/kg)/h","iso1000",true,null,null,1,false,false,0,"mL/(kg.h); mL/kg/hr; mL per kg per hr; milliliters per kilograms per hour; millilitres","LOINC","VCntRat; RelEngRat","Clinical","unit used to measure renal excretion volume rate per body mass","l",null,"1",1,false],[false,"milliliter per kilogram per minute","mL/kg/min","(ML/KG)/MIN","volume",1.6666666666666664e-11,[3,-1,-1,0,0,0,0],"(mL/kg)/min","iso1000",true,null,null,1,false,false,0,"mL/(kg.min); mL/kg/dy; mL per kg per day; milliliters per kilograms per day; millilitres","LOINC","RelEngRat","Clinical","used for tests that measure activity metabolic rate compared to standard resting metabolic rate ","l",null,"1",1,false],[false,"milliliter per square meter","mL/m2","ML/M2","volume",0.000001,[1,0,0,0,0,0,0],"mL/(m<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,"mL/m^2; mL/sq. meter; mL per m2; m^2; sq. meter; milliliters per square meter; millilitres; meter squared","LOINC","ArVol","Clinical","used for tests that relate to heart work - e.g. ventricular stroke volume; atrial volume per body surface area","l",null,"1",1,false],[false,"milliliter per millibar","mL/mbar","ML/MBAR","volume",1e-11,[4,2,-1,0,0,0,0],"mL/mbar","iso1000",true,null,null,1,false,false,0,"mL per mbar; milliliters per millibar; millilitres","LOINC","","Clinical","unit used to measure dynamic lung compliance","l",null,"1",1,false],[false,"milliliter per minute","mL/min","ML/MIN","volume",1.6666666666666667e-8,[3,-1,0,0,0,0,0],"mL/min","iso1000",true,null,null,1,false,false,0,"mL per min; milliliters; millilitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"milliliter per minute per square meter","mL/min/m2","(ML/MIN)/M2","volume",1.6666666666666667e-8,[1,-1,0,0,0,0,0],"(mL/min)/(m<sup>2</sup>)","iso1000",true,null,null,1,false,false,0,"ml/min/m^2; ml/min/sq. meter; mL per min per m2; m^2; sq. meter; milliliters per minutes per square meter; millilitres; metre; meter squared","LOINC","ArVRat","Clinical","unit used to measure volume per body surface area; oxygen consumption index","l",null,"1",1,false],[false,"milliliter per millimeter","mL/mm","ML/MM","volume",0.001,[2,0,0,0,0,0,0],"mL/mm","iso1000",true,null,null,1,false,false,0,"mL per mm; milliliters per millimeter; millilitres; millimetre","LOINC","Lineic Volume","Clinical","","l",null,"1",1,false],[false,"milliliter per second","mL/s","ML/S","volume",0.000001,[3,-1,0,0,0,0,0],"mL/s","iso1000",true,null,null,1,false,false,0,"ml/sec; mL per sec; milliliters per second; millilitres","LOINC","Vel; VelRat; VRat","Clinical","","l",null,"1",1,false],[true,"millimeter","mm","MM","length",0.001,[1,0,0,0,0,0,0],"mm",null,false,"L",null,1,false,false,0,"millimeters; millimetres; height; length; diameter; thickness; axis; curvature; size","LOINC","Len","Clinical","",null,null,null,null,false],[true,"millimeter per hour","mm/h","MM/HR","length",2.7777777777777776e-7,[1,-1,0,0,0,0,0],"mm/h",null,false,"L",null,1,false,false,0,"mm/hr; mm per hr; millimeters per hour; millimetres","LOINC","Vel","Clinical","unit to measure sedimentation rate",null,null,null,null,false],[true,"millimeter per minute","mm/min","MM/MIN","length",0.000016666666666666667,[1,-1,0,0,0,0,0],"mm/min",null,false,"L",null,1,false,false,0,"mm per min; millimeters per minute; millimetres","LOINC","Vel","Clinical","",null,null,null,null,false],[false,"millimeter of water","mm[H2O]","MM[H2O]","pressure",9806.65,[-1,-2,1,0,0,0,0],"mm HO<sub><r>2</r></sub>","clinical",true,null,null,1,false,false,0,"mmH2O; mm H2O; millimeters of water; millimetres","LOINC","Pres","Clinical","","kPa","KPAL","980665e-5",9.80665,false],[false,"millimeter of mercury","mm[Hg]","MM[HG]","pressure",133322,[-1,-2,1,0,0,0,0],"mm Hg","clinical",true,null,null,1,false,false,0,"mmHg; mm Hg; millimeters of mercury; millimetres","LOINC","Pres; PPres; Ratio","Clinical","1 mm[Hg] = 1 torr; unit to measure blood pressure","kPa","KPAL","133.3220",133.322,false],[true,"square millimeter","mm2","MM2","length",0.000001,[2,0,0,0,0,0,0],"mm<sup>2</sup>",null,false,"L",null,1,false,false,0,"mm^2; sq. mm.; sq. millimeters; millimeters squared; millimetres","LOINC","Area","Clinical","",null,null,null,null,false],[false,"millimole","mmol","MMOL","amount of substance",602213670000000000000,[0,0,0,0,0,0,0],"mmol","si",true,null,null,1,false,false,1,"millimoles","LOINC","Sub","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 12 hour","mmol/(12.h)","MMOL/HR","amount of substance",13940131250000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,"mmol/12hrs; mmol/12 hrs; mmol per 12 hrs; 12hrs; millimoles per 12 hours","LOINC","SRat","Clinical","unit for tests related to urine","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 2 hour","mmol/(2.h)","MMOL/HR","amount of substance",83640787500000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,"mmol/2hrs; mmol/2 hrs; mmol per 2 hrs; 2hrs; millimoles per 2 hours","LOINC","SRat","Clinical","unit for tests related to urine","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 24 hour","mmol/(24.h)","MMOL/HR","amount of substance",6970065625000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,"mmol/24hrs; mmol/24 hrs; mmol per 24 hrs; 24hrs; millimoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 5 hour","mmol/(5.h)","MMOL/HR","amount of substance",33456315000000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,"mmol/5hrs; mmol/5 hrs; mmol per 5 hrs; 5hrs; millimoles per 5 hours","LOINC","SRat","Clinical","unit for tests related to doses","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 6 hour","mmol/(6.h)","MMOL/HR","amount of substance",27880262500000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,"mmol/6hrs; mmol/6 hrs; mmol per 6 hrs; 6hrs; millimoles per 6 hours","LOINC","SRat","Clinical","unit for tests related to urine","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per 8 hour","mmol/(8.h)","MMOL/HR","amount of substance",20910196875000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,"mmol/8hrs; mmol/8 hrs; mmol per 8 hrs; 8hrs; millimoles per 8 hours; shift","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per day","mmol/d","MMOL/D","amount of substance",6970065625000000,[0,-1,0,0,0,0,0],"mmol/d","si",true,null,null,1,false,false,1,"mmol/24hrs; mmol/24 hrs; mmol per 24 hrs; 24hrs; millimoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per deciliter","mmol/dL","MMOL/DL","amount of substance",6.022136699999999e+24,[-3,0,0,0,0,0,0],"mmol/dL","si",true,null,null,1,false,false,1,"mmol per dL; millimoles; decilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per gram","mmol/g","MMOL/G","amount of substance",602213670000000000000,[0,0,-1,0,0,0,0],"mmol/g","si",true,null,null,1,false,false,1,"mmol per gram; millimoles","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per hour","mmol/h","MMOL/HR","amount of substance",167281575000000000,[0,-1,0,0,0,0,0],"mmol/h","si",true,null,null,1,false,false,1,"mmol/hr; mmol per hr; millimoles per hour","LOINC","SRat","Clinical","unit for tests related to urine","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram","mmol/kg","MMOL/KG","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"mmol/kg","si",true,null,null,1,false,false,1,"mmol per kg; millimoles per kilogram","LOINC","SCnt","Clinical","unit for tests related to stool","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram per 8 hour","mmol/kg/(8.h)","(MMOL/KG)/HR","amount of substance",20910196875000,[0,-1,-1,0,0,0,0],"(mmol/kg)/h","si",true,null,null,1,false,false,1,"mmol/(8.h.kg); mmol/kg/8hrs; mmol/kg/8 hrs; mmol per kg per 8hrs; 8 hrs; millimoles per kilograms per 8 hours; shift","LOINC","CCnt","Clinical","unit used to measure molar dose rate per patient body mass","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram per day","mmol/kg/d","(MMOL/KG)/D","amount of substance",6970065625000,[0,-1,-1,0,0,0,0],"(mmol/kg)/d","si",true,null,null,1,false,false,1,"mmol/kg/dy; mmol/kg/day; mmol per kg per dy; millimoles per kilograms per day","LOINC","RelSRat","Clinical","unit used to measure molar dose rate per patient body mass","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram per hour","mmol/kg/h","(MMOL/KG)/HR","amount of substance",167281575000000,[0,-1,-1,0,0,0,0],"(mmol/kg)/h","si",true,null,null,1,false,false,1,"mmol/kg/hr; mmol per kg per hr; millimoles per kilograms per hour","LOINC","CCnt","Clinical","unit used to measure molar dose rate per patient body mass","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per kilogram per minute","mmol/kg/min","(MMOL/KG)/MIN","amount of substance",10036894500000000,[0,-1,-1,0,0,0,0],"(mmol/kg)/min","si",true,null,null,1,false,false,1,"mmol/(kg.min); mmol/kg/min; mmol per kg per min; millimoles per kilograms per minute","LOINC","CCnt","Clinical","unit used to measure molar dose rate per patient body mass; note that the unit for the enzyme unit U = umol/min. mmol/kg/min = kU/kg; ","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per liter","mmol/L","MMOL/L","amount of substance",6.0221367e+23,[-3,0,0,0,0,0,0],"mmol/L","si",true,null,null,1,false,false,1,"mmol per L; millimoles per liter; litre","LOINC","SCnc","Clinical","unit for tests related to doses","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per square meter","mmol/m2","MMOL/M2","amount of substance",602213670000000000000,[-2,0,0,0,0,0,0],"mmol/(m<sup>2</sup>)","si",true,null,null,1,false,false,1,"mmol/m^2; mmol/sq. meter; mmol per m2; m^2; sq. meter; millimoles; meter squared; metre","LOINC","ArSub","Clinical","unit used to measure molar dose per patient body surface area","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per minute","mmol/min","MMOL/MIN","amount of substance",10036894500000000000,[0,-1,0,0,0,0,0],"mmol/min","si",true,null,null,1,false,false,1,"mmol per min; millimoles per minute","LOINC","Srat; CAct","Clinical","unit for the enzyme unit U = umol/min. mmol/min = kU","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per millimole","mmol/mmol","MMOL/MMOL","amount of substance",1,[0,0,0,0,0,0,0],"mmol/mmol","si",true,null,null,1,false,false,0,"mmol per mmol; millimoles per millimole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per mole","mmol/mol","MMOL/MOL","amount of substance",0.001,[0,0,0,0,0,0,0],"mmol/mol","si",true,null,null,1,false,false,0,"mmol per mol; millimoles per mole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"millimole per second per liter","mmol/s/L","(MMOL/S)/L","amount of substance",6.0221367e+23,[-3,-1,0,0,0,0,0],"(mmol/s)/L","si",true,null,null,1,false,false,1,"mmol/sec/L; mmol per s per L; per sec; millimoles per seconds per liter; litre","LOINC","CCnc ","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per kilogram","mol/kg","MOL/KG","amount of substance",602213670000000000000,[0,0,-1,0,0,0,0],"mol/kg","si",true,null,null,1,false,false,1,"mol per kg; moles; mols","LOINC","SCnt","Clinical","unit for tests related to stool","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per kilogram per second","mol/kg/s","(MOL/KG)/S","amount of substance",602213670000000000000,[0,-1,-1,0,0,0,0],"(mol/kg)/s","si",true,null,null,1,false,false,1,"mol/kg/sec; mol per kg per sec; moles per kilograms per second; mols","LOINC","CCnt","Clinical","unit of catalytic activity (mol/s) per mass (kg)","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per liter","mol/L","MOL/L","amount of substance",6.0221366999999994e+26,[-3,0,0,0,0,0,0],"mol/L","si",true,null,null,1,false,false,1,"mol per L; moles per liter; litre; moles; mols","LOINC","SCnc","Clinical","unit often used in tests measuring oxygen content","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per cubic meter","mol/m3","MOL/M3","amount of substance",6.0221367e+23,[-3,0,0,0,0,0,0],"mol/(m<sup>3</sup>)","si",true,null,null,1,false,false,1,"mol/m^3; mol/cu. m; mol per m3; m^3; cu. meter; mols; moles; meters cubed; metre; mole per kiloliter; kilolitre; mol/kL","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per milliliter","mol/mL","MOL/ML","amount of substance",6.0221367e+29,[-3,0,0,0,0,0,0],"mol/mL","si",true,null,null,1,false,false,1,"mol per mL; moles; millilitre; mols","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per mole","mol/mol","MOL/MOL","amount of substance",1,[0,0,0,0,0,0,0],"mol/mol","si",true,null,null,1,false,false,0,"mol per mol; moles per mol; mols","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"mole per second","mol/s","MOL/S","amount of substance",6.0221367e+23,[0,-1,0,0,0,0,0],"mol/s","si",true,null,null,1,false,false,1,"mol per sec; moles per second; mols","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"milliosmole","mosm","MOSM","amount of substance (dissolved particles)",602213670000000000000,[0,0,0,0,0,0,0],"mosm","chemical",true,null,null,1,false,false,1,"milliosmoles","LOINC","Osmol","Clinical","equal to 1/1000 of an osmole","mol","MOL","1",1,false],[false,"milliosmole per kilogram","mosm/kg","MOSM/KG","amount of substance (dissolved particles)",602213670000000000,[0,0,-1,0,0,0,0],"mosm/kg","chemical",true,null,null,1,false,false,1,"mosm per kg; milliosmoles per kilogram","LOINC","Osmol","Clinical","","mol","MOL","1",1,false],[false,"milliosmole per liter","mosm/L","MOSM/L","amount of substance (dissolved particles)",6.0221367e+23,[-3,0,0,0,0,0,0],"mosm/L","chemical",true,null,null,1,false,false,1,"mosm per liter; litre; milliosmoles","LOINC","Osmol","Clinical","","mol","MOL","1",1,false],[false,"millipascal","mPa","MPAL","pressure",1,[-1,-2,1,0,0,0,0],"mPa","si",true,null,null,1,false,false,0,"millipascals","LOINC","Pres","Clinical","unit of pressure","N/m2","N/M2","1",1,false],[false,"millipascal second","mPa.s","MPAL.S","pressure",1,[-1,-1,1,0,0,0,0],"mPa.s","si",true,null,null,1,false,false,0,"mPa*s; millipoise; mP; dynamic viscosity","LOINC","Visc","Clinical","base units for millipoise, a measurement of dynamic viscosity","N/m2","N/M2","1",1,false],[true,"megasecond","Ms","MAS","time",1000000,[0,1,0,0,0,0,0],"Ms",null,false,"T",null,1,false,false,0,"megaseconds","LOINC","Time","Clinical","",null,null,null,null,false],[true,"millisecond","ms","MS","time",0.001,[0,1,0,0,0,0,0],"ms",null,false,"T",null,1,false,false,0,"milliseconds; duration","LOINC","Time","Clinical","",null,null,null,null,false],[false,"milli enzyme unit per gram","mU/g","MU/G","catalytic activity",10036894500000,[0,-1,-1,0,0,0,0],"mU/g","chemical",true,null,null,1,false,false,1,"mU per gm; milli enzyme units per gram; enzyme activity; enzymatic activity per mass","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"milli enzyme unit per liter","mU/L","MU/L","catalytic activity",10036894500000000,[-3,-1,0,0,0,0,0],"mU/L","chemical",true,null,null,1,false,false,1,"mU per liter; litre; milli enzyme units enzymatic activity per volume; enzyme activity","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"milli enzyme unit per milligram","mU/mg","MU/MG","catalytic activity",10036894500000000,[0,-1,-1,0,0,0,0],"mU/mg","chemical",true,null,null,1,false,false,1,"mU per mg; milli enzyme units per milligram","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"milli enzyme unit per milliliter","mU/mL","MU/ML","catalytic activity",10036894500000000000,[-3,-1,0,0,0,0,0],"mU/mL","chemical",true,null,null,1,false,false,1,"mU per mL; milli enzyme units per milliliter; millilitre; enzymatic activity per volume; enzyme activity","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"milli enzyme unit per milliliter per minute","mU/mL/min","(MU/ML)/MIN","catalytic activity",167281575000000000,[-3,-2,0,0,0,0,0],"(mU/mL)/min","chemical",true,null,null,1,false,false,1,"mU per mL per min; mU per milliliters per minute; millilitres; milli enzyme units; enzymatic activity; enzyme activity","LOINC","CCncRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 mU = 1 nmol/min","umol/min","UMOL/MIN","1",1,false],[false,"millivolt","mV","MV","electric potential",1,[2,-2,1,0,0,-1,0],"mV","si",true,null,null,1,false,false,0,"millivolts","LOINC","Elpot","Clinical","unit of electric potential (voltage)","J/C","J/C","1",1,false],[false,"Newton centimeter","N.cm","N.CM","force",10,[2,-2,1,0,0,0,0],"N.cm","si",true,null,null,1,false,false,0,"N*cm; Ncm; N cm; Newton*centimeters; Newton* centimetres; torque; work","LOINC","","Clinical","as a measurement of work, N.cm = 1/100 Joules;\nnote that N.m is the standard unit of measurement for torque (although dimensionally equivalent to Joule), and N.cm can also be thought of as a torqe unit","kg.m/s2","KG.M/S2","1",1,false],[false,"Newton second","N.s","N.S","force",1000,[1,-1,1,0,0,0,0],"N.s","si",true,null,null,1,false,false,0,"Newton*seconds; N*s; N s; Ns; impulse; imp","LOINC","","Clinical","standard unit of impulse","kg.m/s2","KG.M/S2","1",1,false],[true,"nanogram","ng","NG","mass",1e-9,[0,0,1,0,0,0,0],"ng",null,false,"M",null,1,false,false,0,"nanograms","LOINC","Mass","Clinical","",null,null,null,null,false],[true,"nanogram per 24 hour","ng/(24.h)","NG/HR","mass",1.1574074074074075e-14,[0,-1,1,0,0,0,0],"ng/h",null,false,"M",null,1,false,false,0,"ng/24hrs; ng/24 hrs; nanograms per 24 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"nanogram per 8 hour","ng/(8.h)","NG/HR","mass",3.4722222222222224e-14,[0,-1,1,0,0,0,0],"ng/h",null,false,"M",null,1,false,false,0,"ng/8hrs; ng/8 hrs; nanograms per 8 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"nanogram per million","ng/10*6","NG/(10*6)","mass",1e-15,[0,0,1,0,0,0,0],"ng/(10<sup>6</sup>)",null,false,"M",null,1,false,false,0,"ng/10^6; ng per 10*6; 10^6; nanograms","LOINC","MNum","Clinical","",null,null,null,null,false],[true,"nanogram per day","ng/d","NG/D","mass",1.1574074074074075e-14,[0,-1,1,0,0,0,0],"ng/d",null,false,"M",null,1,false,false,0,"ng/dy; ng per day; nanograms ","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"nanogram per deciliter","ng/dL","NG/DL","mass",0.00001,[-3,0,1,0,0,0,0],"ng/dL",null,false,"M",null,1,false,false,0,"ng per dL; nanograms per deciliter; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"nanogram per gram","ng/g","NG/G","mass",1e-9,[0,0,0,0,0,0,0],"ng/g",null,false,"M",null,1,false,false,0,"ng/gm; ng per gm; nanograms per gram","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"nanogram per hour","ng/h","NG/HR","mass",2.777777777777778e-13,[0,-1,1,0,0,0,0],"ng/h",null,false,"M",null,1,false,false,0,"ng/hr; ng per hr; nanograms per hour","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"nanogram per kilogram","ng/kg","NG/KG","mass",1e-12,[0,0,0,0,0,0,0],"ng/kg",null,false,"M",null,1,false,false,0,"ng per kg; nanograms per kilogram","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"nanogram per kilogram per 8 hour","ng/kg/(8.h)","(NG/KG)/HR","mass",3.472222222222222e-17,[0,-1,0,0,0,0,0],"(ng/kg)/h",null,false,"M",null,1,false,false,0,"ng/(8.h.kg); ng/kg/8hrs; ng/kg/8 hrs; ng per kg per 8hrs; 8 hrs; nanograms per kilograms per 8 hours; shift","LOINC","MRtoRat ","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"nanogram per kilogram per hour","ng/kg/h","(NG/KG)/HR","mass",2.7777777777777775e-16,[0,-1,0,0,0,0,0],"(ng/kg)/h",null,false,"M",null,1,false,false,0,"ng/(kg.h); ng/kg/hr; ng per kg per hr; nanograms per kilograms per hour","LOINC","MRtoRat ","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"nanogram per kilogram per minute","ng/kg/min","(NG/KG)/MIN","mass",1.6666666666666667e-14,[0,-1,0,0,0,0,0],"(ng/kg)/min",null,false,"M",null,1,false,false,0,"ng/(kg.min); ng per kg per min; nanograms per kilograms per minute","LOINC","MRtoRat ","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"nanogram per liter","ng/L","NG/L","mass",0.000001,[-3,0,1,0,0,0,0],"ng/L",null,false,"M",null,1,false,false,0,"ng per L; nanograms per liter; litre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"nanogram per square meter","ng/m2","NG/M2","mass",1e-9,[-2,0,1,0,0,0,0],"ng/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,"ng/m^2; ng/sq. m; ng per m2; m^2; sq. meter; nanograms; meter squared; metre","LOINC","ArMass","Clinical","unit used to measure mass dose per patient body surface area",null,null,null,null,false],[true,"nanogram per milligram","ng/mg","NG/MG","mass",0.000001,[0,0,0,0,0,0,0],"ng/mg",null,false,"M",null,1,false,false,0,"ng per mg; nanograms","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"nanogram per milligram per hour","ng/mg/h","(NG/MG)/HR","mass",2.7777777777777777e-10,[0,-1,0,0,0,0,0],"(ng/mg)/h",null,false,"M",null,1,false,false,0,"ng/mg/hr; ng per mg per hr; nanograms per milligrams per hour","LOINC","MRtoRat ","Clinical","",null,null,null,null,false],[true,"nanogram per minute","ng/min","NG/MIN","mass",1.6666666666666667e-11,[0,-1,1,0,0,0,0],"ng/min",null,false,"M",null,1,false,false,0,"ng per min; nanograms","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"nanogram per millliiter","ng/mL","NG/ML","mass",0.001,[-3,0,1,0,0,0,0],"ng/mL",null,false,"M",null,1,false,false,0,"ng per mL; nanograms; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"nanogram per milliliter per hour","ng/mL/h","(NG/ML)/HR","mass",2.7777777777777776e-7,[-3,-1,1,0,0,0,0],"(ng/mL)/h",null,false,"M",null,1,false,false,0,"ng/mL/hr; ng per mL per mL; nanograms per milliliter per hour; nanogram per millilitre per hour; nanograms per millilitre per hour; enzymatic activity per volume; enzyme activity per milliliters","LOINC","CCnc","Clinical","tests that measure enzymatic activity",null,null,null,null,false],[true,"nanogram per second","ng/s","NG/S","mass",1e-9,[0,-1,1,0,0,0,0],"ng/s",null,false,"M",null,1,false,false,0,"ng/sec; ng per sec; nanograms per second","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"nanogram per enzyme unit","ng/U","NG/U","mass",9.963241120049634e-26,[0,1,1,0,0,0,0],"ng/U",null,false,"M",null,1,false,false,-1,"ng per U; nanograms per enzyme unit","LOINC","CMass","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)",null,null,null,null,false],[false,"nanokatal","nkat","NKAT","catalytic activity",602213670000000,[0,-1,0,0,0,0,0],"nkat","chemical",true,null,null,1,false,false,1,"nanokatals","LOINC","CAct","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"nanoliter","nL","NL","volume",1.0000000000000002e-12,[3,0,0,0,0,0,0],"nL","iso1000",true,null,null,1,false,false,0,"nanoliters; nanolitres","LOINC","Vol","Clinical","","l",null,"1",1,false],[true,"nanometer","nm","NM","length",1e-9,[1,0,0,0,0,0,0],"nm",null,false,"L",null,1,false,false,0,"nanometers; nanometres","LOINC","Len","Clinical","",null,null,null,null,false],[true,"nanometer per second per liter","nm/s/L","(NM/S)/L","length",0.000001,[-2,-1,0,0,0,0,0],"(nm/s)/L",null,false,"L",null,1,false,false,0,"nm/sec/liter; nm/sec/litre; nm per s per l; nm per sec per l; nanometers per second per liter; nanometre per second per litre; nanometres per second per litre","LOINC","VelCnc","Clinical","",null,null,null,null,false],[false,"nanomole","nmol","NMOL","amount of substance",602213670000000,[0,0,0,0,0,0,0],"nmol","si",true,null,null,1,false,false,1,"nanomoles","LOINC","Sub","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per 24 hour","nmol/(24.h)","NMOL/HR","amount of substance",6970065625,[0,-1,0,0,0,0,0],"nmol/h","si",true,null,null,1,false,false,1,"nmol/24hr; nmol/24 hr; nanomoles per 24 hours; nmol/day; nanomoles per day; nmol per day; nanomole/day; nanomol/day","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per day","nmol/d","NMOL/D","amount of substance",6970065625,[0,-1,0,0,0,0,0],"nmol/d","si",true,null,null,1,false,false,1,"nmol/day; nanomoles per day; nmol per day; nanomole/day; nanomol/day; nmol/24hr; nmol/24 hr; nanomoles per 24 hours; ","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per deciliter","nmol/dL","NMOL/DL","amount of substance",6022136700000000000,[-3,0,0,0,0,0,0],"nmol/dL","si",true,null,null,1,false,false,1,"nmol per dL; nanomoles per deciliter; nanomole per decilitre; nanomoles per decilitre; nanomole/deciliter; nanomole/decilitre; nanomol/deciliter; nanomol/decilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per gram","nmol/g","NMOL/G","amount of substance",602213670000000,[0,0,-1,0,0,0,0],"nmol/g","si",true,null,null,1,false,false,1,"nmol per gram; nanomoles per gram; nanomole/gram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per hour per liter","nmol/h/L","(NMOL/HR)/L","amount of substance",167281575000000,[-3,-1,0,0,0,0,0],"(nmol/h)/L","si",true,null,null,1,false,false,1,"nmol/hrs/L; nmol per hrs per L; nanomoles per hours per liter; litre; enzymatic activity per volume; enzyme activities","LOINC","CCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per liter","nmol/L","NMOL/L","amount of substance",602213670000000000,[-3,0,0,0,0,0,0],"nmol/L","si",true,null,null,1,false,false,1,"nmol per L; nanomoles per liter; litre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milligram","nmol/mg","NMOL/MG","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"nmol/mg","si",true,null,null,1,false,false,1,"nmol per mg; nanomoles per milligram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milligram per hour","nmol/mg/h","(NMOL/MG)/HR","amount of substance",167281575000000,[0,-1,-1,0,0,0,0],"(nmol/mg)/h","si",true,null,null,1,false,false,1,"nmol/mg/hr; nmol per mg per hr; nanomoles per milligrams per hour","LOINC","SCntRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milligram of protein","nmol/mg{prot}","NMOL/MG","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"nmol/mg","si",true,null,null,1,false,false,1,"nanomoles; nmol/mg prot; nmol per mg prot","LOINC","Ratio; CCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per minute","nmol/min","NMOL/MIN","amount of substance",10036894500000,[0,-1,0,0,0,0,0],"nmol/min","si",true,null,null,1,false,false,1,"nmol per min; nanomoles per minute; milli enzyme units; enzyme activity per volume; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. nmol/min = mU (milli enzyme unit)","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per minute per milliliter","nmol/min/mL","(NMOL/MIN)/ML","amount of substance",10036894500000000000,[-3,-1,0,0,0,0,0],"(nmol/min)/mL","si",true,null,null,1,false,false,1,"nmol per min per mL; nanomoles per minutes per milliliter; millilitre; milli enzyme units per volume; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. nmol/mL/min = mU/mL","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milliliter","nmol/mL","NMOL/ML","amount of substance",602213670000000000000,[-3,0,0,0,0,0,0],"nmol/mL","si",true,null,null,1,false,false,1,"nmol per mL; nanomoles per milliliter; millilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milliliter per hour","nmol/mL/h","(NMOL/ML)/HR","amount of substance",167281575000000000,[-3,-1,0,0,0,0,0],"(nmol/mL)/h","si",true,null,null,1,false,false,1,"nmol/mL/hr; nmol per mL per hr; nanomoles per milliliters per hour; millilitres; milli enzyme units per volume; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min.","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per milliliter per minute","nmol/mL/min","(NMOL/ML)/MIN","amount of substance",10036894500000000000,[-3,-1,0,0,0,0,0],"(nmol/mL)/min","si",true,null,null,1,false,false,1,"nmol per mL per min; nanomoles per milliliters per min; millilitres; milli enzyme units per volume; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. nmol/mL/min = mU/mL","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per millimole","nmol/mmol","NMOL/MMOL","amount of substance",0.000001,[0,0,0,0,0,0,0],"nmol/mmol","si",true,null,null,1,false,false,0,"nmol per mmol; nanomoles per millimole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per millimole of creatinine","nmol/mmol{creat}","NMOL/MMOL","amount of substance",0.000001,[0,0,0,0,0,0,0],"nmol/mmol","si",true,null,null,1,false,false,0,"nanomoles","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per mole","nmol/mol","NMOL/MOL","amount of substance",1e-9,[0,0,0,0,0,0,0],"nmol/mol","si",true,null,null,1,false,false,0,"nmol per mole; nanomoles","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per nanomole","nmol/nmol","NMOL/NMOL","amount of substance",1,[0,0,0,0,0,0,0],"nmol/nmol","si",true,null,null,1,false,false,0,"nmol per nmol; nanomoles","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per second","nmol/s","NMOL/S","amount of substance",602213670000000,[0,-1,0,0,0,0,0],"nmol/s","si",true,null,null,1,false,false,1,"nmol/sec; nmol per sec; nanomoles per sercond; milli enzyme units; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min.","10*23","10*23","6.0221367",6.0221367,false],[false,"nanomole per second per liter","nmol/s/L","(NMOL/S)/L","amount of substance",602213670000000000,[-3,-1,0,0,0,0,0],"(nmol/s)/L","si",true,null,null,1,false,false,1,"nmol/sec/L; nmol per s per L; nmol per sec per L; nanomoles per seconds per liter; litre; milli enzyme units per volume; enzyme activity; enzymatic activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min.","10*23","10*23","6.0221367",6.0221367,false],[true,"nanosecond","ns","NS","time",1e-9,[0,1,0,0,0,0,0],"ns",null,false,"T",null,1,false,false,0,"nanoseconds","LOINC","Time","Clinical","",null,null,null,null,false],[false,"nanoenzyme unit per milliliter","nU/mL","NU/ML","catalytic activity",10036894500000,[-3,-1,0,0,0,0,0],"nU/mL","chemical",true,null,null,1,false,false,1,"nU per mL; nanoenzyme units per milliliter; millilitre; enzymatic activity per volume; enzyme activity","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 fU = pmol/min","umol/min","UMOL/MIN","1",1,false],[false,"Ohm meter","Ohm.m","OHM.M","electric resistance",1000,[3,-1,1,0,0,-2,0],"Ω.m","si",true,null,null,1,false,false,0,"electric resistivity; meters; metres","LOINC","","Clinical","unit of electric resistivity","V/A","V/A","1",1,false],[false,"osmole per kilogram","osm/kg","OSM/KG","amount of substance (dissolved particles)",602213670000000000000,[0,0,-1,0,0,0,0],"osm/kg","chemical",true,null,null,1,false,false,1,"osm per kg; osmoles per kilogram; osmols","LOINC","Osmol","Clinical","","mol","MOL","1",1,false],[false,"osmole per liter","osm/L","OSM/L","amount of substance (dissolved particles)",6.0221366999999994e+26,[-3,0,0,0,0,0,0],"osm/L","chemical",true,null,null,1,false,false,1,"osm per L; osmoles per liter; litre; osmols","LOINC","Osmol","Clinical","","mol","MOL","1",1,false],[false,"picoampere","pA","PA","electric current",1e-12,[0,-1,0,0,0,1,0],"pA","si",true,null,null,1,false,false,0,"picoamperes","LOINC","","Clinical","equal to 10^-12 amperes","C/s","C/S","1",1,false],[true,"picogram","pg","PG","mass",1e-12,[0,0,1,0,0,0,0],"pg",null,false,"M",null,1,false,false,0,"picograms","LOINC","Mass; EntMass","Clinical","",null,null,null,null,false],[true,"picogram per deciliter","pg/dL","PG/DL","mass",9.999999999999999e-9,[-3,0,1,0,0,0,0],"pg/dL",null,false,"M",null,1,false,false,0,"pg per dL; picograms; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"picogram per liter","pg/L","PG/L","mass",1e-9,[-3,0,1,0,0,0,0],"pg/L",null,false,"M",null,1,false,false,0,"pg per L; picograms; litre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"picogram per milligram","pg/mg","PG/MG","mass",1e-9,[0,0,0,0,0,0,0],"pg/mg",null,false,"M",null,1,false,false,0,"pg per mg; picograms","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"picogram per milliliter","pg/mL","PG/ML","mass",0.000001,[-3,0,1,0,0,0,0],"pg/mL",null,false,"M",null,1,false,false,0,"pg per mL; picograms per milliliter; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"picogram per millimeter","pg/mm","PG/MM","mass",1e-9,[-1,0,1,0,0,0,0],"pg/mm",null,false,"M",null,1,false,false,0,"pg per mm; picogram/millimeter; picogram/millimetre; picograms per millimeter; millimetre","LOINC","Lineic Mass","Clinical","",null,null,null,null,false],[false,"picokatal","pkat","PKAT","catalytic activity",602213670000,[0,-1,0,0,0,0,0],"pkat","chemical",true,null,null,1,false,false,1,"pkats; picokatals","LOINC","CAct","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"picoliter","pL","PL","volume",1e-15,[3,0,0,0,0,0,0],"pL","iso1000",true,null,null,1,false,false,0,"picoliters; picolitres","LOINC","Vol","Clinical","","l",null,"1",1,false],[true,"picometer","pm","PM","length",1e-12,[1,0,0,0,0,0,0],"pm",null,false,"L",null,1,false,false,0,"picometers; picometres","LOINC","Len","Clinical","",null,null,null,null,false],[false,"picomole","pmol","PMOL","amount of substance",602213670000,[0,0,0,0,0,0,0],"pmol","si",true,null,null,1,false,false,1,"picomoles; pmols","LOINC","Sub","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per 24 hour","pmol/(24.h)","PMOL/HR","amount of substance",6970065.625,[0,-1,0,0,0,0,0],"pmol/h","si",true,null,null,1,false,false,1,"pmol/24hrs; pmol/24 hrs; pmol per 24 hrs; 24hrs; days; dy; picomoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per day","pmol/d","PMOL/D","amount of substance",6970065.625,[0,-1,0,0,0,0,0],"pmol/d","si",true,null,null,1,false,false,1,"pmol/dy; pmol per day; 24 hours; 24hrs; 24 hrs; picomoles","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per deciliter","pmol/dL","PMOL/DL","amount of substance",6022136700000000,[-3,0,0,0,0,0,0],"pmol/dL","si",true,null,null,1,false,false,1,"pmol per dL; picomoles per deciliter; decilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per gram","pmol/g","PMOL/G","amount of substance",602213670000,[0,0,-1,0,0,0,0],"pmol/g","si",true,null,null,1,false,false,1,"pmol per gm; picomoles per gram; picomole/gram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per hour per milliliter ","pmol/h/mL","(PMOL/HR)/ML","amount of substance",167281575000000,[-3,-1,0,0,0,0,0],"(pmol/h)/mL","si",true,null,null,1,false,false,1,"pmol/hrs/mL; pmol per hrs per mL; picomoles per hour per milliliter; millilitre; micro enzyme units per volume; enzymatic activity; enzyme activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. ","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per liter","pmol/L","PMOL/L","amount of substance",602213670000000,[-3,0,0,0,0,0,0],"pmol/L","si",true,null,null,1,false,false,1,"picomole/liter; pmol per L; picomoles; litre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per minute","pmol/min","PMOL/MIN","amount of substance",10036894500,[0,-1,0,0,0,0,0],"pmol/min","si",true,null,null,1,false,false,1,"picomole/minute; pmol per min; picomoles per minute; micro enzyme units; enzymatic activity; enzyme activity","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. pmol/min = uU (micro enzyme unit)","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per milliliter","pmol/mL","PMOL/ML","amount of substance",602213670000000000,[-3,0,0,0,0,0,0],"pmol/mL","si",true,null,null,1,false,false,1,"picomole/milliliter; picomole/millilitre; pmol per mL; picomoles; millilitre; picomols; pmols","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"picomole per micromole","pmol/umol","PMOL/UMOL","amount of substance",0.000001,[0,0,0,0,0,0,0],"pmol/μmol","si",true,null,null,1,false,false,0,"pmol/mcgmol; picomole/micromole; pmol per umol; pmol per mcgmol; picomoles ","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[true,"picosecond","ps","PS","time",1e-12,[0,1,0,0,0,0,0],"ps",null,false,"T",null,1,false,false,0,"picoseconds; psec","LOINC","Time","Clinical","",null,null,null,null,false],[false,"picotesla","pT","PT","magnetic flux density",1e-9,[0,-1,1,0,0,-1,0],"pT","si",true,null,null,1,false,false,0,"picoteslas","LOINC","","Clinical","SI unit of magnetic field strength for magnetic field B","Wb/m2","WB/M2","1",1,false],[false,"enzyme unit per 12 hour","U/(12.h)","U/HR","catalytic activity",232335520833.33334,[0,-2,0,0,0,0,0],"U/h","chemical",true,null,null,1,false,false,1,"U/12hrs; U/ 12hrs; U per 12 hrs; 12hrs; enzyme units per 12 hours; enzyme activity; enzymatic activity per time; umol per min per 12 hours; micromoles per minute per 12 hours; umol/min/12hr","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per 2 hour","U/(2.h)","U/HR","catalytic activity",1394013125000,[0,-2,0,0,0,0,0],"U/h","chemical",true,null,null,1,false,false,1,"U/2hrs; U/ 2hrs; U per 2 hrs; 2hrs; enzyme units per 2 hours; enzyme activity; enzymatic activity per time; umol per minute per 2 hours; micromoles per minute; umol/min/2hr; umol per min per 2hr","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per 24 hour","U/(24.h)","U/HR","catalytic activity",116167760416.66667,[0,-2,0,0,0,0,0],"U/h","chemical",true,null,null,1,false,false,1,"U/24hrs; U/ 24hrs; U per 24 hrs; 24hrs; enzyme units per 24 hours; enzyme activity; enzymatic activity per time; micromoles per minute per 24 hours; umol/min/24hr; umol per min per 24hr","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per 10","U/10","U","catalytic activity",1003689450000000,[0,-1,0,0,0,0,0],"U","chemical",true,null,null,1,false,false,1,"enzyme unit/10; U per 10; enzyme units per 10; enzymatic activity; enzyme activity; micromoles per minute; umol/min/10","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per 10 billion","U/10*10","U/(10*10)","catalytic activity",1003689.45,[0,-1,0,0,0,0,0],"U/(10<sup>10</sup>)","chemical",true,null,null,1,false,false,1,"U per 10*10; enzyme units per 10*10; U per 10 billion; enzyme units; enzymatic activity; micromoles per minute per 10 billion; umol/min/10*10","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per trillion","U/10*12","U/(10*12)","catalytic activity",10036.8945,[0,-1,0,0,0,0,0],"U/(10<sup>12</sup>)","chemical",true,null,null,1,false,false,1,"enzyme unit/10*12; U per 10*12; enzyme units per 10*12; enzyme units per trillion; enzymatic activity; micromoles per minute per trillion; umol/min/10*12; umol per min per 10*12","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per million","U/10*6","U/(10*6)","catalytic activity",10036894500,[0,-1,0,0,0,0,0],"U/(10<sup>6</sup>)","chemical",true,null,null,1,false,false,1,"enzyme unit/10*6; U per 10*6; enzyme units per 10*6; enzyme units; enzymatic activity per volume; micromoles per minute per million; umol/min/10*6; umol per min per 10*6","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per billion","U/10*9","U/(10*9)","catalytic activity",10036894.5,[0,-1,0,0,0,0,0],"U/(10<sup>9</sup>)","chemical",true,null,null,1,false,false,1,"enzyme unit/10*9; U per 10*9; enzyme units per 10*9; enzymatic activity per volume; micromoles per minute per billion; umol/min/10*9; umol per min per 10*9","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per day","U/d","U/D","catalytic activity",116167760416.66667,[0,-2,0,0,0,0,0],"U/d","chemical",true,null,null,1,false,false,1,"U/dy; enzyme units per day; enzyme units; enzyme activity; enzymatic activity per time; micromoles per minute per day; umol/min/day; umol per min per day","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per deciliter","U/dL","U/DL","catalytic activity",100368945000000000000,[-3,-1,0,0,0,0,0],"U/dL","chemical",true,null,null,1,false,false,1,"U per dL; enzyme units per deciliter; decilitre; micromoles per minute per deciliter; umol/min/dL; umol per min per dL","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per gram","U/g","U/G","catalytic activity",10036894500000000,[0,-1,-1,0,0,0,0],"U/g","chemical",true,null,null,1,false,false,1,"U/gm; U per gm; enzyme units per gram; micromoles per minute per gram; umol/min/g; umol per min per g","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per hour","U/h","U/HR","catalytic activity",2788026250000,[0,-2,0,0,0,0,0],"U/h","chemical",true,null,null,1,false,false,1,"U/hr; U per hr; enzyme units per hour; micromoles per minute per hour; umol/min/hr; umol per min per hr","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per liter","U/L","U/L","catalytic activity",10036894500000000000,[-3,-1,0,0,0,0,0],"U/L","chemical",true,null,null,1,false,false,1,"enzyme unit/liter; enzyme unit/litre; U per L; enzyme units per liter; enzyme unit per litre; micromoles per minute per liter; umol/min/L; umol per min per L","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per minute","U/min","U/MIN","catalytic activity",167281575000000,[0,-2,0,0,0,0,0],"U/min","chemical",true,null,null,1,false,false,1,"enzyme unit/minute; U per min; enzyme units; umol/min/min; micromoles per minute per minute; micromoles per min per min; umol","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per milliliter","U/mL","U/ML","catalytic activity",1.00368945e+22,[-3,-1,0,0,0,0,0],"U/mL","chemical",true,null,null,1,false,false,1,"U per mL; enzyme units per milliliter; millilitre; micromoles per minute per milliliter; umol/min/mL; umol per min per mL","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"enzyme unit per second","U/s","U/S","catalytic activity",10036894500000000,[0,-2,0,0,0,0,0],"U/s","chemical",true,null,null,1,false,false,1,"U/sec; U per second; enzyme units per second; micromoles per minute per second; umol/min/sec; umol per min per sec","LOINC","CRat","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min)","umol/min","UMOL/MIN","1",1,false],[false,"micro international unit","u[IU]","U[IU]","arbitrary",0.000001,[0,0,0,0,0,0,0],"μi.U.","chemical",true,null,null,1,false,true,0,"uIU; u IU; microinternational units","LOINC","Arb","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"micro international unit per liter","u[IU]/L","U[IU]/L","arbitrary",0.001,[-3,0,0,0,0,0,0],"(μi.U.)/L","chemical",true,null,null,1,false,true,0,"uIU/L; u IU/L; uIU per L; microinternational units per liter; litre; ","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"micro international unit per milliliter","u[IU]/mL","U[IU]/ML","arbitrary",1,[-3,0,0,0,0,0,0],"(μi.U.)/mL","chemical",true,null,null,1,false,true,0,"uIU/mL; u IU/mL; uIU per mL; microinternational units per milliliter; millilitre","LOINC","ACnc","Clinical","International units (IU) are analyte and reference specimen  specific arbitrary units (held at WHO)","[iU]","[IU]","1",1,false],[false,"microequivalent","ueq","UEQ","amount of substance",602213670000000000,[0,0,0,0,0,0,0],"μeq","chemical",true,null,null,1,false,false,1,"microequivalents; 10^-6 equivalents; 10-6 equivalents","LOINC","Sub","Clinical","","mol","MOL","1",1,false],[false,"microequivalent per liter","ueq/L","UEQ/L","amount of substance",602213670000000000000,[-3,0,0,0,0,0,0],"μeq/L","chemical",true,null,null,1,false,false,1,"ueq per liter; litre; microequivalents","LOINC","MCnc","Clinical","","mol","MOL","1",1,false],[false,"microequivalent per milliliter","ueq/mL","UEQ/ML","amount of substance",6.0221367000000003e+23,[-3,0,0,0,0,0,0],"μeq/mL","chemical",true,null,null,1,false,false,1,"ueq per milliliter; millilitre; microequivalents","LOINC","MCnc","Clinical","","mol","MOL","1",1,false],[true,"microgram","ug","UG","mass",0.000001,[0,0,1,0,0,0,0],"μg",null,false,"M",null,1,false,false,0,"mcg; micrograms; 10^-6 grams; 10-6 grams","LOINC","Mass","Clinical","",null,null,null,null,false],[true,"microgram per 100 gram","ug/(100.g)","UG/G","mass",1e-8,[0,0,0,0,0,0,0],"μg/g",null,false,"M",null,1,false,false,0,"ug/100gm; ug/100 gm; mcg; ug per 100g; 100 gm; mcg per 100g; micrograms per 100 grams","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"microgram per 24 hour","ug/(24.h)","UG/HR","mass",1.1574074074074074e-11,[0,-1,1,0,0,0,0],"μg/h",null,false,"M",null,1,false,false,0,"ug/24hrs; ug/24 hrs; mcg/24hrs; ug per 24hrs; mcg per 24hrs; 24 hrs; micrograms per 24 hours","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"microgram per 8 hour","ug/(8.h)","UG/HR","mass",3.472222222222222e-11,[0,-1,1,0,0,0,0],"μg/h",null,false,"M",null,1,false,false,0,"ug/8hrs; ug/8 hrs; mcg/8hrs; ug per 8hrs; mcg per 8hrs; 8 hrs; micrograms per 8 hours; shift","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"microgram per square foot (international)","ug/[sft_i]","UG/[SFT_I]","mass",0.000010763910416709721,[-2,0,1,0,0,0,0],"μg",null,false,"M",null,1,false,false,0,"ug/sft; ug/ft2; ug/ft^2; ug/sq. ft; micrograms; sq. foot; foot squared","LOINC","ArMass","Clinical","",null,null,null,null,false],[true,"microgram per day","ug/d","UG/D","mass",1.1574074074074074e-11,[0,-1,1,0,0,0,0],"μg/d",null,false,"M",null,1,false,false,0,"ug/dy; mcg/dy; ug per day; mcg; micrograms per day","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"microgram per deciliter","ug/dL","UG/DL","mass",0.009999999999999998,[-3,0,1,0,0,0,0],"μg/dL",null,false,"M",null,1,false,false,0,"ug per dL; mcg/dl; mcg per dl; micrograms per deciliter; decilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"microgram per gram","ug/g","UG/G","mass",0.000001,[0,0,0,0,0,0,0],"μg/g",null,false,"M",null,1,false,false,0,"ug per gm; mcg/gm; mcg per g; micrograms per gram","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"microgram per hour","ug/h","UG/HR","mass",2.7777777777777777e-10,[0,-1,1,0,0,0,0],"μg/h",null,false,"M",null,1,false,false,0,"ug/hr; mcg/hr; mcg per hr; ug per hr; ug per hour; micrograms","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"microgram per kilogram","ug/kg","UG/KG","mass",9.999999999999999e-10,[0,0,0,0,0,0,0],"μg/kg",null,false,"M",null,1,false,false,0,"ug per kg; mcg/kg; mcg per kg; micrograms per kilogram","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"microgram per kilogram per 8 hour","ug/kg/(8.h)","(UG/KG)/HR","mass",3.472222222222222e-14,[0,-1,0,0,0,0,0],"(μg/kg)/h",null,false,"M",null,1,false,false,0,"ug/kg/8hrs; mcg/kg/8hrs; ug/kg/8 hrs; mcg/kg/8 hrs; ug per kg per 8hrs; 8 hrs; mcg per kg per 8hrs; micrograms per kilograms per 8 hours; shift","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"microgram per kilogram per day","ug/kg/d","(UG/KG)/D","mass",1.1574074074074072e-14,[0,-1,0,0,0,0,0],"(μg/kg)/d",null,false,"M",null,1,false,false,0,"ug/(kg.d); ug/kg/dy; mcg/kg/day; ug per kg per dy; 24 hours; 24hrs; mcg; kilograms; microgram per kilogram and day","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"microgram per kilogram per hour","ug/kg/h","(UG/KG)/HR","mass",2.7777777777777774e-13,[0,-1,0,0,0,0,0],"(μg/kg)/h",null,false,"M",null,1,false,false,0,"ug/(kg.h); ug/kg/hr; mcg/kg/hr; ug per kg per hr; mcg per kg per hr; kilograms","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"microgram per kilogram per minute","ug/kg/min","(UG/KG)/MIN","mass",1.6666666666666664e-11,[0,-1,0,0,0,0,0],"(μg/kg)/min",null,false,"M",null,1,false,false,0,"ug/kg/min; ug/kg/min; mcg/kg/min; ug per kg per min; mcg; micrograms per kilograms per minute ","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"microgram per liter","ug/L","UG/L","mass",0.001,[-3,0,1,0,0,0,0],"μg/L",null,false,"M",null,1,false,false,0,"mcg/L; ug per L; mcg; micrograms per liter; litre ","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"microgram per liter per 24 hour","ug/L/(24.h)","(UG/L)/HR","mass",1.1574074074074074e-8,[-3,-1,1,0,0,0,0],"(μg/L)/h",null,false,"M",null,1,false,false,0,"ug/L/24hrs; ug/L/24 hrs; mcg/L/24hrs; ug per L per 24hrs; 24 hrs; day; dy mcg; micrograms per liters per 24 hours; litres","LOINC","","Clinical","unit used to measure mass dose rate per patient body mass",null,null,null,null,false],[true,"microgram per square meter","ug/m2","UG/M2","mass",0.000001,[-2,0,1,0,0,0,0],"μg/(m<sup>2</sup>)",null,false,"M",null,1,false,false,0,"ug/m^2; ug/sq. m; mcg/m2; mcg/m^2; mcg/sq. m; ug per m2; m^2; sq. meter; mcg; micrograms per square meter; meter squared; metre","LOINC","ArMass","Clinical","unit used to measure mass dose per patient body surface area",null,null,null,null,false],[true,"microgram per cubic meter","ug/m3","UG/M3","mass",0.000001,[-3,0,1,0,0,0,0],"μg/(m<sup>3</sup>)",null,false,"M",null,1,false,false,0,"ug/m^3; ug/cu. m; mcg/m3; mcg/m^3; mcg/cu. m; ug per m3; ug per m^3; ug per cu. m; mcg; micrograms per cubic meter; meter cubed; metre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"microgram per milligram","ug/mg","UG/MG","mass",0.001,[0,0,0,0,0,0,0],"μg/mg",null,false,"M",null,1,false,false,0,"ug per mg; mcg/mg; mcg per mg; micromilligrams per milligram","LOINC","MCnt","Clinical","",null,null,null,null,false],[true,"microgram per minute","ug/min","UG/MIN","mass",1.6666666666666667e-8,[0,-1,1,0,0,0,0],"μg/min",null,false,"M",null,1,false,false,0,"ug per min; mcg/min; mcg per min; microminutes per minute","LOINC","MRat","Clinical","",null,null,null,null,false],[true,"microgram per milliliter","ug/mL","UG/ML","mass",1,[-3,0,1,0,0,0,0],"μg/mL",null,false,"M",null,1,false,false,0,"ug per mL; mcg/mL; mcg per mL; micrograms per milliliter; millilitre","LOINC","MCnc","Clinical","",null,null,null,null,false],[true,"microgram per millimole","ug/mmol","UG/MMOL","mass",1.660540186674939e-27,[0,0,1,0,0,0,0],"μg/mmol",null,false,"M",null,1,false,false,-1,"ug per mmol; mcg/mmol; mcg per mmol; micrograms per millimole","LOINC","Ratio","Clinical","",null,null,null,null,false],[true,"microgram per nanogram","ug/ng","UG/NG","mass",999.9999999999999,[0,0,0,0,0,0,0],"μg/ng",null,false,"M",null,1,false,false,0,"ug per ng; mcg/ng; mcg per ng; micrograms per nanogram","LOINC","MCnt","Clinical","",null,null,null,null,false],[false,"microkatal","ukat","UKAT","catalytic activity",602213670000000000,[0,-1,0,0,0,0,0],"μkat","chemical",true,null,null,1,false,false,1,"microkatals; ukats","LOINC","CAct","Clinical","kat is a unit of catalytic activity with base units = mol/s. Rarely used because its units are too large to practically express catalytic activity. See enzyme unit [U] which is the standard unit for catalytic activity.","mol/s","MOL/S","1",1,false],[false,"microliter","uL","UL","volume",1e-9,[3,0,0,0,0,0,0],"μL","iso1000",true,null,null,1,false,false,0,"microliters; microlitres; mcl","LOINC","Vol","Clinical","","l",null,"1",1,false],[false,"microliter per 2 hour","uL/(2.h)","UL/HR","volume",1.388888888888889e-13,[3,-1,0,0,0,0,0],"μL/h","iso1000",true,null,null,1,false,false,0,"uL/2hrs; uL/2 hrs; mcg/2hr; mcg per 2hr; uL per 2hr; uL per 2 hrs; microliters per 2 hours; microlitres ","LOINC","VRat","Clinical","","l",null,"1",1,false],[false,"microliter per hour","uL/h","UL/HR","volume",2.777777777777778e-13,[3,-1,0,0,0,0,0],"μL/h","iso1000",true,null,null,1,false,false,0,"uL/hr; mcg/hr; mcg per hr; uL per hr; microliters per hour; microlitres","LOINC","VRat","Clinical","","l",null,"1",1,false],[true,"micrometer","um","UM","length",0.000001,[1,0,0,0,0,0,0],"μm",null,false,"L",null,1,false,false,0,"micrometers; micrometres; μm; microns","LOINC","Len","Clinical","Unit of length that is usually used in tests related to the eye",null,null,null,null,false],[true,"microns per second","um/s","UM/S","length",0.000001,[1,-1,0,0,0,0,0],"μm/s",null,false,"L",null,1,false,false,0,"um/sec; micron/second; microns/second; um per sec; micrometers per second; micrometres","LOINC","Vel","Clinical","",null,null,null,null,false],[false,"micromole","umol","UMOL","amount of substance",602213670000000000,[0,0,0,0,0,0,0],"μmol","si",true,null,null,1,false,false,1,"micromoles; umols","LOINC","Sub","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per 2 hour","umol/(2.h)","UMOL/HR","amount of substance",83640787500000,[0,-1,0,0,0,0,0],"μmol/h","si",true,null,null,1,false,false,1,"umol/2hrs; umol/2 hrs; umol per 2 hrs; 2hrs; micromoles per 2 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per 24 hour","umol/(24.h)","UMOL/HR","amount of substance",6970065625000,[0,-1,0,0,0,0,0],"μmol/h","si",true,null,null,1,false,false,1,"umol/24hrs; umol/24 hrs; umol per 24 hrs; per 24hrs; micromoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per 8 hour","umol/(8.h)","UMOL/HR","amount of substance",20910196875000,[0,-1,0,0,0,0,0],"μmol/h","si",true,null,null,1,false,false,1,"umol/8hr; umol/8 hr; umol per 8 hr; umol per 8hr; umols per 8hr; umol per 8 hours; micromoles per 8 hours; shift","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per day","umol/d","UMOL/D","amount of substance",6970065625000,[0,-1,0,0,0,0,0],"μmol/d","si",true,null,null,1,false,false,1,"umol/day; umol per day; umols per day; umol per days; micromoles per days; umol/24hr; umol/24 hr; umol per 24 hr; umol per 24hr; umols per 24hr; umol per 24 hours; micromoles per 24 hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per deciliter","umol/dL","UMOL/DL","amount of substance",6.0221367e+21,[-3,0,0,0,0,0,0],"μmol/dL","si",true,null,null,1,false,false,1,"micromole/deciliter; micromole/decilitre; umol per dL; micromoles per deciliters; micromole per decilitres","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per gram","umol/g","UMOL/G","amount of substance",602213670000000000,[0,0,-1,0,0,0,0],"μmol/g","si",true,null,null,1,false,false,1,"micromole/gram; umol per g; micromoles per gram","LOINC","SCnt; Ratio","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per hour","umol/h","UMOL/HR","amount of substance",167281575000000,[0,-1,0,0,0,0,0],"μmol/h","si",true,null,null,1,false,false,1,"umol/hr; umol per hr; umol per hour; micromoles per hours","LOINC","SRat","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per kilogram","umol/kg","UMOL/KG","amount of substance",602213670000000,[0,0,-1,0,0,0,0],"μmol/kg","si",true,null,null,1,false,false,1,"umol per kg; micromoles per kilogram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per liter","umol/L","UMOL/L","amount of substance",602213670000000000000,[-3,0,0,0,0,0,0],"μmol/L","si",true,null,null,1,false,false,1,"micromole/liter; micromole/litre; umol per liter; micromoles per liter; litre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per liter per hour","umol/L/h","(UMOL/L)/HR","amount of substance",167281575000000000,[-3,-1,0,0,0,0,0],"(μmol/L)/h","si",true,null,null,1,false,false,1,"umol/liter/hr; umol/litre/hr; umol per L per hr; umol per liter per hour; micromoles per liters per hour; litre","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min; umol/L/h is a derived unit of enzyme units","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per milligram","umol/mg","UMOL/MG","amount of substance",602213670000000000000,[0,0,-1,0,0,0,0],"μmol/mg","si",true,null,null,1,false,false,1,"micromole/milligram; umol per mg; micromoles per milligram","LOINC","SCnt","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per minute","umol/min","UMOL/MIN","amount of substance",10036894500000000,[0,-1,0,0,0,0,0],"μmol/min","si",true,null,null,1,false,false,1,"micromole/minute; umol per min; micromoles per minute; enzyme units","LOINC","CAct","Clinical","unit for the enzyme unit U = umol/min","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per minute per gram","umol/min/g","(UMOL/MIN)/G","amount of substance",10036894500000000,[0,-1,-1,0,0,0,0],"(μmol/min)/g","si",true,null,null,1,false,false,1,"umol/min/gm; umol per min per gm; micromoles per minutes per gram; U/g; enzyme units","LOINC","CCnt","Clinical","unit for the enzyme unit U = umol/min. umol/min/g = U/g","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per minute per liter","umol/min/L","(UMOL/MIN)/L","amount of substance",10036894500000000000,[-3,-1,0,0,0,0,0],"(μmol/min)/L","si",true,null,null,1,false,false,1,"umol/min/liter; umol/minute/liter; micromoles per minutes per liter; litre; enzyme units; U/L","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. umol/min/L = U/L","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per milliliter","umol/mL","UMOL/ML","amount of substance",6.0221367000000003e+23,[-3,0,0,0,0,0,0],"μmol/mL","si",true,null,null,1,false,false,1,"umol per mL; micromoles per milliliter; millilitre","LOINC","SCnc","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per milliliter per minute","umol/mL/min","(UMOL/ML)/MIN","amount of substance",1.00368945e+22,[-3,-1,0,0,0,0,0],"(μmol/mL)/min","si",true,null,null,1,false,false,1,"umol per mL per min; micromoles per milliliters per minute; millilitres","LOINC","CCnc","Clinical","unit for the enzyme unit U = umol/min. umol/mL/min = U/mL","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per millimole","umol/mmol","UMOL/MMOL","amount of substance",0.001,[0,0,0,0,0,0,0],"μmol/mmol","si",true,null,null,1,false,false,0,"umol per mmol; micromoles per millimole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per mole","umol/mol","UMOL/MOL","amount of substance",0.000001,[0,0,0,0,0,0,0],"μmol/mol","si",true,null,null,1,false,false,0,"umol per mol; micromoles per mole","LOINC","SRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"micromole per micromole","umol/umol","UMOL/UMOL","amount of substance",1,[0,0,0,0,0,0,0],"μmol/μmol","si",true,null,null,1,false,false,0,"umol per umol; micromoles per micromole","LOINC","Srto; SFr; EntSRto","Clinical","","10*23","10*23","6.0221367",6.0221367,false],[false,"microOhm","uOhm","UOHM","electric resistance",0.001,[2,-1,1,0,0,-2,0],"μΩ","si",true,null,null,1,false,false,0,"microOhms; µΩ","LOINC","","Clinical","unit of electric resistance","V/A","V/A","1",1,false],[true,"microsecond","us","US","time",0.000001,[0,1,0,0,0,0,0],"μs",null,false,"T",null,1,false,false,0,"microseconds","LOINC","Time","Clinical","",null,null,null,null,false],[false,"micro enzyme unit per gram","uU/g","UU/G","catalytic activity",10036894500,[0,-1,-1,0,0,0,0],"μU/g","chemical",true,null,null,1,false,false,1,"uU per gm; micro enzyme units per gram; micro enzymatic activity per mass; enzyme activity","LOINC","CCnt","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 uU = 1pmol/min","umol/min","UMOL/MIN","1",1,false],[false,"micro enzyme unit per liter","uU/L","UU/L","catalytic activity",10036894500000,[-3,-1,0,0,0,0,0],"μU/L","chemical",true,null,null,1,false,false,1,"uU per L; micro enzyme units per liter; litre; enzymatic activity per volume; enzyme activity ","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 uU = 1pmol/min","umol/min","UMOL/MIN","1",1,false],[false,"micro enzyme unit per milliliter","uU/mL","UU/ML","catalytic activity",10036894500000000,[-3,-1,0,0,0,0,0],"μU/mL","chemical",true,null,null,1,false,false,1,"uU per mL; micro enzyme units per milliliter; millilitre; enzymatic activity per volume; enzyme activity","LOINC","CCnc","Clinical","1 U is the standard enzyme unit which equals 1 micromole substrate catalyzed per minute (1 umol/min); 1 uU = 1pmol/min","umol/min","UMOL/MIN","1",1,false],[false,"microvolt","uV","UV","electric potential",0.001,[2,-2,1,0,0,-1,0],"μV","si",true,null,null,1,false,false,0,"microvolts","LOINC","Elpot","Clinical","unit of electric potential (voltage)","J/C","J/C","1",1,false]]}}

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -11,7 +11,7 @@
  */
 window.cql = require('../../lib/cql');
 
-window.executeSimpleELM = function (
+window.executeSimpleELM = async function (
   elm,
   patientSource,
   valueSets,

--- a/examples/browser/simple-browser-support.js
+++ b/examples/browser/simple-browser-support.js
@@ -10,7 +10,7 @@
  */
 window.cql = require('../../lib/cql');
 
-window.executeSimpleELM = function (
+window.executeSimpleELM = async function (
   elm,
   patientSource,
   valueSets,

--- a/examples/node/exec-age.js
+++ b/examples/node/exec-age.js
@@ -23,5 +23,11 @@ const psource = new cql.PatientSource([
   }
 ]);
 
-const result = executor.exec(psource);
-console.log(JSON.stringify(result, undefined, 2));
+executor
+  .exec(psource)
+  .then(result => {
+    console.log(JSON.stringify(result, undefined, 2));
+  })
+  .catch(err => {
+    console.error(err);
+  });

--- a/examples/typescript/exec-age.ts
+++ b/examples/typescript/exec-age.ts
@@ -22,5 +22,11 @@ const psource = new cql.PatientSource([
   }
 ]);
 
-const result = executor.exec(psource);
-console.log(JSON.stringify(result, undefined, 2));
+executor
+  .exec(psource)
+  .then(result => {
+    console.log(JSON.stringify(result, undefined, 2));
+  })
+  .catch(err => {
+    console.error(err);
+  });

--- a/src/elm/aggregate.ts
+++ b/src/elm/aggregate.ts
@@ -20,8 +20,8 @@ export class Count extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    const items = await this.source.execute(ctx);
     if (typeIsArray(items)) {
       return removeNulls(items).length;
     }
@@ -34,8 +34,8 @@ export class Sum extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    let items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    let items = await this.source.execute(ctx);
     if (!typeIsArray(items)) {
       return null;
     }
@@ -65,8 +65,8 @@ export class Min extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const list = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    const list = await this.source.execute(ctx);
     if (list == null) {
       return null;
     }
@@ -99,8 +99,8 @@ export class Max extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    const items = await this.source.execute(ctx);
     if (items == null) {
       return null;
     }
@@ -133,8 +133,8 @@ export class Avg extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    let items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    let items = await this.source.execute(ctx);
     if (!typeIsArray(items)) {
       return null;
     }
@@ -165,8 +165,8 @@ export class Median extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    let items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    let items = await this.source.execute(ctx);
     if (!typeIsArray(items)) {
       return null;
     }
@@ -195,8 +195,8 @@ export class Mode extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    const items = await this.source.execute(ctx);
     if (!typeIsArray(items)) {
       return null;
     }
@@ -261,8 +261,8 @@ export class StdDev extends AggregateExpression {
     this.type = 'standard_deviation';
   }
 
-  exec(ctx: Context) {
-    let items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    let items = await this.source.execute(ctx);
     if (!typeIsArray(items)) {
       return null;
     }
@@ -320,8 +320,8 @@ export class Product extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    let items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    let items = await this.source.execute(ctx);
     if (!typeIsArray(items)) {
       return null;
     }
@@ -351,8 +351,8 @@ export class GeometricMean extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    let items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    let items = await this.source.execute(ctx);
     if (!typeIsArray(items)) {
       return null;
     }
@@ -405,8 +405,8 @@ export class AllTrue extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    const items = await this.source.execute(ctx);
     return allTrue(removeNulls(items));
   }
 }
@@ -416,8 +416,8 @@ export class AnyTrue extends AggregateExpression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const items = this.source.execute(ctx);
+  async exec(ctx: Context) {
+    const items = await this.source.execute(ctx);
     return anyTrue(items);
   }
 }

--- a/src/elm/arithmetic.ts
+++ b/src/elm/arithmetic.ts
@@ -17,8 +17,8 @@ export class Add extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args == null || args.some((x: any) => x == null)) {
       return null;
     }
@@ -60,8 +60,8 @@ export class Subtract extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args == null || args.some((x: any) => x == null)) {
       return null;
     }
@@ -98,8 +98,8 @@ export class Multiply extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args == null || args.some((x: any) => x == null)) {
       return null;
     }
@@ -136,8 +136,8 @@ export class Divide extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args == null || args.some((x: any) => x == null)) {
       return null;
     }
@@ -176,8 +176,8 @@ export class TruncatedDivide extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args == null || args.some((x: any) => x == null)) {
       return null;
     }
@@ -197,8 +197,8 @@ export class Modulo extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args == null || args.some((x: any) => x == null)) {
       return null;
     }
@@ -214,8 +214,8 @@ export class Ceiling extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }
@@ -229,8 +229,8 @@ export class Floor extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }
@@ -244,8 +244,8 @@ export class Truncate extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }
@@ -258,8 +258,8 @@ export class Abs extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     } else if (arg.isQuantity) {
@@ -275,8 +275,8 @@ export class Negate extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     } else if (arg.isQuantity) {
@@ -295,13 +295,13 @@ export class Round extends Expression {
     this.precision = build(json.precision);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }
 
-    const dec = this.precision != null ? this.precision.execute(ctx) : 0;
+    const dec = this.precision != null ? await this.precision.execute(ctx) : 0;
     return Math.round(arg * Math.pow(10, dec)) / Math.pow(10, dec);
   }
 }
@@ -311,8 +311,8 @@ export class Ln extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }
@@ -328,8 +328,8 @@ export class Exp extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }
@@ -348,8 +348,8 @@ export class Log extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args == null || args.some((x: any) => x == null)) {
       return null;
     }
@@ -365,8 +365,8 @@ export class Power extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args == null || args.some((x: any) => x == null)) {
       return null;
     }
@@ -396,7 +396,7 @@ export class MinValue extends Expression {
     this.valueType = json.valueType;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     if (MinValue.MIN_VALUES[this.valueType]) {
       if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
         const minDateTime = (MinValue.MIN_VALUES[this.valueType] as DateTime).copy();
@@ -427,7 +427,7 @@ export class MaxValue extends Expression {
     this.valueType = json.valueType;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     if (MaxValue.MAX_VALUES[this.valueType] != null) {
       if (this.valueType === '{urn:hl7-org:elm-types:r1}DateTime') {
         const maxDateTime = (MaxValue.MAX_VALUES[this.valueType] as DateTime).copy();
@@ -447,8 +447,8 @@ export class Successor extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }
@@ -476,8 +476,8 @@ export class Predecessor extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }

--- a/src/elm/builder.ts
+++ b/src/elm/builder.ts
@@ -2,13 +2,13 @@
 import * as E from './expressions';
 import { typeIsArray } from '../util/util';
 
-export function build(json: any): any {
+export function build(json: any): E.Expression | E.Expression[] | null {
   if (json == null) {
     return json;
   }
 
   if (typeIsArray(json)) {
-    return (json as any[]).map(child => build(child));
+    return (json as any[]).map(child => build(child) as E.Expression);
   }
 
   if (json.type === 'FunctionRef') {
@@ -27,7 +27,7 @@ function functionExists(name: string) {
   return typeof E[name] === 'function';
 }
 
-function constructByName(name: string, json: any) {
+function constructByName(name: string, json: any): E.Expression {
   // @ts-ignore
   return new E[name](json);
 }

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -16,7 +16,7 @@ export class ValueSetDef extends Expression {
   }
   //todo: code systems and versions
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     const valueset =
       ctx.codeService.findValueSet(this.id, this.version) || new dt.ValueSet(this.id, this.version);
     ctx.rootContext().set(this.name, valueset);
@@ -34,11 +34,11 @@ export class ValueSetRef extends Expression {
     this.libraryName = json.libraryName;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     // TODO: This calls the code service every time-- should be optimized
     let valueset = ctx.getValueSet(this.name, this.libraryName);
     if (valueset instanceof Expression) {
-      valueset = valueset.execute(ctx);
+      valueset = await valueset.execute(ctx);
     }
     return valueset;
   }
@@ -54,14 +54,14 @@ export class AnyInValueSet extends Expression {
     this.valueset = new ValueSetRef(json.valueset);
   }
 
-  exec(ctx: Context) {
-    const valueset = this.valueset.execute(ctx);
+  async exec(ctx: Context) {
+    const valueset = await this.valueset.execute(ctx);
     // If the value set reference cannot be resolved, a run-time error is thrown.
     if (valueset == null || !valueset.isValueSet) {
       throw new Error('ValueSet must be provided to InValueSet function');
     }
 
-    const codes = this.codes.exec(ctx);
+    const codes = await this.codes.exec(ctx);
     return codes != null && codes.some((code: any) => valueset.hasMatch(code));
   }
 }
@@ -76,7 +76,7 @@ export class InValueSet extends Expression {
     this.valueset = new ValueSetRef(json.valueset);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     // If the code argument is null, the result is false
     if (this.code == null) {
       return false;
@@ -84,12 +84,12 @@ export class InValueSet extends Expression {
     if (this.valueset == null) {
       throw new Error('ValueSet must be provided to InValueSet function');
     }
-    const code = this.code.execute(ctx);
+    const code = await this.code.execute(ctx);
     // spec indicates to return false if code is null, throw error if value set cannot be resolved
     if (code == null) {
       return false;
     }
-    const valueset = this.valueset.execute(ctx);
+    const valueset = await this.valueset.execute(ctx);
     if (valueset == null || !valueset.isValueSet) {
       throw new Error('ValueSet must be provided to InValueSet function');
     }
@@ -110,7 +110,7 @@ export class CodeSystemDef extends Expression {
     this.version = json.version;
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     return new dt.CodeSystem(this.id, this.version);
   }
 }
@@ -129,8 +129,8 @@ export class CodeDef extends Expression {
     this.display = json.display;
   }
 
-  exec(ctx: Context) {
-    const system = ctx.getCodeSystem(this.systemName).execute(ctx);
+  async exec(ctx: Context) {
+    const system = await ctx.getCodeSystem(this.systemName).execute(ctx);
     return new dt.Code(this.id, system.id, system.version, this.display);
   }
 }
@@ -145,7 +145,7 @@ export class CodeRef extends Expression {
     this.library = json.libraryName;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
     const codeDef = ctx.getCode(this.name);
     return codeDef ? codeDef.execute(ctx) : undefined;
@@ -172,7 +172,7 @@ export class Code extends Expression {
     return true;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     const system = ctx.getCodeSystem(this.systemName) || {};
     return new dt.Code(this.code, system.id, this.version, this.display);
   }
@@ -190,11 +190,14 @@ export class ConceptDef extends Expression {
     this.codes = json.code;
   }
 
-  exec(ctx: Context) {
-    const codes = this.codes.map((code: any) => {
-      const codeDef = ctx.getCode(code.name);
-      return codeDef ? codeDef.execute(ctx) : undefined;
-    });
+  async exec(ctx: Context) {
+    // TODO (MATT): check this
+    const codes = await Promise.all(
+      this.codes.map(async (code: any) => {
+        const codeDef = ctx.getCode(code.name);
+        return codeDef ? codeDef.execute(ctx) : undefined;
+      })
+    );
     return new dt.Concept(codes, this.display);
   }
 }
@@ -207,7 +210,7 @@ export class ConceptRef extends Expression {
     this.name = json.name;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     const conceptDef = ctx.getConcept(this.name);
     return conceptDef ? conceptDef.execute(ctx) : undefined;
   }
@@ -234,7 +237,7 @@ export class Concept extends Expression {
     return new dt.Code(code.code, system.id, code.version, code.display);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     const codes = this.codes.map((code: any) => this.toCode(ctx, code));
     return new dt.Concept(codes, this.display);
   }
@@ -248,8 +251,8 @@ export class CalculateAge extends Expression {
     this.precision = json.precision;
   }
 
-  exec(ctx: Context) {
-    const date1 = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const date1 = await this.execArgs(ctx);
     const date2 = dt.DateTime.fromJSDate(ctx.getExecutionDateTime());
     const result =
       date1 != null ? date1.durationBetween(date2, this.precision.toLowerCase()) : undefined;
@@ -268,9 +271,9 @@ export class CalculateAgeAt extends Expression {
     this.precision = json.precision;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     // eslint-disable-next-line prefer-const
-    let [date1, date2] = this.execArgs(ctx);
+    let [date1, date2] = await this.execArgs(ctx);
     if (date1 != null && date2 != null) {
       // date1 is the birthdate, convert it to date if date2 is a date (to support ignoring time)
       if (date2.isDate && date1.isDateTime) {

--- a/src/elm/clinical.ts
+++ b/src/elm/clinical.ts
@@ -191,7 +191,6 @@ export class ConceptDef extends Expression {
   }
 
   async exec(ctx: Context) {
-    // TODO (MATT): check this
     const codes = await Promise.all(
       this.codes.map(async (code: any) => {
         const codeDef = ctx.getCode(code.name);

--- a/src/elm/comparison.ts
+++ b/src/elm/comparison.ts
@@ -11,8 +11,8 @@ export class Less extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx).map((x: any) => Uncertainty.from(x));
+  async exec(ctx: Context) {
+    const args = (await this.execArgs(ctx)).map((x: any) => Uncertainty.from(x));
     if (args[0] == null || args[1] == null) {
       return null;
     }
@@ -25,8 +25,8 @@ export class LessOrEqual extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx).map((x: any) => Uncertainty.from(x));
+  async exec(ctx: Context) {
+    const args = (await this.execArgs(ctx)).map((x: any) => Uncertainty.from(x));
     if (args[0] == null || args[1] == null) {
       return null;
     }
@@ -39,8 +39,8 @@ export class Greater extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx).map((x: any) => Uncertainty.from(x));
+  async exec(ctx: Context) {
+    const args = (await this.execArgs(ctx)).map((x: any) => Uncertainty.from(x));
     if (args[0] == null || args[1] == null) {
       return null;
     }
@@ -53,8 +53,8 @@ export class GreaterOrEqual extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx).map((x: any) => Uncertainty.from(x));
+  async exec(ctx: Context) {
+    const args = (await this.execArgs(ctx)).map((x: any) => Uncertainty.from(x));
     if (args[0] == null || args[1] == null) {
       return null;
     }

--- a/src/elm/conditional.ts
+++ b/src/elm/conditional.ts
@@ -3,6 +3,7 @@ import { build } from './builder';
 import { equals } from '../util/comparison';
 import { Context } from '../runtime/context';
 
+// TODO (MATT): check this
 // TODO: Spec lists "Conditional", but it's "If" in the XSD
 export class If extends Expression {
   condition: any;
@@ -16,8 +17,8 @@ export class If extends Expression {
     this.els = build(json.else);
   }
 
-  exec(ctx: Context) {
-    if (this.condition.execute(ctx)) {
+  async exec(ctx: Context) {
+    if (await this.condition.execute(ctx)) {
       return this.th.execute(ctx);
     } else {
       return this.els.execute(ctx);
@@ -47,7 +48,7 @@ export class Case extends Expression {
     this.els = build(json.else);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     if (this.comparand) {
       return this.exec_selected(ctx);
     } else {
@@ -55,19 +56,19 @@ export class Case extends Expression {
     }
   }
 
-  exec_selected(ctx: Context) {
-    const val = this.comparand.execute(ctx);
+  async exec_selected(ctx: Context) {
+    const val = await this.comparand.execute(ctx);
     for (const ci of this.caseItems) {
-      if (equals(ci.when.execute(ctx), val)) {
+      if (equals(await ci.when.execute(ctx), val)) {
         return ci.then.execute(ctx);
       }
     }
     return this.els.execute(ctx);
   }
 
-  exec_standard(ctx: Context) {
+  async exec_standard(ctx: Context) {
     for (const ci of this.caseItems) {
-      if (ci.when.execute(ctx)) {
+      if (await ci.when.execute(ctx)) {
         return ci.then.execute(ctx);
       }
     }

--- a/src/elm/conditional.ts
+++ b/src/elm/conditional.ts
@@ -3,7 +3,6 @@ import { build } from './builder';
 import { equals } from '../util/comparison';
 import { Context } from '../runtime/context';
 
-// TODO (MATT): check this
 // TODO: Spec lists "Conditional", but it's "If" in the XSD
 export class If extends Expression {
   condition: any;

--- a/src/elm/datetime.ts
+++ b/src/elm/datetime.ts
@@ -24,7 +24,7 @@ export class DateTime extends Expression {
     this.json = json;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     for (const property of DateTime.PROPERTIES) {
       // if json does not contain 'timezoneOffset' set it to the executionDateTime from the context
       if (this.json[property] != null) {
@@ -39,8 +39,11 @@ export class DateTime extends Expression {
         });
       }
     }
-    // @ts-ignore
-    const args = DateTime.PROPERTIES.map(p => (this[p] != null ? this[p].execute(ctx) : undefined));
+    // TODO (MATT): check this
+    const args = await Promise.all(
+      // @ts-ignore
+      DateTime.PROPERTIES.map(async p => (this[p] != null ? this[p].execute(ctx) : undefined))
+    );
     return new DT.DateTime(...args);
   }
 }
@@ -55,15 +58,18 @@ export class Date extends Expression {
     this.json = json;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     for (const property of Date.PROPERTIES) {
       if (this.json[property] != null) {
         // @ts-ignore
         this[property] = build(this.json[property]);
       }
     }
-    // @ts-ignore
-    const args = Date.PROPERTIES.map(p => (this[p] != null ? this[p].execute(ctx) : undefined));
+    // TODO (MATT): check this
+    const args = await Promise.all(
+      // @ts-ignore
+      Date.PROPERTIES.map(async p => (this[p] != null ? this[p].execute(ctx) : undefined))
+    );
     return new DT.Date(...args);
   }
 }
@@ -80,9 +86,11 @@ export class Time extends Expression {
     }
   }
 
-  exec(ctx: Context) {
-    // @ts-ignore
-    const args = Time.PROPERTIES.map(p => (this[p] != null ? this[p].execute(ctx) : undefined));
+  async exec(ctx: Context) {
+    const args = await Promise.all(
+      // @ts-ignore
+      Time.PROPERTIES.map(async p => (this[p] != null ? this[p].execute(ctx) : undefined))
+    );
     return new DT.DateTime(0, 1, 1, ...args).getTime();
   }
 }
@@ -92,7 +100,7 @@ export class Today extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     return ctx.getExecutionDateTime().getDate();
   }
 }
@@ -102,7 +110,7 @@ export class Now extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     return ctx.getExecutionDateTime();
   }
 }
@@ -112,7 +120,7 @@ export class TimeOfDay extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     return ctx.getExecutionDateTime().getTime();
   }
 }
@@ -125,8 +133,8 @@ export class DateTimeComponentFrom extends Expression {
     this.precision = json.precision;
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       return arg[this.precision.toLowerCase()];
     } else {
@@ -140,8 +148,8 @@ export class DateFrom extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const date = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const date = await this.execArgs(ctx);
     if (date != null) {
       return date.getDate();
     } else {
@@ -155,8 +163,8 @@ export class TimeFrom extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const date = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const date = await this.execArgs(ctx);
     if (date != null) {
       return date.getTime();
     } else {
@@ -170,8 +178,8 @@ export class TimezoneOffsetFrom extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const date = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const date = await this.execArgs(ctx);
     if (date != null) {
       return date.timezoneOffset;
     } else {
@@ -198,8 +206,8 @@ export class DifferenceBetween extends Expression {
     this.precision = json.precision;
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     // Check to make sure args exist and that they have differenceBetween functions so that they can be compared to one another
     if (
       args[0] == null ||
@@ -229,8 +237,8 @@ export class DurationBetween extends Expression {
     this.precision = json.precision;
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     // Check to make sure args exist and that they have durationBetween functions so that they can be compared to one another
     if (
       args[0] == null ||

--- a/src/elm/datetime.ts
+++ b/src/elm/datetime.ts
@@ -39,7 +39,6 @@ export class DateTime extends Expression {
         });
       }
     }
-    // TODO (MATT): check this
     const args = await Promise.all(
       // @ts-ignore
       DateTime.PROPERTIES.map(async p => (this[p] != null ? this[p].execute(ctx) : undefined))
@@ -65,7 +64,6 @@ export class Date extends Expression {
         this[property] = build(this.json[property]);
       }
     }
-    // TODO (MATT): check this
     const args = await Promise.all(
       // @ts-ignore
       Date.PROPERTIES.map(async p => (this[p] != null ? this[p].execute(ctx) : undefined))

--- a/src/elm/expression.ts
+++ b/src/elm/expression.ts
@@ -5,16 +5,16 @@ import { build } from './builder';
 
 export class Expression {
   localId?: string;
-  arg?: any;
-  args?: any[];
+  arg?: Expression;
+  args?: Expression[];
 
   constructor(json: any) {
     if (json.operand != null) {
       const op = build(json.operand);
       if (typeIsArray(json.operand)) {
-        this.args = op;
+        this.args = op as Expression[];
       } else {
-        this.arg = op;
+        this.arg = op as Expression;
       }
     }
     if (json.localId != null) {

--- a/src/elm/expression.ts
+++ b/src/elm/expression.ts
@@ -22,10 +22,10 @@ export class Expression {
     }
   }
 
-  execute(ctx: Context) {
+  async execute(ctx: Context) {
     if (this.localId != null) {
       // Store the localId and result on the root context of this library
-      const execValue = this.exec(ctx);
+      const execValue = await this.exec(ctx);
       ctx.rootContext().setLocalIdWithResult(this.localId, execValue);
       return execValue;
     } else {
@@ -33,13 +33,14 @@ export class Expression {
     }
   }
 
-  exec(_ctx: Context): any {
+  async exec(_ctx: Context): Promise<any> {
     return this;
   }
 
-  execArgs(ctx: Context) {
+  async execArgs(ctx: Context) {
     if (this.args != null) {
-      return this.args.map(arg => arg.execute(ctx));
+      // TODO (MATT): check this
+      return Promise.all(this.args.map(async arg => arg.execute(ctx)));
     } else if (this.arg != null) {
       return this.arg.execute(ctx);
     } else {
@@ -56,7 +57,7 @@ export class UnimplementedExpression extends Expression {
     this.json = json;
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     throw new Error(`Unimplemented Expression: ${this.json.type}`);
   }
 }

--- a/src/elm/expression.ts
+++ b/src/elm/expression.ts
@@ -39,7 +39,7 @@ export class Expression {
 
   async execArgs(ctx: Context) {
     if (this.args != null) {
-      // TODO (MATT): check this
+      // TODO (MATT) ALERT: check this. doesn't work at all. sad
       return Promise.all(this.args.map(async arg => arg.execute(ctx)));
     } else if (this.arg != null) {
       return this.arg.execute(ctx);

--- a/src/elm/expression.ts
+++ b/src/elm/expression.ts
@@ -39,7 +39,6 @@ export class Expression {
 
   async execArgs(ctx: Context) {
     if (this.args != null) {
-      // TODO (MATT) ALERT: check this. doesn't work at all. sad
       return Promise.all(this.args.map(async arg => arg.execute(ctx)));
     } else if (this.arg != null) {
       return this.arg.execute(ctx);

--- a/src/elm/external.ts
+++ b/src/elm/external.ts
@@ -21,11 +21,11 @@ export class Retrieve extends Expression {
     this.dateRange = build(json.dateRange);
   }
 
-  exec(ctx: Context) {
-    let records = ctx.findRecords(this.templateId != null ? this.templateId : this.datatype);
+  async exec(ctx: Context) {
+    let records = await ctx.findRecords(this.templateId != null ? this.templateId : this.datatype);
     let codes = this.codes;
     if (this.codes && typeof this.codes.exec === 'function') {
-      codes = this.codes.execute(ctx);
+      codes = await this.codes.execute(ctx);
       if (codes == null) {
         return [];
       }
@@ -35,7 +35,7 @@ export class Retrieve extends Expression {
     }
     // TODO: Added @dateProperty check due to previous fix in cql4browsers in cql_qdm_patient_api hash: ddbc57
     if (this.dateRange && this.dateProperty) {
-      const range = this.dateRange.execute(ctx);
+      const range = await this.dateRange.execute(ctx);
       records = records.filter((r: any) => range.includes(r.getDateOrInterval(this.dateProperty)));
     }
 

--- a/src/elm/instance.ts
+++ b/src/elm/instance.ts
@@ -12,7 +12,7 @@ class Element {
     this.name = json.name;
     this.value = build(json.value);
   }
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     return this.value != null ? this.value.execute(ctx) : undefined;
   }
 }
@@ -27,10 +27,10 @@ export class Instance extends Expression {
     this.element = json.element.map((child: any) => new Element(child));
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     const obj: any = {};
     for (const el of this.element) {
-      obj[el.name] = el.exec(ctx);
+      obj[el.name] = await el.exec(ctx);
     }
     switch (this.classType) {
       case '{urn:hl7-org:elm-types:r1}Quantity':

--- a/src/elm/interval.ts
+++ b/src/elm/interval.ts
@@ -30,17 +30,17 @@ export class Interval extends Expression {
     return true;
   }
 
-  exec(ctx: Context) {
-    const lowValue = this.low.execute(ctx);
-    const highValue = this.high.execute(ctx);
+  async exec(ctx: Context) {
+    const lowValue = await this.low.execute(ctx);
+    const highValue = await this.high.execute(ctx);
     const lowClosed =
       this.lowClosed != null
         ? this.lowClosed
-        : this.lowClosedExpression && this.lowClosedExpression.execute(ctx);
+        : this.lowClosedExpression && (await this.lowClosedExpression.execute(ctx));
     const highClosed =
       this.highClosed != null
         ? this.highClosed
-        : this.highClosedExpression && this.highClosedExpression.execute(ctx);
+        : this.highClosedExpression && (await this.highClosedExpression.execute(ctx));
     let defaultPointType;
     if (lowValue == null && highValue == null) {
       // try to get the default point type from a cast
@@ -94,8 +94,8 @@ export class Meets extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.meets(b, this.precision);
     } else {
@@ -112,8 +112,8 @@ export class MeetsAfter extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.meetsAfter(b, this.precision);
     } else {
@@ -130,8 +130,8 @@ export class MeetsBefore extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.meetsBefore(b, this.precision);
     } else {
@@ -148,8 +148,8 @@ export class Overlaps extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.overlaps(b, this.precision);
     } else {
@@ -166,8 +166,8 @@ export class OverlapsAfter extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.overlapsAfter(b, this.precision);
     } else {
@@ -184,8 +184,8 @@ export class OverlapsBefore extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.overlapsBefore(b, this.precision);
     } else {
@@ -222,8 +222,8 @@ export class Width extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const interval = this.arg.execute(ctx);
+  async exec(ctx: Context) {
+    const interval = await this.arg.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -236,8 +236,8 @@ export class Size extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const interval = this.arg.execute(ctx);
+  async exec(ctx: Context) {
+    const interval = await this.arg.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -250,8 +250,8 @@ export class Start extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const interval = this.arg.execute(ctx);
+  async exec(ctx: Context) {
+    const interval = await this.arg.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -269,8 +269,8 @@ export class End extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const interval = this.arg.execute(ctx);
+  async exec(ctx: Context) {
+    const interval = await this.arg.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -291,8 +291,8 @@ export class Starts extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.starts(b, this.precision);
     } else {
@@ -309,8 +309,8 @@ export class Ends extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.ends(b, this.precision);
     } else {
@@ -405,10 +405,10 @@ export class Expand extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     // expand(argument List<Interval<T>>, per Quantity) List<Interval<T>>
     let defaultPer, expandFunction;
-    let [intervals, per] = this.execArgs(ctx);
+    let [intervals, per] = await this.execArgs(ctx);
     // CQL 1.5 introduced an overload to allow singular intervals; make it a list so we can use the same logic for either overload
     if (!Array.isArray(intervals)) {
       intervals = [intervals];
@@ -640,9 +640,9 @@ export class Collapse extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     // collapse(argument List<Interval<T>>, per Quantity) List<Interval<T>>
-    const [intervals, perWidth] = this.execArgs(ctx);
+    const [intervals, perWidth] = await this.execArgs(ctx);
     return collapseIntervals(intervals, perWidth);
   }
 }

--- a/src/elm/interval.ts
+++ b/src/elm/interval.ts
@@ -223,7 +223,7 @@ export class Width extends Expression {
   }
 
   async exec(ctx: Context) {
-    const interval = await this.arg.execute(ctx);
+    const interval = await this.arg?.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -237,7 +237,7 @@ export class Size extends Expression {
   }
 
   async exec(ctx: Context) {
-    const interval = await this.arg.execute(ctx);
+    const interval = await this.arg?.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -251,7 +251,7 @@ export class Start extends Expression {
   }
 
   async exec(ctx: Context) {
-    const interval = await this.arg.execute(ctx);
+    const interval = await this.arg?.execute(ctx);
     if (interval == null) {
       return null;
     }
@@ -270,7 +270,7 @@ export class End extends Expression {
   }
 
   async exec(ctx: Context) {
-    const interval = await this.arg.execute(ctx);
+    const interval = await this.arg?.execute(ctx);
     if (interval == null) {
       return null;
     }

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -5,11 +5,11 @@ import { equals } from '../util/comparison';
 import { Context } from '../runtime/context';
 
 export class List extends Expression {
-  elements: any[];
+  elements: Expression[];
 
   constructor(json: any) {
     super(json);
-    this.elements = build(json.element) || [];
+    this.elements = (build(json.element) as Expression[]) || [];
   }
 
   get isList() {
@@ -17,7 +17,7 @@ export class List extends Expression {
   }
 
   async exec(ctx: Context) {
-    return this.elements.map(item => item.execute(ctx));
+    return await Promise.all(this.elements.map(async item => await item.execute(ctx)));
   }
 }
 
@@ -99,19 +99,19 @@ export class ToList extends Expression {
 }
 
 export class IndexOf extends Expression {
-  source: any;
-  element: any;
+  source: Expression;
+  element: Expression;
 
   constructor(json: any) {
     super(json);
-    this.source = build(json.source);
-    this.element = build(json.element);
+    this.source = build(json.source) as Expression;
+    this.element = build(json.element) as Expression;
   }
 
   async exec(ctx: Context) {
     let index;
-    const src = this.source.execute(ctx);
-    const el = this.element.execute(ctx);
+    const src = await this.source.execute(ctx);
+    const el = await this.element.execute(ctx);
     if (src == null || el == null) {
       return null;
     }
@@ -211,11 +211,11 @@ function removeDuplicateNulls(list: any[]) {
 export class Current extends UnimplementedExpression {}
 
 export class First extends Expression {
-  source: any;
+  source: Expression;
 
   constructor(json: any) {
     super(json);
-    this.source = build(json.source);
+    this.source = build(json.source) as Expression;
   }
 
   async exec(ctx: Context) {
@@ -229,11 +229,11 @@ export class First extends Expression {
 }
 
 export class Last extends Expression {
-  source: any;
+  source: Expression;
 
   constructor(json: any) {
     super(json);
-    this.source = build(json.source);
+    this.source = build(json.source) as Expression;
   }
 
   async exec(ctx: Context) {
@@ -247,15 +247,15 @@ export class Last extends Expression {
 }
 
 export class Slice extends Expression {
-  source: any;
-  startIndex: any;
-  endIndex: any;
+  source: Expression;
+  startIndex: Expression;
+  endIndex: Expression;
 
   constructor(json: any) {
     super(json);
-    this.source = build(json.source);
-    this.startIndex = build(json.startIndex);
-    this.endIndex = build(json.endIndex);
+    this.source = build(json.source) as Expression;
+    this.startIndex = build(json.startIndex) as Expression;
+    this.endIndex = build(json.endIndex) as Expression;
   }
 
   async exec(ctx: Context) {

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -16,7 +16,7 @@ export class List extends Expression {
     return true;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     return this.elements.map(item => item.execute(ctx));
   }
 }
@@ -26,8 +26,8 @@ export class Exists extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const list = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const list = await this.execArgs(ctx);
     // if list exists and has non empty length we need to make sure it isnt just full of nulls
     if (list) {
       return list.some((item: any) => item != null);
@@ -71,8 +71,8 @@ export class SingletonFrom extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null && arg.length > 1) {
       throw new Error("IllegalArgument: 'SingletonFrom' requires a 0 or 1 arg array");
     } else if (arg != null && arg.length === 1) {
@@ -88,8 +88,8 @@ export class ToList extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       return [arg];
     } else {
@@ -108,7 +108,7 @@ export class IndexOf extends Expression {
     this.element = build(json.element);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     let index;
     const src = this.source.execute(ctx);
     const el = this.element.execute(ctx);
@@ -157,8 +157,8 @@ export class Flatten extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (typeIsArray(arg) && (arg as any[]).every(x => typeIsArray(x))) {
       return (arg as any[]).reduce((x, y) => x.concat(y), []);
     } else {
@@ -172,8 +172,8 @@ export class Distinct extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const result = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const result = await this.execArgs(ctx);
     if (result == null) {
       return null;
     }
@@ -218,8 +218,8 @@ export class First extends Expression {
     this.source = build(json.source);
   }
 
-  exec(ctx: Context) {
-    const src = this.source.exec(ctx);
+  async exec(ctx: Context) {
+    const src = await this.source.exec(ctx);
     if (src != null && typeIsArray(src) && src.length > 0) {
       return src[0];
     } else {
@@ -236,8 +236,8 @@ export class Last extends Expression {
     this.source = build(json.source);
   }
 
-  exec(ctx: Context) {
-    const src = this.source.exec(ctx);
+  async exec(ctx: Context) {
+    const src = await this.source.exec(ctx);
     if (src != null && typeIsArray(src) && src.length > 0) {
       return src[src.length - 1];
     } else {
@@ -258,11 +258,11 @@ export class Slice extends Expression {
     this.endIndex = build(json.endIndex);
   }
 
-  exec(ctx: Context) {
-    const src = this.source.exec(ctx);
+  async exec(ctx: Context) {
+    const src = await this.source.exec(ctx);
     if (src != null && typeIsArray(src)) {
-      const startIndex = this.startIndex.exec(ctx);
-      const endIndex = this.endIndex.exec(ctx);
+      const startIndex = await this.startIndex.exec(ctx);
+      const endIndex = await this.endIndex.exec(ctx);
       const start = startIndex != null ? startIndex : 0;
       const end = endIndex != null ? endIndex : src.length;
       if (src.length === 0 || start < 0 || end < 0 || end < start) {

--- a/src/elm/list.ts
+++ b/src/elm/list.ts
@@ -17,7 +17,7 @@ export class List extends Expression {
   }
 
   async exec(ctx: Context) {
-    return await Promise.all(this.elements.map(async item => await item.execute(ctx)));
+    return await Promise.all(this.elements.map(item => item.execute(ctx)));
   }
 }
 

--- a/src/elm/literal.ts
+++ b/src/elm/literal.ts
@@ -26,7 +26,7 @@ export class Literal extends Expression {
     this.value = json.value;
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     return this.value;
   }
 }
@@ -45,7 +45,7 @@ export class BooleanLiteral extends Literal {
     return true;
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     return this.value;
   }
 }
@@ -62,7 +62,7 @@ export class IntegerLiteral extends Literal {
     return true;
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     return this.value;
   }
 }
@@ -79,7 +79,7 @@ export class DecimalLiteral extends Literal {
     return true;
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     return this.value;
   }
 }
@@ -95,7 +95,7 @@ export class StringLiteral extends Literal {
     return true;
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     // TODO: Remove these replacements when CQL-to-ELM fixes bug: https://github.com/cqframework/clinical_quality_language/issues/82
     return this.value.replace(/\\'/g, "'").replace(/\\"/g, '"');
   }

--- a/src/elm/logical.ts
+++ b/src/elm/logical.ts
@@ -1,3 +1,4 @@
+// TODO (MATT): check this pattern
 import { Expression } from './expression';
 import { ThreeValuedLogic } from '../datatypes/datatypes';
 import { Context } from '../runtime/context';
@@ -7,8 +8,8 @@ export class And extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    return ThreeValuedLogic.and(...this.execArgs(ctx));
+  async exec(ctx: Context) {
+    return ThreeValuedLogic.and(...(await this.execArgs(ctx)));
   }
 }
 
@@ -17,8 +18,8 @@ export class Or extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    return ThreeValuedLogic.or(...this.execArgs(ctx));
+  async exec(ctx: Context) {
+    return ThreeValuedLogic.or(...(await this.execArgs(ctx)));
   }
 }
 
@@ -27,8 +28,8 @@ export class Not extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    return ThreeValuedLogic.not(this.execArgs(ctx));
+  async exec(ctx: Context) {
+    return ThreeValuedLogic.not(await this.execArgs(ctx));
   }
 }
 
@@ -37,8 +38,8 @@ export class Xor extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    return ThreeValuedLogic.xor(...this.execArgs(ctx));
+  async exec(ctx: Context) {
+    return ThreeValuedLogic.xor(...(await this.execArgs(ctx)));
   }
 }
 
@@ -47,8 +48,8 @@ export class IsTrue extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    return true === this.execArgs(ctx);
+  async exec(ctx: Context) {
+    return true === (await this.execArgs(ctx));
   }
 }
 
@@ -57,7 +58,7 @@ export class IsFalse extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    return false === this.execArgs(ctx);
+  async exec(ctx: Context) {
+    return false === (await this.execArgs(ctx));
   }
 }

--- a/src/elm/logical.ts
+++ b/src/elm/logical.ts
@@ -1,4 +1,3 @@
-// TODO (MATT): check this pattern
 import { Expression } from './expression';
 import { ThreeValuedLogic } from '../datatypes/datatypes';
 import { Context } from '../runtime/context';

--- a/src/elm/message.ts
+++ b/src/elm/message.ts
@@ -18,7 +18,6 @@ export class Message extends Expression {
     this.message = build(json.message);
   }
 
-  // TODO (MATT): Check this
   async exec(ctx: Context) {
     const source = await this.source.execute(ctx);
     const condition = await this.condition.execute(ctx);

--- a/src/elm/message.ts
+++ b/src/elm/message.ts
@@ -18,13 +18,14 @@ export class Message extends Expression {
     this.message = build(json.message);
   }
 
-  exec(ctx: Context) {
-    const source = this.source.execute(ctx);
-    const condition = this.condition.execute(ctx);
+  // TODO (MATT): Check this
+  async exec(ctx: Context) {
+    const source = await this.source.execute(ctx);
+    const condition = await this.condition.execute(ctx);
     if (condition) {
-      const code = this.code.execute(ctx);
-      const severity = this.severity.execute(ctx);
-      const message = this.message.execute(ctx);
+      const code = await this.code.execute(ctx);
+      const severity = await this.severity.execute(ctx);
+      const message = await this.message.execute(ctx);
       const listener = ctx.getMessageListener();
       if (listener && typeof listener.onMessage === 'function') {
         listener.onMessage(source, code, severity, message);

--- a/src/elm/nullological.ts
+++ b/src/elm/nullological.ts
@@ -6,7 +6,7 @@ export class Null extends Expression {
     super(json);
   }
 
-  exec(_ctx: Context): any {
+  async exec(_ctx: Context): Promise<any> {
     return null;
   }
 }
@@ -16,8 +16,8 @@ export class IsNull extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    return this.execArgs(ctx) == null;
+  async exec(ctx: Context) {
+    return (await this.execArgs(ctx)) == null;
   }
 }
 
@@ -26,10 +26,10 @@ export class Coalesce extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     if (this.args) {
       for (const arg of this.args) {
-        const result = arg.execute(ctx);
+        const result = await arg.execute(ctx);
         // if a single arg that's a list, coalesce over the list
         if (this.args.length === 1 && Array.isArray(result)) {
           const item = result.find(item => item != null);

--- a/src/elm/overloaded.ts
+++ b/src/elm/overloaded.ts
@@ -51,7 +51,6 @@ export class NotEqual extends Expression {
     if (args[0] == null || args[1] == null) {
       return null;
     }
-    // TODO (MATT): check this
     // @ts-ignore
     return ThreeValuedLogic.not(equals(...(await this.execArgs(ctx))));
   }

--- a/src/elm/overloaded.ts
+++ b/src/elm/overloaded.ts
@@ -80,7 +80,7 @@ export class Union extends Expression {
   }
 
   listTypeArgs() {
-    return this.args?.some(arg => {
+    return this.args?.some((arg: any) => {
       return arg.asTypeSpecifier != null && arg.asTypeSpecifier.type === 'ListTypeSpecifier';
     });
   }
@@ -259,7 +259,7 @@ export class Length extends Expression {
     const arg = await this.execArgs(ctx);
     if (arg != null) {
       return arg.length;
-    } else if (this.arg.asTypeSpecifier.type === 'ListTypeSpecifier') {
+    } else if ((this.arg as any).asTypeSpecifier.type === 'ListTypeSpecifier') {
       return 0;
     } else {
       return null;

--- a/src/elm/overloaded.ts
+++ b/src/elm/overloaded.ts
@@ -14,8 +14,8 @@ export class Equal extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args[0] == null || args[1] == null) {
       return null;
     }
@@ -29,8 +29,8 @@ export class Equivalent extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a == null && b == null) {
       return true;
     } else if (a == null || b == null) {
@@ -46,13 +46,14 @@ export class NotEqual extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args[0] == null || args[1] == null) {
       return null;
     }
+    // TODO (MATT): check this
     // @ts-ignore
-    return ThreeValuedLogic.not(equals(...this.execArgs(ctx)));
+    return ThreeValuedLogic.not(equals(...(await this.execArgs(ctx))));
   }
 }
 
@@ -61,8 +62,8 @@ export class Union extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a == null && b == null) {
       return this.listTypeArgs() ? [] : null;
     }
@@ -90,8 +91,8 @@ export class Except extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a == null) {
       return null;
     }
@@ -108,8 +109,8 @@ export class Intersect extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a == null || b == null) {
       return null;
     }
@@ -123,8 +124,8 @@ export class Indexer extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const [operand, index] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [operand, index] = await this.execArgs(ctx);
     if (operand == null || index == null) {
       return null;
     }
@@ -143,8 +144,8 @@ export class In extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [item, container] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [item, container] = await this.execArgs(ctx);
     if (item == null) {
       return null;
     }
@@ -164,8 +165,8 @@ export class Contains extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [container, item] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [container, item] = await this.execArgs(ctx);
     if (container == null) {
       return false;
     }
@@ -185,8 +186,8 @@ export class Includes extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [container, contained] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [container, contained] = await this.execArgs(ctx);
     if (container == null || contained == null) {
       return null;
     }
@@ -203,8 +204,8 @@ export class IncludedIn extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [contained, container] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [contained, container] = await this.execArgs(ctx);
     if (container == null || contained == null) {
       return null;
     }
@@ -221,8 +222,8 @@ export class ProperIncludes extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [container, contained] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [container, contained] = await this.execArgs(ctx);
     if (container == null || contained == null) {
       return null;
     }
@@ -239,8 +240,8 @@ export class ProperIncludedIn extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [contained, container] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [contained, container] = await this.execArgs(ctx);
     if (container == null || contained == null) {
       return null;
     }
@@ -254,8 +255,8 @@ export class Length extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       return arg.length;
     } else if (this.arg.asTypeSpecifier.type === 'ListTypeSpecifier') {
@@ -274,8 +275,8 @@ export class After extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a == null || b == null) {
       return null;
     }
@@ -292,8 +293,8 @@ export class Before extends Expression {
     this.precision = json.precision != null ? json.precision.toLowerCase() : undefined;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a == null || b == null) {
       return null;
     }
@@ -310,8 +311,8 @@ export class SameAs extends Expression {
     this.precision = json.precision;
   }
 
-  exec(ctx: Context) {
-    const [a, b] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [a, b] = await this.execArgs(ctx);
     if (a != null && b != null) {
       return a.sameAs(b, this.precision != null ? this.precision.toLowerCase() : undefined);
     } else {
@@ -328,8 +329,8 @@ export class SameOrAfter extends Expression {
     this.precision = json.precision;
   }
 
-  exec(ctx: Context) {
-    const [d1, d2] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [d1, d2] = await this.execArgs(ctx);
     if (d1 != null && d2 != null) {
       return d1.sameOrAfter(d2, this.precision != null ? this.precision.toLowerCase() : undefined);
     } else {
@@ -346,8 +347,8 @@ export class SameOrBefore extends Expression {
     this.precision = json.precision;
   }
 
-  exec(ctx: Context) {
-    const [d1, d2] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [d1, d2] = await this.execArgs(ctx);
     if (d1 != null && d2 != null) {
       return d1.sameOrBefore(d2, this.precision != null ? this.precision.toLowerCase() : undefined);
     } else {
@@ -362,8 +363,8 @@ export class Precision extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     }

--- a/src/elm/parameters.ts
+++ b/src/elm/parameters.ts
@@ -24,7 +24,6 @@ export class ParameterDef extends Expression {
       return parentParam.default != null ? parentParam.default.execute(ctx) : parentParam;
       // If default type exists, execute the default type
     } else if (this.default != null) {
-      // TODO (MATT): check this
       await this.default.execute(ctx);
     }
   }

--- a/src/elm/parameters.ts
+++ b/src/elm/parameters.ts
@@ -14,7 +14,7 @@ export class ParameterDef extends Expression {
     this.parameterTypeSpecifier = json.parameterTypeSpecifier;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     // If context parameters contains the name, return value.
     if (ctx && ctx.parameters[this.name] !== undefined) {
       return ctx.parameters[this.name];
@@ -24,7 +24,8 @@ export class ParameterDef extends Expression {
       return parentParam.default != null ? parentParam.default.execute(ctx) : parentParam;
       // If default type exists, execute the default type
     } else if (this.default != null) {
-      this.default.execute(ctx);
+      // TODO (MATT): check this
+      await this.default.execute(ctx);
     }
   }
 }
@@ -39,7 +40,7 @@ export class ParameterRef extends Expression {
     this.library = json.libraryName;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
     const param = ctx.getParameter(this.name);
     return param != null ? param.execute(ctx) : undefined;

--- a/src/elm/quantity.ts
+++ b/src/elm/quantity.ts
@@ -14,7 +14,7 @@ export class Quantity extends Expression {
     this.unit = json.unit;
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     return new DT.Quantity(this.value, this.unit);
   }
 }

--- a/src/elm/query.ts
+++ b/src/elm/query.ts
@@ -216,7 +216,7 @@ class AggregateClause extends Expression {
 export class Query extends Expression {
   sources: MultiSource;
   letClauses: LetClause[];
-  relationship: any[];
+  relationship: Expression[];
   where: any;
   returnClause: ReturnClause | null;
   aggregateClause: AggregateClause | null;
@@ -227,7 +227,7 @@ export class Query extends Expression {
     super(json);
     this.sources = new MultiSource(json.source.map((s: any) => new AliasedQuerySource(s)));
     this.letClauses = json.let != null ? json.let.map((d: any) => new LetClause(d)) : [];
-    this.relationship = json.relationship != null ? build(json.relationship) : [];
+    this.relationship = json.relationship != null ? (build(json.relationship) as Expression[]) : [];
     this.where = build(json.where);
     this.returnClause = json.return != null ? new ReturnClause(json.return) : null;
     this.aggregateClause = json.aggregate != null ? new AggregateClause(json.aggregate) : null;

--- a/src/elm/query.ts
+++ b/src/elm/query.ts
@@ -56,7 +56,6 @@ export class Without extends With {
     super(json);
   }
   async exec(ctx: Context) {
-    // TODO (MATT): check this
     return !(await super.exec(ctx));
   }
 }
@@ -200,17 +199,11 @@ class AggregateClause extends Expression {
 
   async aggregate(returnedValues: any, ctx: Context) {
     let aggregateValue = this.starting != null ? await this.starting.exec(ctx) : null;
-    // TODO (MATT): check this
-    for await (const contextValues of returnedValues) {
+    for (const contextValues of returnedValues) {
       const childContext = ctx.childContext(contextValues);
       childContext.set(this.identifier, aggregateValue);
       aggregateValue = await this.expression.exec(childContext);
     }
-    /* returnedValues.forEach((contextValues: any) => {
-      const childContext = ctx.childContext(contextValues);
-      childContext.set(this.identifier, aggregateValue);
-      aggregateValue = this.expression.exec(childContext);
-    }); */
     return aggregateValue;
   }
 }
@@ -246,10 +239,8 @@ export class Query extends Expression {
     return true;
   }
 
-  // TODO (MATT) ALERT: might not work yet
   async exec(ctx: Context) {
     let returnedValues: any[] = [];
-    // TODO (MATT): there's no way this works, right?
     await this.sources.forEach(ctx, async (rctx: any) => {
       for (const def of this.letClauses) {
         rctx.set(def.identifier, await def.expression.execute(rctx));
@@ -345,8 +336,6 @@ class MultiSource {
     return this.isList || (this.rest && this.rest.returnsList());
   }
 
-  // TODO (MATT): check this (usage anywhere else in code needs to await)
-  // TODO (MATT) ALERT: might not work
   async forEach(ctx: Context, func: any) {
     let records = await this.expression.execute(ctx);
     this.isList = typeIsArray(records);

--- a/src/elm/query.ts
+++ b/src/elm/query.ts
@@ -35,8 +35,8 @@ export class With extends Expression {
     this.expression = build(json.expression);
     this.suchThat = build(json.suchThat);
   }
-  exec(ctx: Context) {
-    let records = this.expression.execute(ctx);
+  async exec(ctx: Context) {
+    let records = await this.expression.execute(ctx);
     if (!typeIsArray(records)) {
       records = [records];
     }
@@ -53,8 +53,9 @@ export class Without extends With {
   constructor(json: any) {
     super(json);
   }
-  exec(ctx: Context) {
-    return !super.exec(ctx);
+  async exec(ctx: Context) {
+    // TODO (MATT): check this
+    return !(await super.exec(ctx));
   }
 }
 
@@ -75,7 +76,7 @@ export class ByDirection extends Expression {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  exec(ctx: Context, a: any, b: any) {
+  async exec(ctx: Context, a: any, b: any) {
     if (a === b) {
       return 0;
     } else if (a.isQuantity && b.isQuantity) {
@@ -108,11 +109,11 @@ export class ByExpression extends Expression {
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  exec(ctx: Context, a: any, b: any) {
+  async exec(ctx: Context, a: any, b: any) {
     let sctx = ctx.childContext(a);
-    const a_val = this.expression.execute(sctx);
+    const a_val = await this.expression.execute(sctx);
     sctx = ctx.childContext(b);
-    const b_val = this.expression.execute(sctx);
+    const b_val = await this.expression.execute(sctx);
 
     if (a_val === b_val || (a_val == null && b_val == null)) {
       return 0;
@@ -159,6 +160,7 @@ export class SortClause {
         let order = 0;
         for (const item of this.by) {
           // Do not use execute here because the value of the sort order is not important.
+          // TODO (MATT) ALERT: doesn't work yet
           order = item.exec(ctx, a, b);
           if (order !== 0) {
             break;
@@ -194,13 +196,19 @@ class AggregateClause extends Expression {
     this.distinct = json.distinct != null ? json.distinct : true;
   }
 
-  aggregate(returnedValues: any, ctx: Context) {
-    let aggregateValue = this.starting != null ? this.starting.exec(ctx) : null;
-    returnedValues.forEach((contextValues: any) => {
+  async aggregate(returnedValues: any, ctx: Context) {
+    let aggregateValue = this.starting != null ? await this.starting.exec(ctx) : null;
+    // TODO (MATT): check this
+    for await (const contextValues of returnedValues) {
+      const childContext = ctx.childContext(contextValues);
+      childContext.set(this.identifier, aggregateValue);
+      aggregateValue = await this.expression.exec(childContext);
+    }
+    /* returnedValues.forEach((contextValues: any) => {
       const childContext = ctx.childContext(contextValues);
       childContext.set(this.identifier, aggregateValue);
       aggregateValue = this.expression.exec(childContext);
-    });
+    }); */
     return aggregateValue;
   }
 }
@@ -236,21 +244,23 @@ export class Query extends Expression {
     return true;
   }
 
-  exec(ctx: Context) {
+  // TODO (MATT) ALERT: might not work yet
+  async exec(ctx: Context) {
     let returnedValues: any[] = [];
-    this.sources.forEach(ctx, (rctx: any) => {
+    // TODO (MATT): there's no way this works, right?
+    await this.sources.forEach(ctx, async (rctx: any) => {
       for (const def of this.letClauses) {
-        rctx.set(def.identifier, def.expression.execute(rctx));
+        rctx.set(def.identifier, await def.expression.execute(rctx));
       }
 
       const relations = this.relationship.map(rel => {
         const child_ctx = rctx.childContext();
         return rel.execute(child_ctx);
       });
-      const passed = allTrue(relations) && (this.where ? this.where.execute(rctx) : true);
+      const passed = allTrue(relations) && (this.where ? await this.where.execute(rctx) : true);
       if (passed) {
         if (this.returnClause != null) {
-          const val = this.returnClause.expression.execute(rctx);
+          const val = await this.returnClause.expression.execute(rctx);
           returnedValues.push(val);
         } else {
           if (this.aliases.length === 1 && this.aggregateClause == null) {
@@ -267,7 +277,7 @@ export class Query extends Expression {
     }
 
     if (this.aggregateClause != null) {
-      returnedValues = this.aggregateClause.aggregate(returnedValues, ctx);
+      returnedValues = await this.aggregateClause.aggregate(returnedValues, ctx);
     }
 
     if (this.sortClause != null) {
@@ -289,7 +299,7 @@ export class AliasRef extends Expression {
     this.name = json.name;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     return ctx != null ? ctx.get(this.name) : undefined;
   }
 }
@@ -331,18 +341,22 @@ class MultiSource {
     return this.isList || (this.rest && this.rest.returnsList());
   }
 
-  forEach(ctx: Context, func: any) {
-    let records = this.expression.execute(ctx);
+  // TODO (MATT): check this (usage anywhere else in code needs to await)
+  // TODO (MATT) ALERT: might not work
+  async forEach(ctx: Context, func: any) {
+    let records = await this.expression.execute(ctx);
     this.isList = typeIsArray(records);
     records = this.isList ? records : [records];
-    return records.map((rec: any) => {
-      const rctx = new Context(ctx);
-      rctx.set(this.alias, rec);
-      if (this.rest) {
-        return this.rest.forEach(rctx, func);
-      } else {
-        return func(rctx);
-      }
-    });
+    return Promise.all(
+      records.map(async (rec: any) => {
+        const rctx = new Context(ctx);
+        rctx.set(this.alias, rec);
+        if (this.rest) {
+          return this.rest.forEach(rctx, func);
+        } else {
+          return func(rctx);
+        }
+      })
+    );
   }
 }

--- a/src/elm/query.ts
+++ b/src/elm/query.ts
@@ -27,24 +27,26 @@ export class LetClause {
 export class With extends Expression {
   alias: any;
   expression: any;
-  suchThat: any;
+  suchThat: Expression;
 
   constructor(json: any) {
     super(json);
     this.alias = json.alias;
     this.expression = build(json.expression);
-    this.suchThat = build(json.suchThat);
+    this.suchThat = build(json.suchThat) as Expression;
   }
   async exec(ctx: Context) {
-    let records = await this.expression.execute(ctx);
+    let records: any[] = await this.expression.execute(ctx);
     if (!typeIsArray(records)) {
       records = [records];
     }
-    const returns = records.map((rec: any) => {
-      const childCtx = ctx.childContext();
-      childCtx.set(this.alias, rec);
-      return this.suchThat.execute(childCtx);
-    });
+    const returns = await Promise.all(
+      records.map((rec: any) => {
+        const childCtx = ctx.childContext();
+        childCtx.set(this.alias, rec);
+        return this.suchThat.execute(childCtx);
+      })
+    );
     return returns.some((x: any) => x);
   }
 }
@@ -253,10 +255,12 @@ export class Query extends Expression {
         rctx.set(def.identifier, await def.expression.execute(rctx));
       }
 
-      const relations = this.relationship.map(rel => {
-        const child_ctx = rctx.childContext();
-        return rel.execute(child_ctx);
-      });
+      const relations = await Promise.all(
+        this.relationship.map(rel => {
+          const child_ctx = rctx.childContext();
+          return rel.execute(child_ctx);
+        })
+      );
       const passed = allTrue(relations) && (this.where ? await this.where.execute(rctx) : true);
       if (passed) {
         if (this.returnClause != null) {

--- a/src/elm/ratio.ts
+++ b/src/elm/ratio.ts
@@ -22,7 +22,7 @@ export class Ratio extends Expression {
     }
   }
 
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     return new DT.Ratio(this.numerator, this.denominator);
   }
 }

--- a/src/elm/reusable.ts
+++ b/src/elm/reusable.ts
@@ -14,8 +14,8 @@ export class ExpressionDef extends Expression {
     this.context = json.context;
     this.expression = build(json.expression);
   }
-  exec(ctx: Context) {
-    const value = this.expression != null ? this.expression.execute(ctx) : undefined;
+  async exec(ctx: Context) {
+    const value = this.expression != null ? await this.expression.execute(ctx) : undefined;
     ctx.rootContext().set(this.name, value);
     return value;
   }
@@ -30,11 +30,11 @@ export class ExpressionRef extends Expression {
     this.name = json.name;
     this.library = json.libraryName;
   }
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     ctx = this.library ? ctx.getLibraryContext(this.library) : ctx;
     let value = ctx.get(this.name);
     if (value instanceof Expression) {
-      value = value.execute(ctx);
+      value = await value.execute(ctx);
     }
     return value;
   }
@@ -51,7 +51,7 @@ export class FunctionDef extends Expression {
     this.expression = build(json.expression);
     this.parameters = json.operand;
   }
-  exec(_ctx: Context) {
+  async exec(_ctx: Context) {
     return this;
   }
 }
@@ -66,7 +66,7 @@ export class FunctionRef extends Expression {
     this.library = json.libraryName;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     let functionDefs, child_ctx;
     if (this.library) {
       const lib = ctx.get(this.library);
@@ -77,7 +77,7 @@ export class FunctionRef extends Expression {
       functionDefs = ctx.get(this.name);
       child_ctx = ctx.childContext();
     }
-    const args = this.execArgs(ctx);
+    const args = await this.execArgs(ctx);
 
     // Filter out functions w/ wrong number of arguments.
     functionDefs = functionDefs.filter((f: any) => f.parameters.length === args.length);
@@ -127,7 +127,7 @@ export class OperandRef extends Expression {
     this.name = json.name;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     return ctx.get(this.name);
   }
 }
@@ -141,7 +141,7 @@ export class IdentifierRef extends Expression {
     this.name = json.name;
     this.library = json.libraryName;
   }
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     // TODO: Technically, the ELM Translator should never output one of these
     // but this code is needed since it does, as a work-around to get queries
     // to work properly when sorting by a field in a tuple

--- a/src/elm/string.ts
+++ b/src/elm/string.ts
@@ -7,8 +7,8 @@ export class Concatenate extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args.some((x: any) => x == null)) {
       return null;
     } else {
@@ -27,9 +27,9 @@ export class Combine extends Expression {
     this.separator = build(json.separator);
   }
 
-  exec(ctx: Context) {
-    const source = this.source.execute(ctx);
-    const separator = this.separator != null ? this.separator.execute(ctx) : '';
+  async exec(ctx: Context) {
+    const source = await this.source.execute(ctx);
+    const separator = this.separator != null ? await this.separator.execute(ctx) : '';
     if (source == null) {
       return null;
     } else {
@@ -53,9 +53,9 @@ export class Split extends Expression {
     this.separator = build(json.separator);
   }
 
-  exec(ctx: Context) {
-    const stringToSplit = this.stringToSplit.execute(ctx);
-    const separator = this.separator.execute(ctx);
+  async exec(ctx: Context) {
+    const stringToSplit = await this.stringToSplit.execute(ctx);
+    const separator = await this.separator.execute(ctx);
     if (stringToSplit && separator) {
       return stringToSplit.split(separator);
     }
@@ -73,9 +73,9 @@ export class SplitOnMatches extends Expression {
     this.separatorPattern = build(json.separatorPattern);
   }
 
-  exec(ctx: Context) {
-    const stringToSplit = this.stringToSplit.execute(ctx);
-    const separatorPattern = this.separatorPattern.execute(ctx);
+  async exec(ctx: Context) {
+    const stringToSplit = await this.stringToSplit.execute(ctx);
+    const separatorPattern = await this.separatorPattern.execute(ctx);
     if (stringToSplit && separatorPattern) {
       return stringToSplit.split(new RegExp(separatorPattern));
     }
@@ -90,8 +90,8 @@ export class Upper extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       return arg.toUpperCase();
     } else {
@@ -105,8 +105,8 @@ export class Lower extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       return arg.toLowerCase();
     } else {
@@ -127,9 +127,9 @@ export class PositionOf extends Expression {
     this.string = build(json.string);
   }
 
-  exec(ctx: Context) {
-    const pattern = this.pattern.execute(ctx);
-    const string = this.string.execute(ctx);
+  async exec(ctx: Context) {
+    const pattern = await this.pattern.execute(ctx);
+    const string = await this.string.execute(ctx);
     if (pattern == null || string == null) {
       return null;
     } else {
@@ -148,9 +148,9 @@ export class LastPositionOf extends Expression {
     this.string = build(json.string);
   }
 
-  exec(ctx: Context) {
-    const pattern = this.pattern.execute(ctx);
-    const string = this.string.execute(ctx);
+  async exec(ctx: Context) {
+    const pattern = await this.pattern.execute(ctx);
+    const string = await this.string.execute(ctx);
     if (pattern == null || string == null) {
       return null;
     } else {
@@ -164,8 +164,8 @@ export class Matches extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const [string, pattern] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [string, pattern] = await this.execArgs(ctx);
     if (string == null || pattern == null) {
       return null;
     }
@@ -186,10 +186,10 @@ export class Substring extends Expression {
     this.length = build(json['length']);
   }
 
-  exec(ctx: Context) {
-    const stringToSub = this.stringToSub.execute(ctx);
-    const startIndex = this.startIndex.execute(ctx);
-    const length = this.length != null ? this.length.execute(ctx) : null;
+  async exec(ctx: Context) {
+    const stringToSub = await this.stringToSub.execute(ctx);
+    const startIndex = await this.startIndex.execute(ctx);
+    const length = this.length != null ? await this.length.execute(ctx) : null;
     // According to spec: If stringToSub or startIndex is null, or startIndex is out of range, the result is null.
     if (
       stringToSub == null ||
@@ -211,8 +211,8 @@ export class StartsWith extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args.some((x: any) => x == null)) {
       return null;
     } else {
@@ -226,8 +226,8 @@ export class EndsWith extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args.some((x: any) => x == null)) {
       return null;
     } else {
@@ -241,8 +241,8 @@ export class ReplaceMatches extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const args = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const args = await this.execArgs(ctx);
     if (args.some((x: any) => x == null)) {
       return null;
     } else {

--- a/src/elm/structured.ts
+++ b/src/elm/structured.ts
@@ -14,10 +14,10 @@ export class Property extends Expression {
     this.path = json.path;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     let obj = this.scope != null ? ctx.get(this.scope) : this.source;
     if (obj instanceof Expression) {
-      obj = obj.execute(ctx);
+      obj = await obj.execute(ctx);
     }
     let val = getPropertyFromObject(obj, this.path);
     if (val == null) {
@@ -66,10 +66,11 @@ export class Tuple extends Expression {
     return true;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     const val: any = {};
+    // TODO (MATT): check this
     for (const el of this.elements) {
-      val[el.name] = el.value != null ? el.value.execute(ctx) : undefined;
+      val[el.name] = el.value != null ? await el.value.execute(ctx) : undefined;
     }
     return val;
   }

--- a/src/elm/structured.ts
+++ b/src/elm/structured.ts
@@ -68,7 +68,6 @@ export class Tuple extends Expression {
 
   async exec(ctx: Context) {
     const val: any = {};
-    // TODO (MATT): check this
     for (const el of this.elements) {
       val[el.name] = el.value != null ? await el.value.execute(ctx) : undefined;
     }

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -485,9 +485,9 @@ export class ConvertsToTime extends Expression {
   }
 }
 
-function canConvertToType(toFunction: any, operand: any, ctx: Context) {
+async function canConvertToType(toFunction: any, operand: any, ctx: Context) {
   try {
-    const value = new toFunction({ type: toFunction.name, operand: operand }).execute(ctx);
+    const value = await new toFunction({ type: toFunction.name, operand: operand }).execute(ctx);
     if (value != null) {
       return true;
     } else {

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -246,10 +246,9 @@ export class ToTime extends Expression {
       const timeString = arg.toString();
       // Return null if string doesn't represent a valid ISO-8601 Time
       // hh:mm:ss.fff or hh:mm:ss.fff
-      const matches =
-        /^T?((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?$/.exec(
-          timeString
-        );
+      const matches = /^T?((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?$/.exec(
+        timeString
+      );
       if (matches == null) {
         return null;
       }

--- a/src/elm/type.ts
+++ b/src/elm/type.ts
@@ -29,8 +29,8 @@ export class As extends Expression {
     this.strict = json.strict != null ? json.strict : false;
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     // If it is null, return null
     if (arg == null) {
       return null;
@@ -53,8 +53,8 @@ export class ToBoolean extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       const strArg = arg.toString().toLowerCase();
       if (['true', 't', 'yes', 'y', '1'].includes(strArg)) {
@@ -72,8 +72,8 @@ export class ToConcept extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       return new Concept([arg], arg.display);
     } else {
@@ -87,8 +87,8 @@ export class ToDate extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     } else if (arg.isDateTime) {
@@ -104,8 +104,8 @@ export class ToDateTime extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg == null) {
       return null;
     } else if (arg.isDate) {
@@ -121,8 +121,8 @@ export class ToDecimal extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       if (arg.isUncertainty) {
         const low = limitDecimalPrecision(parseFloat(arg.low.toString()));
@@ -144,8 +144,8 @@ export class ToInteger extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (typeof arg === 'string') {
       const integer = parseInt(arg);
       if (isValidInteger(integer)) {
@@ -163,8 +163,8 @@ export class ToQuantity extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    return this.convertValue(this.execArgs(ctx));
+  async exec(ctx: Context) {
+    return this.convertValue(await this.execArgs(ctx));
   }
 
   convertValue(val: any): any {
@@ -189,8 +189,8 @@ export class ToRatio extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       // Argument will be of form '<quantity>:<quantity>'
       let denominator, numerator;
@@ -225,8 +225,8 @@ export class ToString extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       return arg.toString();
     } else {
@@ -240,15 +240,16 @@ export class ToTime extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg != null) {
       const timeString = arg.toString();
       // Return null if string doesn't represent a valid ISO-8601 Time
       // hh:mm:ss.fff or hh:mm:ss.fff
-      const matches = /^T?((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?$/.exec(
-        timeString
-      );
+      const matches =
+        /^T?((\d{2})(:(\d{2})(:(\d{2})(\.(\d+))?)?)?)?(Z|(([+-])(\d{2})(:?(\d{2}))?))?$/.exec(
+          timeString
+        );
       if (matches == null) {
         return null;
       }
@@ -297,7 +298,7 @@ export class Convert extends Expression {
     this.toType = json.toType;
   }
 
-  exec(ctx: Context) {
+  async exec(ctx: Context) {
     switch (this.toType) {
       case '{urn:hl7-org:elm-types:r1}Boolean':
         return new ToBoolean({ type: 'ToBoolean', operand: this.operand }).execute(ctx);
@@ -331,8 +332,8 @@ export class ConvertsToBoolean extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -349,8 +350,8 @@ export class ConvertsToDate extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -367,8 +368,8 @@ export class ConvertsToDateTime extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -385,8 +386,8 @@ export class ConvertsToDecimal extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -403,8 +404,8 @@ export class ConvertsToInteger extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -421,8 +422,8 @@ export class ConvertsToQuantity extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -439,8 +440,8 @@ export class ConvertsToRatio extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -457,8 +458,8 @@ export class ConvertsToString extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -475,8 +476,8 @@ export class ConvertsToTime extends Expression {
     this.operand = json.operand;
   }
 
-  exec(ctx: Context) {
-    const operatorValue = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const operatorValue = await this.execArgs(ctx);
     if (operatorValue === null) {
       return null;
     } else {
@@ -503,8 +504,8 @@ export class ConvertQuantity extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const [quantity, newUnit] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [quantity, newUnit] = await this.execArgs(ctx);
 
     if (quantity != null && newUnit != null) {
       try {
@@ -522,8 +523,8 @@ export class CanConvertQuantity extends Expression {
     super(json);
   }
 
-  exec(ctx: Context) {
-    const [quantity, newUnit] = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const [quantity, newUnit] = await this.execArgs(ctx);
 
     if (quantity != null && newUnit != null) {
       try {
@@ -553,8 +554,8 @@ export class Is extends Expression {
     }
   }
 
-  exec(ctx: Context) {
-    const arg = this.execArgs(ctx);
+  async exec(ctx: Context) {
+    const arg = await this.execArgs(ctx);
     if (arg === null) {
       return false;
     }

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -77,7 +77,7 @@ export class Context {
     }
   }
 
-  findRecords(profile: any): any {
+  async findRecords(profile: any): Promise<any> {
     return this.parent && this.parent.findRecords(profile);
   }
 
@@ -461,7 +461,7 @@ export class PatientContext extends Context {
     return this.localId_context[localId];
   }
 
-  findRecords(profile: any) {
+  async findRecords(profile: any) {
     return this.patient && this.patient.findRecords(profile);
   }
 }
@@ -482,7 +482,7 @@ export class UnfilteredContext extends Context {
     return this;
   }
 
-  findRecords(_template: any) {
+  async findRecords(_template: any) {
     throw new Exception('Retreives are not currently supported in Unfiltered Context');
   }
 

--- a/src/runtime/executor.ts
+++ b/src/runtime/executor.ts
@@ -64,7 +64,6 @@ export class Executor {
       this.messageListener
     );
     const resultMap: any = {};
-    // TODO (MATT): check this
     for (const key in this.library.expressions) {
       const expr = this.library.expressions[key];
       if (expr.context === 'Unfiltered') {
@@ -87,7 +86,6 @@ export class Executor {
         this.messageListener
       );
       const resultMap: any = {};
-      // TODO (MATT): check this
       for (const key in this.library.expressions) {
         const expr = this.library.expressions[key];
         if (expr.context === 'Patient') {

--- a/src/runtime/executor.ts
+++ b/src/runtime/executor.ts
@@ -33,7 +33,7 @@ export class Executor {
     return this;
   }
 
-  exec_expression(expression: any, patientSource: DataProvider, executionDateTime: DateTime) {
+  async exec_expression(expression: any, patientSource: DataProvider, executionDateTime: DateTime) {
     const r = new Results();
     const expr = this.library.expressions[expression];
     if (expr != null) {
@@ -53,8 +53,8 @@ export class Executor {
     return r;
   }
 
-  exec(patientSource: DataProvider, executionDateTime?: DateTime) {
-    const r = this.exec_patient_context(patientSource, executionDateTime);
+  async exec(patientSource: DataProvider, executionDateTime?: DateTime) {
+    const r = await this.exec_patient_context(patientSource, executionDateTime);
     const unfilteredContext = new UnfilteredContext(
       this.library,
       r,
@@ -64,17 +64,18 @@ export class Executor {
       this.messageListener
     );
     const resultMap: any = {};
+    // TODO (MATT): check this
     for (const key in this.library.expressions) {
       const expr = this.library.expressions[key];
       if (expr.context === 'Unfiltered') {
-        resultMap[key] = expr.exec(unfilteredContext);
+        resultMap[key] = await expr.exec(unfilteredContext);
       }
     }
     r.recordUnfilteredResults(resultMap);
     return r;
   }
 
-  exec_patient_context(patientSource: DataProvider, executionDateTime?: DateTime) {
+  async exec_patient_context(patientSource: DataProvider, executionDateTime?: DateTime) {
     const r = new Results();
     while (patientSource.currentPatient()) {
       const patient_ctx = new PatientContext(
@@ -86,10 +87,11 @@ export class Executor {
         this.messageListener
       );
       const resultMap: any = {};
+      // TODO (MATT): check this
       for (const key in this.library.expressions) {
         const expr = this.library.expressions[key];
         if (expr.context === 'Patient') {
-          resultMap[key] = expr.execute(patient_ctx);
+          resultMap[key] = await expr.execute(patient_ctx);
         }
       }
       r.recordPatientResults(patient_ctx, resultMap);

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -75,9 +75,9 @@ export function getTimezoneSeparatorFromString(string: string) {
   return '';
 }
 
-type SortCompareFn = (a: any, b: any) => Promise<number>;
+type SortCompareFn<T> = (a: T, b: T) => Promise<number>;
 
-export async function asyncMergeSort(arr: any[], compareFn: SortCompareFn): Promise<any[]> {
+export async function asyncMergeSort<T>(arr: T[], compareFn: SortCompareFn<T>): Promise<T[]> {
   if (arr.length <= 1) return arr;
 
   const midpoint = Math.floor(arr.length / 2);
@@ -88,13 +88,19 @@ export async function asyncMergeSort(arr: any[], compareFn: SortCompareFn): Prom
   return merge(left, right, compareFn);
 }
 
-async function merge(left: any[], right: any[], compareFn: SortCompareFn) {
-  const sorted: any[] = [];
+async function merge<T>(left: T[], right: T[], compareFn: SortCompareFn<T>) {
+  const sorted: T[] = [];
   while (left.length > 0 && right.length > 0) {
     if ((await compareFn(left[0], right[0])) < 0) {
-      sorted.push(left.shift());
+      const sortedElem = left.shift();
+      if (sortedElem !== undefined) {
+        sorted.push(sortedElem);
+      }
     } else {
-      sorted.push(right.shift());
+      const sortedElem = right.shift();
+      if (sortedElem !== undefined) {
+        sorted.push(sortedElem);
+      }
     }
   }
   return [...sorted, ...left, ...right];

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -74,3 +74,28 @@ export function getTimezoneSeparatorFromString(string: string) {
   }
   return '';
 }
+
+type SortCompareFn = (a: any, b: any) => Promise<number>;
+
+export async function asyncMergeSort(arr: any[], compareFn: SortCompareFn): Promise<any[]> {
+  if (arr.length <= 1) return arr;
+
+  const midpoint = Math.floor(arr.length / 2);
+
+  const left = await asyncMergeSort(arr.slice(0, midpoint), compareFn);
+  const right = await asyncMergeSort(arr.slice(midpoint), compareFn);
+
+  return merge(left, right, compareFn);
+}
+
+async function merge(left: any[], right: any[], compareFn: SortCompareFn) {
+  const sorted: any[] = [];
+  while (left.length > 0 && right.length > 0) {
+    if ((await compareFn(left[0], right[0])) < 0) {
+      sorted.push(left.shift());
+    } else {
+      sorted.push(right.shift());
+    }
+  }
+  return [...sorted, ...left, ...right];
+}

--- a/test/elm/aggregate/aggregate-test.ts
+++ b/test/elm/aggregate/aggregate-test.ts
@@ -12,17 +12,17 @@ describe('Count', () => {
     setup(this, data);
   });
 
-  it('should be able to count lists without nulls', function () {
-    this.not_null.exec(this.ctx).should.equal(5);
+  it('should be able to count lists without nulls', async function () {
+    (await this.not_null.exec(this.ctx)).should.equal(5);
   });
-  it('should be able to count lists with nulls', function () {
-    this.has_null.exec(this.ctx).should.equal(2);
+  it('should be able to count lists with nulls', async function () {
+    (await this.has_null.exec(this.ctx)).should.equal(2);
   });
-  it('should be able to count empty list', function () {
-    this.empty.exec(this.ctx).should.equal(0);
+  it('should be able to count empty list', async function () {
+    (await this.empty.exec(this.ctx)).should.equal(0);
   });
-  it('should be able to count null list', function () {
-    this.is_null.exec(this.ctx).should.equal(0);
+  it('should be able to count null list', async function () {
+    (await this.is_null.exec(this.ctx)).should.equal(0);
   });
 });
 
@@ -31,42 +31,42 @@ describe('Sum', () => {
     setup(this, data);
   });
 
-  it('should be able to sum lists without nulls', function () {
-    this.not_null.exec(this.ctx).should.equal(15);
+  it('should be able to sum lists without nulls', async function () {
+    (await this.not_null.exec(this.ctx)).should.equal(15);
   });
 
-  it('should be able to sum lists with nulls', function () {
-    this.has_null.exec(this.ctx).should.equal(3);
+  it('should be able to sum lists with nulls', async function () {
+    (await this.has_null.exec(this.ctx)).should.equal(3);
   });
 
-  it('should be able to sum empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should be able to sum empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
 
-  it('should be able to sum quantity lists without nulls', function () {
-    const q = this.not_null_q.exec(this.ctx);
+  it('should be able to sum quantity lists without nulls', async function () {
+    const q = await this.not_null_q.exec(this.ctx);
     validateQuantity(q, 15, 'ml');
   });
 
-  it('should be able to sum  quantity lists with nulls', function () {
-    validateQuantity(this.has_null_q.exec(this.ctx), 3, 'ml');
+  it('should be able to sum  quantity lists with nulls', async function () {
+    validateQuantity(await this.has_null_q.exec(this.ctx), 3, 'ml');
   });
 
-  it('should return null for unmatched units in a list of quantiies', function () {
-    should(this.unmatched_units_q.exec(this.ctx)).be.null();
+  it('should return null for unmatched units in a list of quantiies', async function () {
+    should(await this.unmatched_units_q.exec(this.ctx)).be.null();
   });
 
-  it('should be able to sum quantity lists with related units', function () {
-    const q = this.q_diff_units.exec(this.ctx);
+  it('should be able to sum quantity lists with related units', async function () {
+    const q = await this.q_diff_units.exec(this.ctx);
     validateQuantity(q, 15, 'ml');
   });
 
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
 
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -75,71 +75,71 @@ describe('Min', () => {
     setup(this, data);
   });
 
-  it('should be able to find min in lists without nulls', function () {
-    this.not_null.exec(this.ctx).should.equal(0);
+  it('should be able to find min in lists without nulls', async function () {
+    (await this.not_null.exec(this.ctx)).should.equal(0);
   });
-  it('should be able to find min in lists with nulls', function () {
-    this.has_null.exec(this.ctx).should.equal(-1);
+  it('should be able to find min in lists with nulls', async function () {
+    (await this.has_null.exec(this.ctx)).should.equal(-1);
   });
-  it('should return null for empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
-  it('should be able to find min in lists of quantiies without nulls', function () {
-    validateQuantity(this.not_null_q.exec(this.ctx), 0, 'ml');
+  it('should be able to find min in lists of quantiies without nulls', async function () {
+    validateQuantity(await this.not_null_q.exec(this.ctx), 0, 'ml');
   });
-  it('should be able to find min in lists of quantiies with nulls', function () {
-    validateQuantity(this.has_null_q.exec(this.ctx), -1, 'ml');
+  it('should be able to find min in lists of quantiies with nulls', async function () {
+    validateQuantity(await this.has_null_q.exec(this.ctx), -1, 'ml');
   });
-  it('should be able to find min in lists of quantiies with related units', function () {
-    validateQuantity(this.q_diff_units.exec(this.ctx), 0, 'ml');
-  });
-
-  it('list of Integers', function () {
-    this.integerMin.exec(this.ctx).should.equal(2);
+  it('should be able to find min in lists of quantiies with related units', async function () {
+    validateQuantity(await this.q_diff_units.exec(this.ctx), 0, 'ml');
   });
 
-  it('list of Decimals', function () {
-    this.decimalMin.exec(this.ctx).should.equal(-5);
+  it('list of Integers', async function () {
+    (await this.integerMin.exec(this.ctx)).should.equal(2);
   });
 
-  it('list of DateTimes', function () {
-    const dateTimeMin = this.dateTimeMin.exec(this.ctx);
+  it('list of Decimals', async function () {
+    (await this.decimalMin.exec(this.ctx)).should.equal(-5);
+  });
+
+  it('list of DateTimes', async function () {
+    const dateTimeMin = await this.dateTimeMin.exec(this.ctx);
     dateTimeMin.year.should.equal(2012);
     dateTimeMin.month.should.equal(9);
     dateTimeMin.day.should.equal(5);
   });
 
-  it('list of Dates', function () {
-    const dateMin = this.dateMin.exec(this.ctx);
+  it('list of Dates', async function () {
+    const dateMin = await this.dateMin.exec(this.ctx);
     dateMin.year.should.equal(2012);
     dateMin.month.should.equal(1);
   });
 
-  it('list of Times', function () {
-    const timeMin = this.timeMin.exec(this.ctx);
+  it('list of Times', async function () {
+    const timeMin = await this.timeMin.exec(this.ctx);
     timeMin.hour.should.equal(12);
     timeMin.minute.should.equal(30);
     timeMin.second.should.equal(3);
   });
 
-  it('list of Strings', function () {
-    this.stringMin.exec(this.ctx).should.equal('abc');
+  it('list of Strings', async function () {
+    (await this.stringMin.exec(this.ctx)).should.equal('abc');
   });
 
-  it('list of Nulls', function () {
-    should(this.minIsNull.exec(this.ctx)).be.null();
+  it('list of Nulls', async function () {
+    should(await this.minIsNull.exec(this.ctx)).be.null();
   });
 
-  it('null list', function () {
-    should(this.minIsAlsoNull.exec(this.ctx)).be.null();
+  it('null list', async function () {
+    should(await this.minIsAlsoNull.exec(this.ctx)).be.null();
   });
 
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
 
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -148,70 +148,70 @@ describe('Max', () => {
     setup(this, data);
   });
 
-  it('should be able to find max in lists without nulls', function () {
-    this.not_null.exec(this.ctx).should.equal(10);
+  it('should be able to find max in lists without nulls', async function () {
+    (await this.not_null.exec(this.ctx)).should.equal(10);
   });
-  it('should be able to find max in lists with nulls', function () {
-    this.has_null.exec(this.ctx).should.equal(2);
+  it('should be able to find max in lists with nulls', async function () {
+    (await this.has_null.exec(this.ctx)).should.equal(2);
   });
-  it('should return null for empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
-  it('should be able to find max in lists of quantiies without nulls', function () {
-    validateQuantity(this.not_null_q.exec(this.ctx), 10, 'ml');
+  it('should be able to find max in lists of quantiies without nulls', async function () {
+    validateQuantity(await this.not_null_q.exec(this.ctx), 10, 'ml');
   });
-  it('should be able to find max in lists of quantiies with nulls', function () {
-    validateQuantity(this.has_null_q.exec(this.ctx), 2, 'ml');
+  it('should be able to find max in lists of quantiies with nulls', async function () {
+    validateQuantity(await this.has_null_q.exec(this.ctx), 2, 'ml');
   });
-  it('should be able to find max in lists of quantiies with related units', function () {
-    validateQuantity(this.q_diff_units.exec(this.ctx), 5, 'l');
-  });
-
-  it('list of Integers', function () {
-    this.integerMax.exec(this.ctx).should.equal(8);
+  it('should be able to find max in lists of quantiies with related units', async function () {
+    validateQuantity(await this.q_diff_units.exec(this.ctx), 5, 'l');
   });
 
-  it('list of Decimals', function () {
-    this.decimalMax.exec(this.ctx).should.equal(5.1);
+  it('list of Integers', async function () {
+    (await this.integerMax.exec(this.ctx)).should.equal(8);
   });
 
-  it('list of DateTimes', function () {
-    const dateTimeMax = this.dateTimeMax.exec(this.ctx);
+  it('list of Decimals', async function () {
+    (await this.decimalMax.exec(this.ctx)).should.equal(5.1);
+  });
+
+  it('list of DateTimes', async function () {
+    const dateTimeMax = await this.dateTimeMax.exec(this.ctx);
     dateTimeMax.year.should.equal(2012);
     dateTimeMax.month.should.equal(9);
   });
 
-  it('list of Dates', function () {
-    const dateMax = this.dateMax.exec(this.ctx);
+  it('list of Dates', async function () {
+    const dateMax = await this.dateMax.exec(this.ctx);
     dateMax.year.should.equal(2013);
     dateMax.month.should.equal(1);
   });
 
-  it('list of Times', function () {
-    const timeMax = this.timeMax.exec(this.ctx);
+  it('list of Times', async function () {
+    const timeMax = await this.timeMax.exec(this.ctx);
     timeMax.hour.should.equal(12);
     timeMax.minute.should.equal(30);
     timeMax.second.should.equal(3);
   });
 
-  it('list of Strings', function () {
-    this.stringMax.exec(this.ctx).should.equal('jkl');
+  it('list of Strings', async function () {
+    (await this.stringMax.exec(this.ctx)).should.equal('jkl');
   });
 
-  it('list of Nulls', function () {
-    should(this.maxIsNull.exec(this.ctx)).be.null();
+  it('list of Nulls', async function () {
+    should(await this.maxIsNull.exec(this.ctx)).be.null();
   });
 
-  it('null list', function () {
-    should(this.maxIsAlsoNull.exec(this.ctx)).be.null();
+  it('null list', async function () {
+    should(await this.maxIsAlsoNull.exec(this.ctx)).be.null();
   });
 
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
 
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -220,39 +220,39 @@ describe('Avg', () => {
     setup(this, data);
   });
 
-  it('should be able to find average for lists without nulls', function () {
-    this.not_null.exec(this.ctx).should.equal(3);
+  it('should be able to find average for lists without nulls', async function () {
+    (await this.not_null.exec(this.ctx)).should.equal(3);
   });
 
-  it('should be able to find average for lists with nulls', function () {
-    this.has_null.exec(this.ctx).should.equal(1.5);
+  it('should be able to find average for lists with nulls', async function () {
+    (await this.has_null.exec(this.ctx)).should.equal(1.5);
   });
 
-  it('should return null for empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
 
-  it('should be able to find average for lists of quantiies without nulls', function () {
-    const q = this.not_null_q.exec(this.ctx);
+  it('should be able to find average for lists of quantiies without nulls', async function () {
+    const q = await this.not_null_q.exec(this.ctx);
     validateQuantity(q, 3, 'ml');
   });
 
-  it('should be able to find average for lists of quantiies with nulls', function () {
-    const q = this.has_null_q.exec(this.ctx);
+  it('should be able to find average for lists of quantiies with nulls', async function () {
+    const q = await this.has_null_q.exec(this.ctx);
     validateQuantity(q, 1.5, 'ml');
   });
 
-  it('should be able to find average for lists of quantiies with related units', function () {
-    const q = this.q_diff_units.exec(this.ctx);
+  it('should be able to find average for lists of quantiies with related units', async function () {
+    const q = await this.q_diff_units.exec(this.ctx);
     validateQuantity(q, 3, 'ml');
   });
 
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
 
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -261,57 +261,57 @@ describe('Median', () => {
     setup(this, data);
   });
 
-  it('should be able to find median of odd numbered list', function () {
-    this.odd.exec(this.ctx).should.equal(3);
+  it('should be able to find median of odd numbered list', async function () {
+    (await this.odd.exec(this.ctx)).should.equal(3);
   });
 
-  it('should be able to find median of even numbered list', function () {
-    this.even.exec(this.ctx).should.equal(3.5);
+  it('should be able to find median of even numbered list', async function () {
+    (await this.even.exec(this.ctx)).should.equal(3.5);
   });
 
-  it('should be able to find median of odd numbered list that contains duplicates', function () {
-    this.dup_vals_odd.exec(this.ctx).should.equal(3);
+  it('should be able to find median of odd numbered list that contains duplicates', async function () {
+    (await this.dup_vals_odd.exec(this.ctx)).should.equal(3);
   });
 
-  it('should be able to find median of even numbered list that contians duplicates', function () {
-    this.dup_vals_even.exec(this.ctx).should.equal(2.5);
+  it('should be able to find median of even numbered list that contians duplicates', async function () {
+    (await this.dup_vals_even.exec(this.ctx)).should.equal(2.5);
   });
 
-  it('should return null for empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
 
-  it('should be able to find median of odd numbered list', function () {
-    const q = this.odd_q.exec(this.ctx);
+  it('should be able to find median of odd numbered list', async function () {
+    const q = await this.odd_q.exec(this.ctx);
     validateQuantity(q, 3, 'ml');
   });
 
-  it('should be able to find median of even numbered list', function () {
-    const q = this.even_q.exec(this.ctx);
+  it('should be able to find median of even numbered list', async function () {
+    const q = await this.even_q.exec(this.ctx);
     validateQuantity(q, 3.5, 'ml');
   });
 
-  it('should be able to find median of odd numbered list that contains duplicates', function () {
-    const q = this.dup_vals_odd_q.exec(this.ctx);
+  it('should be able to find median of odd numbered list that contains duplicates', async function () {
+    const q = await this.dup_vals_odd_q.exec(this.ctx);
     validateQuantity(q, 3, 'ml');
   });
 
-  it('should be able to find median of even numbered list that contians duplicates', function () {
-    const q = this.dup_vals_even_q.exec(this.ctx);
+  it('should be able to find median of even numbered list that contians duplicates', async function () {
+    const q = await this.dup_vals_even_q.exec(this.ctx);
     validateQuantity(q, 2.5, 'ml');
   });
 
-  it('should be able to find median of even numbered list of quantities with related units', function () {
-    const q = this.q_diff_units.exec(this.ctx);
+  it('should be able to find median of even numbered list of quantities with related units', async function () {
+    const q = await this.q_diff_units.exec(this.ctx);
     validateQuantity(q, 3.5, 'ml');
   });
 
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
 
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -319,25 +319,25 @@ describe('Mode', () => {
   beforeEach(function () {
     setup(this, data);
   });
-  it('should be able to find mode of lists without nulls', function () {
-    this.not_null.exec(this.ctx).should.equal(2);
+  it('should be able to find mode of lists without nulls', async function () {
+    (await this.not_null.exec(this.ctx)).should.equal(2);
   });
-  it('should be able to find Mode lists with nulls', function () {
-    this.has_null.exec(this.ctx).should.equal(2);
+  it('should be able to find Mode lists with nulls', async function () {
+    (await this.has_null.exec(this.ctx)).should.equal(2);
   });
-  it('should return null for empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
-  it('should be able to find bimodal', function () {
-    this.bi_modal.exec(this.ctx).should.eql([2, 3]);
-  });
-
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be able to find bimodal', async function () {
+    (await this.bi_modal.exec(this.ctx)).should.eql([2, 3]);
   });
 
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
+  });
+
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -345,20 +345,20 @@ describe('PopulationVariance', () => {
   beforeEach(function () {
     setup(this, data);
   });
-  it('should be able to find PopulationVariance of a list ', function () {
-    this.v.exec(this.ctx).should.equal(2);
+  it('should be able to find PopulationVariance of a list ', async function () {
+    (await this.v.exec(this.ctx)).should.equal(2);
   });
-  it('should be able to find PopulationVariance of a list of like quantities', function () {
-    validateQuantity(this.v_q.exec(this.ctx), 2, 'ml');
+  it('should be able to find PopulationVariance of a list of like quantities', async function () {
+    validateQuantity(await this.v_q.exec(this.ctx), 2, 'ml');
   });
-  it('should be able to find PopulationVariance of a list of related quantities', function () {
-    validateQuantity(this.q_diff_units.exec(this.ctx), 2, 'ml');
+  it('should be able to find PopulationVariance of a list of related quantities', async function () {
+    validateQuantity(await this.q_diff_units.exec(this.ctx), 2, 'ml');
   });
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -366,20 +366,20 @@ describe('Variance', () => {
   beforeEach(function () {
     setup(this, data);
   });
-  it('should be able to find Variance of a list ', function () {
-    this.v.exec(this.ctx).should.equal(2.5);
+  it('should be able to find Variance of a list ', async function () {
+    (await this.v.exec(this.ctx)).should.equal(2.5);
   });
-  it('should be able to find Variance of a list of matched quantities', function () {
-    validateQuantity(this.v_q.exec(this.ctx), 2.5, 'ml');
+  it('should be able to find Variance of a list of matched quantities', async function () {
+    validateQuantity(await this.v_q.exec(this.ctx), 2.5, 'ml');
   });
-  it('should be able to find Variance of a list of related quantities', function () {
-    validateQuantity(this.q_diff_units.exec(this.ctx), 2.5, 'ml');
+  it('should be able to find Variance of a list of related quantities', async function () {
+    validateQuantity(await this.q_diff_units.exec(this.ctx), 2.5, 'ml');
   });
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -387,20 +387,20 @@ describe('StdDev', () => {
   beforeEach(function () {
     setup(this, data);
   });
-  it('should be able to find Standard Dev of a list ', function () {
-    this.std.exec(this.ctx).should.equal(1.5811388300841898);
+  it('should be able to find Standard Dev of a list ', async function () {
+    (await this.std.exec(this.ctx)).should.equal(1.5811388300841898);
   });
-  it('should be able to find Standard Dev of a list of like quantities', function () {
-    validateQuantity(this.std_q.exec(this.ctx), 1.5811388300841898, 'ml');
+  it('should be able to find Standard Dev of a list of like quantities', async function () {
+    validateQuantity(await this.std_q.exec(this.ctx), 1.5811388300841898, 'ml');
   });
-  it('should be able to find Standard Dev of a list of related quantities', function () {
-    validateQuantity(this.q_diff_units.exec(this.ctx), 1.5811388300841898, 'ml');
+  it('should be able to find Standard Dev of a list of related quantities', async function () {
+    validateQuantity(await this.q_diff_units.exec(this.ctx), 1.5811388300841898, 'ml');
   });
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -408,20 +408,20 @@ describe('PopulationStdDev', () => {
   beforeEach(function () {
     setup(this, data);
   });
-  it('should be able to find Population Standard Dev of a list ', function () {
-    this.dev.exec(this.ctx).should.equal(1.4142135623730951);
+  it('should be able to find Population Standard Dev of a list ', async function () {
+    (await this.dev.exec(this.ctx)).should.equal(1.4142135623730951);
   });
-  it('should be able to find Population Standard Dev of a list of quantities', function () {
-    validateQuantity(this.dev_q.exec(this.ctx), 1.4142135623730951, 'ml');
+  it('should be able to find Population Standard Dev of a list of quantities', async function () {
+    validateQuantity(await this.dev_q.exec(this.ctx), 1.4142135623730951, 'ml');
   });
-  it('should be able to find Population Standard Dev of a list of related quantities', function () {
-    validateQuantity(this.q_diff_units.exec(this.ctx), 1.4142135623730951, 'ml');
+  it('should be able to find Population Standard Dev of a list of related quantities', async function () {
+    validateQuantity(await this.q_diff_units.exec(this.ctx), 1.4142135623730951, 'ml');
   });
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -430,49 +430,49 @@ describe('Product', () => {
     setup(this, data);
   });
 
-  it('should return a decimal product', function () {
-    this.decimal_product.exec(this.ctx).should.equal(24.0);
+  it('should return a decimal product', async function () {
+    (await this.decimal_product.exec(this.ctx)).should.equal(24.0);
   });
 
-  it('should return a integer product', function () {
-    this.integer_product.exec(this.ctx).should.equal(100);
+  it('should return a integer product', async function () {
+    (await this.integer_product.exec(this.ctx)).should.equal(100);
   });
 
-  it('should return 0', function () {
-    this.zero_product.exec(this.ctx).should.equal(0);
+  it('should return 0', async function () {
+    (await this.zero_product.exec(this.ctx)).should.equal(0);
   });
 
-  it('should return product of non-null items', function () {
-    this.product_with_null.exec(this.ctx).should.equal(20);
+  it('should return product of non-null items', async function () {
+    (await this.product_with_null.exec(this.ctx)).should.equal(20);
   });
 
-  it('should return a quantity product', function () {
-    validateQuantity(this.quantity_product.exec(this.ctx), 24, 'g');
+  it('should return a quantity product', async function () {
+    validateQuantity(await this.quantity_product.exec(this.ctx), 24, 'g');
   });
 
-  it('should return a 0 quantity product', function () {
-    const q = this.quantity_zero_product.exec(this.ctx);
+  it('should return a 0 quantity product', async function () {
+    const q = await this.quantity_zero_product.exec(this.ctx);
     validateQuantity(q, 0, 'g');
   });
 
-  it('should return null when null list is passed in', function () {
-    should(this.product_null.exec(this.ctx)).be.null();
+  it('should return null when null list is passed in', async function () {
+    should(await this.product_null.exec(this.ctx)).be.null();
   });
 
-  it('should return null when passed in list of null quantities', function () {
-    should(this.product_quantity_null.exec(this.ctx)).be.null();
+  it('should return null when passed in list of null quantities', async function () {
+    should(await this.product_quantity_null.exec(this.ctx)).be.null();
   });
 
-  it('should return null when list is all null', function () {
-    should(this.product_of_nulls.exec(this.ctx)).be.null();
+  it('should return null when list is all null', async function () {
+    should(await this.product_of_nulls.exec(this.ctx)).be.null();
   });
 
-  it('should be null if some are numbers and some are quantities', function () {
-    should(this.numbersAndQuantities.exec(this.ctx)).be.null();
+  it('should be null if some are numbers and some are quantities', async function () {
+    should(await this.numbersAndQuantities.exec(this.ctx)).be.null();
   });
 
-  it('should be null if quantity units are not compatible', function () {
-    should(this.incompatibleUnitsNull.exec(this.ctx)).be.null();
+  it('should be null if quantity units are not compatible', async function () {
+    should(await this.incompatibleUnitsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -481,24 +481,24 @@ describe('GeometricMean', () => {
     setup(this, data);
   });
 
-  it('should return decimal geometric mean', function () {
-    this.decimal_geometric_mean.exec(this.ctx).should.equal(4.0);
+  it('should return decimal geometric mean', async function () {
+    (await this.decimal_geometric_mean.exec(this.ctx)).should.equal(4.0);
   });
 
-  it('should retun 0 as a geometric mean', function () {
-    this.zero_geometric_mean.exec(this.ctx).should.equal(0);
+  it('should retun 0 as a geometric mean', async function () {
+    (await this.zero_geometric_mean.exec(this.ctx)).should.equal(0);
   });
 
-  it('should return value when pass in list that contains nulls', function () {
-    this.null_geometric_mean.exec(this.ctx).should.equal(1.4142135623730951);
+  it('should return value when pass in list that contains nulls', async function () {
+    (await this.null_geometric_mean.exec(this.ctx)).should.equal(1.4142135623730951);
   });
 
-  it('should return null when list is all null', function () {
-    should(this.all_nulls.exec(this.ctx)).be.null();
+  it('should return null when list is all null', async function () {
+    should(await this.all_nulls.exec(this.ctx)).be.null();
   });
 
-  it('should return null when pass in list as null', function () {
-    should(this.also_null_geometric_mean.exec(this.ctx)).be.null();
+  it('should return null when pass in list as null', async function () {
+    should(await this.also_null_geometric_mean.exec(this.ctx)).be.null();
   });
 });
 
@@ -507,11 +507,11 @@ describe('AllTrue', () => {
     setup(this, data);
   });
 
-  it('should be able to calculate all true', function () {
-    this.at.exec(this.ctx).should.equal(true);
-    this.atwn.exec(this.ctx).should.equal(true);
-    this.atf.exec(this.ctx).should.equal(false);
-    this.atfwn.exec(this.ctx).should.equal(false);
+  it('should be able to calculate all true', async function () {
+    (await this.at.exec(this.ctx)).should.equal(true);
+    (await this.atwn.exec(this.ctx)).should.equal(true);
+    (await this.atf.exec(this.ctx)).should.equal(false);
+    (await this.atfwn.exec(this.ctx)).should.equal(false);
   });
 });
 
@@ -520,10 +520,10 @@ describe('AnyTrue', () => {
     setup(this, data);
   });
 
-  it('should be able to calculate any true', function () {
-    this.at.exec(this.ctx).should.equal(true);
-    this.atwn.exec(this.ctx).should.equal(true);
-    this.atf.exec(this.ctx).should.equal(false);
-    this.atfwn.exec(this.ctx).should.equal(false);
+  it('should be able to calculate any true', async function () {
+    (await this.at.exec(this.ctx)).should.equal(true);
+    (await this.atwn.exec(this.ctx)).should.equal(true);
+    (await this.atf.exec(this.ctx)).should.equal(false);
+    (await this.atfwn.exec(this.ctx)).should.equal(false);
   });
 });

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -60,7 +60,6 @@ describe('Add', () => {
   });
 
   it('should add Time/Quantity', async function () {
-    //not sure this is correct
     (await this.addTime.exec(this.ctx)).isTime().should.be.true();
   });
 
@@ -626,7 +625,6 @@ describe('Quantity', () => {
   });
 
   it('should be able to perform Quantity Addition', async function () {
-    //this seems like it could be off
     validateQuantity(await this.add_q_q.exec(this.ctx), 20, 'days');
     const adq = await this.add_d_q.exec(this.ctx);
     adq.isDateTime.should.be.true();

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -974,7 +974,7 @@ describe('OutOfBounds', () => {
     });
 
     it('should return null for successor overflow', async function () {
-      should(this.timeSuccessorOverflow.exec(this.ctx)).be.null();
+      should(await this.timeSuccessorOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for predecessor underflow', async function () {

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -183,7 +183,7 @@ describe('Divide', () => {
   });
 
   it('should divide uncertainty by number', async function () {
-    const result = await his.divideUncertaintyByNumber.exec(this.ctx);
+    const result = await this.divideUncertaintyByNumber.exec(this.ctx);
     result.low.should.equal(3);
     result.high.should.equal(9);
   });

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -265,8 +265,7 @@ describe('MinValue', () => {
   });
 
   it('of types other than Integer/Decimal/DateTime/Time should throw an error', async function () {
-    //not clear about how to handle this one adding await give an error
-    should(() => this.minWrongType.exec(this.ctx)).throw();
+   return this.minWrongType.exec(this.ctx).should.be.rejected();
   });
 });
 
@@ -319,8 +318,7 @@ describe('MaxValue', () => {
   });
 
   it('of types other than Integer/Decimal/DateTime/Time should throw an error', async function () {
-    //same issue here ask in slack
-    should(() => this.maxWrongType.exec(this.ctx)).throw();
+    return this.maxWrongType.exec(this.ctx).should.be.rejected();
   });
 });
 

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -393,7 +393,7 @@ describe('Modulo', () => {
     setup(this, data);
 
     it('should be able to return the remainder of a division', async function () {
-     (await  this.mod.exec(this.ctx)).should.equal(1);
+      (await this.mod.exec(this.ctx)).should.equal(1);
     });
   });
 });
@@ -424,7 +424,7 @@ describe('Round', () => {
     (await this.down.exec(this.ctx)).should.equal(4);
   });
   it('should be able to round a number up or down to the closest decimal place ', async function () {
-   (await this.up_percent.exec(this.ctx)).should.equal(4.6);
+    (await this.up_percent.exec(this.ctx)).should.equal(4.6);
     (await this.down_percent.exec(this.ctx)).should.equal(4.4);
   });
 });
@@ -442,7 +442,7 @@ describe('Successor', () => {
   });
 
   it('should return null for Successor greater than Integer Max value', async function () {
-    should((await this.ofr.exec(this.ctx))).be.null();
+    should(await this.ofr.exec(this.ctx)).be.null();
   });
 
   it('should be able to get Date Successor for year', async function () {
@@ -533,13 +533,13 @@ describe('Predecessor', () => {
   });
 
   it('should be able to get Integer Predecessor', async function () {
-   (await this.is.exec(this.ctx)).should.equal(1);
+    (await this.is.exec(this.ctx)).should.equal(1);
   });
   it('should be able to get Real Predecessor', async function () {
     (await this.rs.exec(this.ctx)).should.equal(2.2 - Math.pow(10, -8));
   });
   it('should return null for Predecessor greater than Integer Max value', async function () {
-    should((await this.ufr.exec(this.ctx))).be.null();
+    should(await this.ufr.exec(this.ctx)).be.null();
   });
 
   it('should be able to get Date Predecessor for year', async function () {
@@ -586,7 +586,7 @@ describe('Predecessor', () => {
   });
 
   it('should be able to get Date Predecessor for year,month,day,hour,minute', async function () {
-    const dp = await  this.ymdhm_date.exec(this.ctx);
+    const dp = await this.ymdhm_date.exec(this.ctx);
     dp.year.should.equal(2014);
     dp.month.should.equal(12);
     dp.day.should.equal(31);
@@ -618,7 +618,7 @@ describe('Predecessor', () => {
   });
 
   it('should return null when attempting to get the Predecessor of the minimum allowed date', async function () {
-    should((await this.min_date.exec(this.ctx))).be.null();
+    should(await this.min_date.exec(this.ctx)).be.null();
   });
 });
 
@@ -629,36 +629,36 @@ describe('Quantity', () => {
 
   it('should be able to perform Quantity Addition', async function () {
     //this seems like it could be off
-    validateQuantity((await this.add_q_q.exec(this.ctx)), 20, 'days');
-    const adq =await  this.add_d_q.exec(this.ctx);
+    validateQuantity(await this.add_q_q.exec(this.ctx), 20, 'days');
+    const adq = await this.add_d_q.exec(this.ctx);
     adq.isDateTime.should.be.true();
     adq.year.should.equal(2000);
     adq.month.should.equal(1);
     adq.day.should.equal(11);
-    validateQuantity((await this.add_q_q_diff.exec(this.ctx)), 10 + 10 / (24 * 60), 'days');
+    validateQuantity(await this.add_q_q_diff.exec(this.ctx), 10 + 10 / (24 * 60), 'days');
   });
 
   it('should be able to perform Quantity Subtraction', async function () {
-    validateQuantity((await this.sub_q_q.exec(this.ctx)), 0, 'days');
+    validateQuantity(await this.sub_q_q.exec(this.ctx), 0, 'days');
     const sdq = await this.sub_d_q.exec(this.ctx);
     sdq.isDateTime.should.be.true();
     sdq.year.should.equal(1999);
     sdq.month.should.equal(12);
     sdq.day.should.equal(22);
-    validateQuantity((await this.sub_q_q_diff.exec(this.ctx)), 10 - 10 / (24 * 60), 'days');
+    validateQuantity(await this.sub_q_q_diff.exec(this.ctx), 10 - 10 / (24 * 60), 'days');
   });
 
   it('should be able to perform Quantity Division', async function () {
-    validateQuantity((await this.div_q_d.exec(this.ctx)), 5, 'days');
-    validateQuantity((await this.div_q_q.exec(this.ctx)), 1, '1');
+    validateQuantity(await this.div_q_d.exec(this.ctx), 5, 'days');
+    validateQuantity(await this.div_q_q.exec(this.ctx), 1, '1');
   });
 
   it('should be able to perform Quantity Multiplication', async function () {
     // decimal to quantity multiplication results in decimal value only
-    validateQuantity((await this.mul_d_q.exec(this.ctx)), 20, 'days');
-    validateQuantity((await this.mul_q_d.exec(this.ctx)), 20, 'days');
-    validateQuantity((await this.mul_q_q.exec(this.ctx)), 20, 'm2');
-    validateQuantity((await this.mul_q_q_diff.exec(this.ctx)), 20, 'm/d');
+    validateQuantity(await this.mul_d_q.exec(this.ctx), 20, 'days');
+    validateQuantity(await this.mul_q_d.exec(this.ctx), 20, 'days');
+    validateQuantity(await this.mul_q_q.exec(this.ctx), 20, 'm2');
+    validateQuantity(await this.mul_q_q_diff.exec(this.ctx), 20, 'm/d');
   });
 
   it('should be able to perform Quantity Absolution', async function () {
@@ -668,7 +668,7 @@ describe('Quantity', () => {
   });
 
   it('should be able to perform Quantity Negation', async function () {
-    const q =await this.neg.exec(this.ctx);
+    const q = await this.neg.exec(this.ctx);
     q.value.should.equal(-10);
     q.unit.should.equal('days');
   });
@@ -738,187 +738,187 @@ describe('OutOfBounds', () => {
 
   describe('Integer', () => {
     it('should return null for Add overflow', async function () {
-      should((await this.integerAddOverflow.exec(this.ctx))).be.null();
+      should(await this.integerAddOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Add underflow', async function () {
-      should((await this.integerAddUnderflow.exec(this.ctx))).be.null();
+      should(await this.integerAddUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract overflow', async function () {
-      should((await this.integerSubtractOverflow.exec(this.ctx))).be.null();
+      should(await this.integerSubtractOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract underflow', async function () {
-      should((await this.integerSubtractUnderflow.exec(this.ctx))).be.null();
+      should(await this.integerSubtractUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Multiply overflow', async function () {
-      should((await this.integerMultiplyOverflow.exec(this.ctx))).be.null();
+      should(await this.integerMultiplyOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Multiply underflow', async function () {
-      should((await this.integerMultiplyUnderflow.exec(this.ctx))).be.null();
+      should(await this.integerMultiplyUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide overflow', async function () {
-      should((await this.integerDivideOverflow.exec(this.ctx))).be.null();
+      should(await this.integerDivideOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide underflow', async function () {
-      should((await this.integerDivideUnderflow.exec(this.ctx))).be.null();
+      should(await this.integerDivideUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide By Zero', async function () {
-      should((await this.integerDivideByZero.exec(this.ctx))).be.null();
+      should(await this.integerDivideByZero.exec(this.ctx)).be.null();
     });
 
     it('should return null for Power overflow', async function () {
-      should((await this.integerPowerOverflow.exec(this.ctx))).be.null();
+      should(await this.integerPowerOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Power underflow', async function () {
-      should((await this.integerPowerUnderflow.exec(this.ctx))).be.null();
+      should(await this.integerPowerUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for successor overflow', async function () {
-      should((await this.integerSuccessorOverflow.exec(this.ctx))).be.null();
+      should(await this.integerSuccessorOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for predecessor underflow', async function () {
-      should((await this.integerPredecessorUnderflow.exec(this.ctx))).be.null();
+      should(await this.integerPredecessorUnderflow.exec(this.ctx)).be.null();
     });
   });
 
   describe('Decimal', () => {
     it('should return null for Add overflow', async function () {
-      should((await this.decimalAddOverflow.exec(this.ctx))).be.null();
+      should(await this.decimalAddOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Add underflow', async function () {
-      should((await this.decimalAddUnderflow.exec(this.ctx))).be.null();
+      should(await this.decimalAddUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract overflow', async function () {
-      should((await this.decimalSubtractOverflow.exec(this.ctx))).be.null();
+      should(await this.decimalSubtractOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract underflow', async function () {
-      should((await this.decimalSubtractUnderflow.exec(this.ctx))).be.null();
+      should(await this.decimalSubtractUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Multiply overflow', async function () {
-      should((await this.decimalMultiplyOverflow.exec(this.ctx))).be.null();
+      should(await this.decimalMultiplyOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Multiply underflow', async function () {
-      should((await this.decimalMultiplyUnderflow.exec(this.ctx))).be.null();
+      should(await this.decimalMultiplyUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide overflow', async function () {
-      should((await this.decimalDivideOverflow.exec(this.ctx))).be.null();
+      should(await this.decimalDivideOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide underflow', async function () {
-      should((await this.decimalDivideUnderflow.exec(this.ctx))).be.null();
+      should(await this.decimalDivideUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide By Zero', async function () {
-      should((await this.decimalDivideByZero.exec(this.ctx))).be.null();
+      should(await this.decimalDivideByZero.exec(this.ctx)).be.null();
     });
 
     it('should return null for Power overflow', async function () {
-      should((await this.decimalPowerOverflow.exec(this.ctx))).be.null();
+      should(await this.decimalPowerOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Power underflow', async function () {
-      should((await this.decimalPowerUnderflow.exec(this.ctx))).be.null();
+      should(await this.decimalPowerUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for successor overflow', async function () {
-      should((await this.decimalSuccessorOverflow.exec(this.ctx))).be.null();
+      should(await this.decimalSuccessorOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for predecessor underflow', async function () {
-      should((await this.decimalPredecessorUnderflow.exec(this.ctx))).be.null();
+      should(await this.decimalPredecessorUnderflow.exec(this.ctx)).be.null();
     });
   });
 
   describe('Quantity', () => {
     it('should return null for Add overflow', async function () {
-      should((await this.quantityAddOverflow.exec(this.ctx))).be.null();
+      should(await this.quantityAddOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Add underflow', async function () {
-      should((await this.quantityAddUnderflow.exec(this.ctx))).be.null();
+      should(await this.quantityAddUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract overflow', async function () {
-      should((await this.quantitySubtractOverflow.exec(this.ctx))).be.null();
+      should(await this.quantitySubtractOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract underflow', async function () {
-      should((await this.quantitySubtractUnderflow.exec(this.ctx))).be.null();
+      should(await this.quantitySubtractUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Multiply overflow', async function () {
-      should((await this.quantityMultiplyOverflow.exec(this.ctx))).be.null();
+      should(await this.quantityMultiplyOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Multiply underflow', async function () {
-      should((await this.quantityMultiplyUnderflow.exec(this.ctx))).be.null();
+      should(await this.quantityMultiplyUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide overflow', async function () {
-      should((await this.quantityDivideOverflow.exec(this.ctx))).be.null();
+      should(await this.quantityDivideOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide underflow', async function () {
-      should((await this.quantityDivideUnderflow.exec(this.ctx))).be.null();
+      should(await this.quantityDivideUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Divide By Zero', async function () {
-      should((await this.quantityDivideByZero.exec(this.ctx))).be.null();
+      should(await this.quantityDivideByZero.exec(this.ctx)).be.null();
     });
 
     it('should return null for successor overflow', async function () {
-      should((await this.quantitySuccessorOverflow.exec(this.ctx))).be.null();
+      should(await this.quantitySuccessorOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for predecessor underflow', async function () {
-      should((await this.quantityPredecessorUnderflow.exec(this.ctx))).be.null();
+      should(await this.quantityPredecessorUnderflow.exec(this.ctx)).be.null();
     });
   });
 
   describe('DateTime', () => {
     it('should return null for Add overflow', async function () {
-      should((await this.dateTimeAddOverflow.exec(this.ctx))).be.null();
+      should(await this.dateTimeAddOverflow.exec(this.ctx)).be.null();
     });
 
     // TODO: Fix the logic so this test passes. It's been broken for a long time, but due to a
     // faulty test, this was not noticed until now. The cause of the failure is not obvious, so
     // this should be revisited (but is lower priority since it's an extremely rare use case).
     it.skip('should return null for Add underflow', async function () {
-      should((await this.dateTimeAddUnderflow.exec(this.ctx))).be.null();
+      should(await this.dateTimeAddUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract overflow', async function () {
-      should((await this.dateTimeSubtractOverflow.exec(this.ctx))).be.null();
+      should(await this.dateTimeSubtractOverflow.exec(this.ctx)).be.null();
     });
 
     // TODO: Fix the logic so this test passes. It's been broken for a long time, but due to a
     // faulty test, this was not noticed until now. The cause of the failure is not obvious, so
     // this should be revisited (but is lower priority since it's an extremely rare use case).
     it.skip('should return null for Subtract underflow', async function () {
-      should((await this.dateTimeSubtractUnderflow.exec(this.ctx))).be.null();
+      should(await this.dateTimeSubtractUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for successor overflow', async function () {
-      should((await this.dateTimeSuccessorOverflow.exec(this.ctx))).be.null();
+      should(await this.dateTimeSuccessorOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for predecessor underflow', async function () {
-      should((await this.dateTimePredecessorUnderflow.exec(this.ctx))).be.null();
+      should(await this.dateTimePredecessorUnderflow.exec(this.ctx)).be.null();
     });
 
     // Tests for Precision are include in the spec tests
@@ -926,33 +926,33 @@ describe('OutOfBounds', () => {
 
   describe('Date', () => {
     it('should return null for Add overflow', async function () {
-      should((await this.dateAddOverflow.exec(this.ctx))).be.null();
+      should(await this.dateAddOverflow.exec(this.ctx)).be.null();
     });
 
     // TODO: Fix the logic so this test passes. It's been broken for a long time, but due to a
     // faulty test, this was not noticed until now. The cause of the failure is not obvious, so
     // this should be revisited (but is lower priority since it's an extremely rare use case).
     it.skip('should return null for Add underflow', async function () {
-      should((await this.dateAddUnderflow.exec(this.ctx))).be.null();
+      should(await this.dateAddUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract overflow', async function () {
-      should((await this.dateSubtractOverflow.exec(this.ctx)).be.null();
+      should(await this.dateSubtractOverflow.exec(this.ctx)).be.null();
     });
 
     // TODO: Fix the logic so this test passes. It's been broken for a long time, but due to a
     // faulty test, this was not noticed until now. The cause of the failure is not obvious, so
     // this should be revisited (but is lower priority since it's an extremely rare use case).
     it.skip('should return null for Subtract underflow', async function () {
-      should((await this.dateSubtractUnderflow.exec(this.ctx))).be.null();
+      should(await this.dateSubtractUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for successor overflow', async function () {
-      should(await this.dateSuccessorOverflow.exec(this.ctx))).be.null();
+      should(await this.dateSuccessorOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for predecessor underflow', async function () {
-      should((await this.datePredecessorUnderflow.exec(this.ctx))).be.null();
+      should(await this.datePredecessorUnderflow.exec(this.ctx)).be.null();
     });
 
     // Tests for Precision are include in the spec tests
@@ -960,33 +960,33 @@ describe('OutOfBounds', () => {
 
   describe('Time', () => {
     it('should return null for Add overflow', async function () {
-      should((await this.timeAddOverflow.exec(this.ctx))).be.null();
+      should(await this.timeAddOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Add underflow', async function () {
-      should((await this.timeAddUnderflow.exec(this.ctx))).be.null();
+      should(await this.timeAddUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract overflow', async function () {
-      should((await this.timeSubtractOverflow.exec(this.ctx))).be.null();
+      should(await this.timeSubtractOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for Subtract underflow', async function () {
-      should((await this.timeSubtractUnderflow.exec(this.ctx))).be.null();
+      should(await this.timeSubtractUnderflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for successor overflow', async function () {
-      should((this.timeSuccessorOverflow.exec(this.ctx))).be.null();
+      should(this.timeSuccessorOverflow.exec(this.ctx)).be.null();
     });
 
     it('should return null for predecessor underflow', async function () {
-      should((await this.timePredecessorUnderflow.exec(this.ctx))).be.null();
+      should(await this.timePredecessorUnderflow.exec(this.ctx)).be.null();
     });
 
     // Tests for Precision are include in the spec tests
   });
 
   it('Exp should return null for overflow', async function () {
-    should((await this.expOverflow.exec(this.ctx))).be.null();
+    should(await this.expOverflow.exec(this.ctx)).be.null();
   });
 });

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -866,7 +866,7 @@ describe('OutOfBounds', () => {
     });
 
     it('should return null for Multiply underflow', async function () {
-      should((await this.quantityMultiplyUnderflow.exec(this.ctx)).be.null();
+      should((await this.quantityMultiplyUnderflow.exec(this.ctx))).be.null();
     });
 
     it('should return null for Divide overflow', async function () {

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -47,36 +47,37 @@ describe('Add', () => {
     setup(this, data);
   });
 
-  it('should add two numbers', function () {
-    this.onePlusTwo.exec(this.ctx).should.equal(3);
+  it('should add two numbers', async function () {
+    (await this.onePlusTwo.exec(this.ctx)).should.equal(3);
   });
 
-  it('should add multiple numbers', function () {
-    this.addMultiple.exec(this.ctx).should.equal(55);
+  it('should add multiple numbers', async function () {
+    (await this.addMultiple.exec(this.ctx)).should.equal(55);
   });
 
-  it('should add variables', function () {
-    this.addVariables.exec(this.ctx).should.equal(21);
+  it('should add variables', async function () {
+    (await this.addVariables.exec(this.ctx)).should.equal(21);
   });
 
-  it('should add Time/Quantity', function () {
-    this.addTime.exec(this.ctx).isTime().should.be.true();
+  it('should add Time/Quantity', async function () {
+    //not sure this is correct
+    (await this.addTime.exec(this.ctx)).isTime().should.be.true();
   });
 
-  it('should add uncertainty and uncertainty', function () {
-    const result = this.addUncertainties.exec(this.ctx);
+  it('should add uncertainty and uncertainty', async function () {
+    const result = await this.addUncertainties.exec(this.ctx);
     result.low.should.equal(6);
     result.high.should.equal(30);
   });
 
-  it('should add uncertainty and number', function () {
-    const result = this.addUncertaintyAndNumber.exec(this.ctx);
+  it('should add uncertainty and number', async function () {
+    const result = await this.addUncertaintyAndNumber.exec(this.ctx);
     result.low.should.equal(5);
     result.high.should.equal(17);
   });
 
-  it('should add number and uncertainty', function () {
-    const result = this.addNumberAndUncertainty.exec(this.ctx);
+  it('should add number and uncertainty', async function () {
+    const result = await this.addNumberAndUncertainty.exec(this.ctx);
     result.low.should.equal(10);
     result.high.should.equal(22);
   });
@@ -87,32 +88,32 @@ describe('Subtract', () => {
     setup(this, data);
   });
 
-  it('should subtract two numbers', function () {
-    this.fiveMinusTwo.exec(this.ctx).should.equal(3);
+  it('should subtract two numbers', async function () {
+    (await this.fiveMinusTwo.exec(this.ctx)).should.equal(3);
   });
 
-  it('should subtract multiple numbers', function () {
-    this.subtractMultiple.exec(this.ctx).should.equal(15);
+  it('should subtract multiple numbers', async function () {
+    (await this.subtractMultiple.exec(this.ctx)).should.equal(15);
   });
 
-  it('should subtract variables', function () {
-    this.subtractVariables.exec(this.ctx).should.equal(1);
+  it('should subtract variables', async function () {
+    (await this.subtractVariables.exec(this.ctx)).should.equal(1);
   });
 
-  it('should subtract uncertainty from uncertainty', function () {
-    const result = this.subtractUncertainties.exec(this.ctx);
+  it('should subtract uncertainty from uncertainty', async function () {
+    const result = await this.subtractUncertainties.exec(this.ctx);
     result.low.should.equal(-6);
     result.high.should.equal(18);
   });
 
-  it('should subtract number from uncertainty', function () {
-    const result = this.subtractNumberFromUncertainty.exec(this.ctx);
+  it('should subtract number from uncertainty', async function () {
+    const result = await this.subtractNumberFromUncertainty.exec(this.ctx);
     result.low.should.equal(1);
     result.high.should.equal(13);
   });
 
-  it('should subtract uncertainty from number', function () {
-    const result = this.subtractUncertaintyFromNumber.exec(this.ctx);
+  it('should subtract uncertainty from number', async function () {
+    const result = await this.subtractUncertaintyFromNumber.exec(this.ctx);
     result.low.should.equal(-8);
     result.high.should.equal(4);
   });
@@ -123,32 +124,32 @@ describe('Multiply', () => {
     setup(this, data);
   });
 
-  it('should multiply two numbers', function () {
-    this.fiveTimesTwo.exec(this.ctx).should.equal(10);
+  it('should multiply two numbers', async function () {
+    (await this.fiveTimesTwo.exec(this.ctx)).should.equal(10);
   });
 
-  it('should multiply multiple numbers', function () {
-    this.multiplyMultiple.exec(this.ctx).should.equal(120);
+  it('should multiply multiple numbers', async function () {
+    (await this.multiplyMultiple.exec(this.ctx)).should.equal(120);
   });
 
-  it('should multiply variables', function () {
-    this.multiplyVariables.exec(this.ctx).should.equal(110);
+  it('should multiply variables', async function () {
+    (await this.multiplyVariables.exec(this.ctx)).should.equal(110);
   });
 
-  it('should multiply uncertainty and uncertainty', function () {
-    const result = this.multiplyUncertainties.exec(this.ctx);
+  it('should multiply uncertainty and uncertainty', async function () {
+    const result = await this.multiplyUncertainties.exec(this.ctx);
     result.low.should.equal(12);
     result.high.should.equal(252);
   });
 
-  it('should multiply uncertainty and number', function () {
-    const result = this.multiplyUncertaintyAndNumber.exec(this.ctx);
+  it('should multiply uncertainty and number', async function () {
+    const result = await this.multiplyUncertaintyAndNumber.exec(this.ctx);
     result.low.should.equal(10);
     result.high.should.equal(70);
   });
 
-  it('should multiply number and uncertainty', function () {
-    const result = this.multiplyNumberAndUncertainty.exec(this.ctx);
+  it('should multiply number and uncertainty', async function () {
+    const result = await this.multiplyNumberAndUncertainty.exec(this.ctx);
     result.low.should.equal(20);
     result.high.should.equal(140);
   });
@@ -159,36 +160,36 @@ describe('Divide', () => {
     setup(this, data);
   });
 
-  it('should divide two numbers', function () {
-    this.tenDividedByTwo.exec(this.ctx).should.equal(5);
+  it('should divide two numbers', async function () {
+    (await this.tenDividedByTwo.exec(this.ctx)).should.equal(5);
   });
 
-  it("should divide two numbers that don't evenly divide", function () {
-    this.tenDividedByFour.exec(this.ctx).should.equal(2.5);
+  it("should divide two numbers that don't evenly divide", async function () {
+    (await this.tenDividedByFour.exec(this.ctx)).should.equal(2.5);
   });
 
-  it('should divide multiple numbers', function () {
-    this.divideMultiple.exec(this.ctx).should.equal(5);
+  it('should divide multiple numbers', async function () {
+    (await this.divideMultiple.exec(this.ctx)).should.equal(5);
   });
 
-  it('should divide variables', function () {
-    this.divideVariables.exec(this.ctx).should.equal(25);
+  it('should divide variables', async function () {
+    (await this.divideVariables.exec(this.ctx)).should.equal(25);
   });
 
-  it('should divide uncertainty by uncertainty', function () {
-    const result = this.divideUncertainties.exec(this.ctx);
+  it('should divide uncertainty by uncertainty', async function () {
+    const result = await this.divideUncertainties.exec(this.ctx);
     result.low.should.equal(6 / 14);
     result.high.should.equal(9);
   });
 
-  it('should divide uncertainty by number', function () {
-    const result = this.divideUncertaintyByNumber.exec(this.ctx);
+  it('should divide uncertainty by number', async function () {
+    const result = await his.divideUncertaintyByNumber.exec(this.ctx);
     result.low.should.equal(3);
     result.high.should.equal(9);
   });
 
-  it('should divide number by uncertainty', function () {
-    const result = this.divideNumberByUncertainty.exec(this.ctx);
+  it('should divide number by uncertainty', async function () {
+    const result = await this.divideNumberByUncertainty.exec(this.ctx);
     result.low.should.equal(2);
     result.high.should.equal(6);
   });
@@ -199,8 +200,8 @@ describe('Negate', () => {
     setup(this, data);
   });
 
-  it('should negate a number', function () {
-    this.negativeOne.exec(this.ctx).should.equal(-1);
+  it('should negate a number', async function () {
+    (await this.negativeOne.exec(this.ctx)).should.equal(-1);
   });
 });
 
@@ -209,12 +210,12 @@ describe('MathPrecedence', () => {
     setup(this, data);
   });
 
-  it('should follow order of operations', function () {
-    this.mixed.exec(this.ctx).should.equal(46);
+  it('should follow order of operations', async function () {
+    (await this.mixed.exec(this.ctx)).should.equal(46);
   });
 
-  it('should allow parentheses to override order of operations', function () {
-    this.parenthetical.exec(this.ctx).should.equal(-10);
+  it('should allow parentheses to override order of operations', async function () {
+    (await this.parenthetical.exec(this.ctx)).should.equal(-10);
   });
 });
 
@@ -223,8 +224,8 @@ describe('Power', () => {
     setup(this, data);
   });
 
-  it('should be able to calculate the power of a number', function () {
-    this.pow.exec(this.ctx).should.equal(81);
+  it('should be able to calculate the power of a number', async function () {
+    (await this.pow.exec(this.ctx)).should.equal(81);
   });
 });
 
@@ -233,19 +234,19 @@ describe('MinValue', () => {
     setup(this, data);
   });
 
-  it('of Integer should return minimum representable Integer value', function () {
+  it('of Integer should return minimum representable Integer value', async function () {
     const minIntegerValue = -2147483648;
-    this.minInteger.exec(this.ctx).should.equal(minIntegerValue);
+    (await this.minInteger.exec(this.ctx)).should.equal(minIntegerValue);
   });
 
-  it('of Decimal should return minimum representable Decimal value', function () {
+  it('of Decimal should return minimum representable Decimal value', async function () {
     // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
     const minDecimalValue = -99999999999999999999.99999999;
-    this.minDecimal.exec(this.ctx).should.be.approximately(minDecimalValue, 0.000000001);
+    (await this.minDecimal.exec(this.ctx)).should.be.approximately(minDecimalValue, 0.000000001);
   });
 
-  it('of DateTime should return minimum representable DateTime value', function () {
-    const dateTimeResult = this.minDateTime.exec(this.ctx);
+  it('of DateTime should return minimum representable DateTime value', async function () {
+    const dateTimeResult = await this.minDateTime.exec(this.ctx);
     dateTimeResult.year.should.equal(1);
     dateTimeResult.month.should.equal(1);
     dateTimeResult.day.should.equal(1);
@@ -255,15 +256,16 @@ describe('MinValue', () => {
     dateTimeResult.millisecond.should.equal(0);
   });
 
-  it('of Time should return minimum representable Time value', function () {
-    const timeResult = this.minTime.exec(this.ctx);
+  it('of Time should return minimum representable Time value', async function () {
+    const timeResult = await this.minTime.exec(this.ctx);
     timeResult.hour.should.equal(0);
     timeResult.minute.should.equal(0);
     timeResult.second.should.equal(0);
     timeResult.millisecond.should.equal(0);
   });
 
-  it('of types other than Integer/Decimal/DateTime/Time should throw an error', function () {
+  it('of types other than Integer/Decimal/DateTime/Time should throw an error', async function () {
+    //not clear about how to handle this one adding await give an error
     should(() => this.minWrongType.exec(this.ctx)).throw();
   });
 });
@@ -273,19 +275,19 @@ describe('MaxValue', () => {
     setup(this, data);
   });
 
-  it('of Integer should return maximum representable Integer value', function () {
+  it('of Integer should return maximum representable Integer value', async function () {
     const maxIntegerValue = 2147483647;
-    this.maxInteger.exec(this.ctx).should.equal(maxIntegerValue);
+    (await this.maxInteger.exec(this.ctx)).should.equal(maxIntegerValue);
   });
 
-  it('of Decimal should return maximum representable Decimal value', function () {
+  it('of Decimal should return maximum representable Decimal value', async function () {
     // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
     const maxDecimalValue = 99999999999999999999.99999999;
-    this.maxDecimal.exec(this.ctx).should.be.approximately(maxDecimalValue, 0.000000001);
+    (await this.maxDecimal.exec(this.ctx)).should.be.approximately(maxDecimalValue, 0.000000001);
   });
 
-  it('of DateTime should return maximum representable DateTime value', function () {
-    const dateTimeResult = this.maxDateTime.exec(this.ctx);
+  it('of DateTime should return maximum representable DateTime value', async function () {
+    const dateTimeResult = await this.maxDateTime.exec(this.ctx);
     dateTimeResult.year.should.equal(9999);
     dateTimeResult.month.should.equal(12);
     dateTimeResult.day.should.equal(31);
@@ -295,9 +297,9 @@ describe('MaxValue', () => {
     dateTimeResult.millisecond.should.equal(999);
   });
 
-  it('of DateTime should work with different execution timezoneOffsets', function () {
+  it('of DateTime should work with different execution timezoneOffsets', async function () {
     this.ctx.executionDateTime.timezoneOffset = -4.0;
-    const dateTimeResult = this.maxDateTime.exec(this.ctx);
+    const dateTimeResult = await this.maxDateTime.exec(this.ctx);
     dateTimeResult.year.should.equal(9999);
     dateTimeResult.month.should.equal(12);
     dateTimeResult.day.should.equal(31);
@@ -308,15 +310,16 @@ describe('MaxValue', () => {
     dateTimeResult.timezoneOffset.should.equal(-4.0);
   });
 
-  it('of Time should return maximum representable Time value', function () {
-    const timeResult = this.maxTime.exec(this.ctx);
+  it('of Time should return maximum representable Time value', async function () {
+    const timeResult = await this.maxTime.exec(this.ctx);
     timeResult.hour.should.equal(23);
     timeResult.minute.should.equal(59);
     timeResult.second.should.equal(59);
     timeResult.millisecond.should.equal(999);
   });
 
-  it('of types other than Integer/Decimal/DateTime/Time should throw an error', function () {
+  it('of types other than Integer/Decimal/DateTime/Time should throw an error', async function () {
+    //same issue here ask in slack
     should(() => this.maxWrongType.exec(this.ctx)).throw();
   });
 });
@@ -326,9 +329,9 @@ describe('TruncatedDivide', () => {
     setup(this, data);
   });
 
-  it('should be able to return just the integer portion of a division', function () {
-    this.trunc.exec(this.ctx).should.equal(3);
-    this.even.exec(this.ctx).should.equal(3);
+  it('should be able to return just the integer portion of a division', async function () {
+    (await this.trunc.exec(this.ctx)).should.equal(3);
+    (await this.even.exec(this.ctx)).should.equal(3);
   });
 });
 
@@ -337,9 +340,9 @@ describe('Truncate', () => {
     setup(this, data);
   });
 
-  it('should be able to return the integer portion of a number', function () {
-    this.trunc.exec(this.ctx).should.equal(10);
-    this.even.exec(this.ctx).should.equal(10);
+  it('should be able to return the integer portion of a number', async function () {
+    (await this.trunc.exec(this.ctx)).should.equal(10);
+    (await this.even.exec(this.ctx)).should.equal(10);
   });
 });
 
@@ -348,9 +351,9 @@ describe('Floor', () => {
     setup(this, data);
   });
 
-  it('should be able to round down to the closest integer', function () {
-    this.flr.exec(this.ctx).should.equal(10);
-    this.even.exec(this.ctx).should.equal(10);
+  it('should be able to round down to the closest integer', async function () {
+    (await this.flr.exec(this.ctx)).should.equal(10);
+    (await this.even.exec(this.ctx)).should.equal(10);
   });
 });
 
@@ -358,9 +361,9 @@ describe('Ceiling', () => {
   beforeEach(function () {
     setup(this, data);
 
-    it('should be able to round up to the closest integer', function () {
-      this.ceil.exec(this.ctx).should.equal(11);
-      this.even.exec(this.ctx).should.equal(10);
+    it('should be able to round up to the closest integer', async function () {
+      (await this.ceil.exec(this.ctx)).should.equal(11);
+      (await this.even.exec(this.ctx)).should.equal(10);
     });
   });
 });
@@ -370,8 +373,8 @@ describe('Ln', () => {
     setup(this, data);
   });
 
-  it('should be able to return the natural log of a number', function () {
-    this.ln.exec(this.ctx).should.equal(Math.log(4));
+  it('should be able to return the natural log of a number', async function () {
+    (await this.ln.exec(this.ctx)).should.equal(Math.log(4));
   });
 });
 
@@ -379,8 +382,8 @@ describe('Log', () => {
   beforeEach(function () {
     setup(this, data);
 
-    it('should be able to return the log of a number based on an arbitary base value', function () {
-      this.log.exec(this.ctx).should.equal(0.25);
+    it('should be able to return the log of a number based on an arbitary base value', async function () {
+      (await this.log.exec)(this.ctx).should.equal(0.25);
     });
   });
 });
@@ -389,8 +392,8 @@ describe('Modulo', () => {
   beforeEach(function () {
     setup(this, data);
 
-    it('should be able to return the remainder of a division', function () {
-      this.mod.exec(this.ctx).should.equal(1);
+    it('should be able to return the remainder of a division', async function () {
+     (await  this.mod.exec(this.ctx)).should.equal(1);
     });
   });
 });
@@ -400,14 +403,14 @@ describe('Abs', () => {
     setup(this, data);
   });
 
-  it('should be able to return the absolute value of a positive number', function () {
-    this.pos.exec(this.ctx).should.equal(10);
+  it('should be able to return the absolute value of a positive number', async function () {
+    (await this.pos.exec(this.ctx)).should.equal(10);
   });
-  it('should be able to return the absolute value of a negative number', function () {
-    this.neg.exec(this.ctx).should.equal(10);
+  it('should be able to return the absolute value of a negative number', async function () {
+    (await this.neg.exec(this.ctx)).should.equal(10);
   });
-  it('should be able to return the absolute value of 0', function () {
-    this.zero.exec(this.ctx).should.equal(0);
+  it('should be able to return the absolute value of 0', async function () {
+    (await this.zero.exec(this.ctx)).should.equal(0);
   });
 });
 
@@ -416,13 +419,13 @@ describe('Round', () => {
     setup(this, data);
   });
 
-  it('should be able to round a number up or down to the closest integer value', function () {
-    this.up.exec(this.ctx).should.equal(5);
-    this.down.exec(this.ctx).should.equal(4);
+  it('should be able to round a number up or down to the closest integer value', async function () {
+    (await this.up.exec(this.ctx)).should.equal(5);
+    (await this.down.exec(this.ctx)).should.equal(4);
   });
-  it('should be able to round a number up or down to the closest decimal place ', function () {
-    this.up_percent.exec(this.ctx).should.equal(4.6);
-    this.down_percent.exec(this.ctx).should.equal(4.4);
+  it('should be able to round a number up or down to the closest decimal place ', async function () {
+   (await this.up_percent.exec(this.ctx)).should.equal(4.6);
+    (await this.down_percent.exec(this.ctx)).should.equal(4.4);
   });
 });
 
@@ -431,19 +434,19 @@ describe('Successor', () => {
     setup(this, data);
   });
 
-  it('should be able to get Integer Successor', function () {
-    this.is.exec(this.ctx).should.equal(3);
+  it('should be able to get Integer Successor', async function () {
+    (await this.is.exec(this.ctx)).should.equal(3);
   });
-  it('should be able to get Real Successor', function () {
-    this.rs.exec(this.ctx).should.equal(2.2 + Math.pow(10, -8));
-  });
-
-  it('should return null for Successor greater than Integer Max value', function () {
-    should(this.ofr.exec(this.ctx)).be.null();
+  it('should be able to get Real Successor', async function () {
+    (await this.rs.exec(this.ctx)).should.equal(2.2 + Math.pow(10, -8));
   });
 
-  it('should be able to get Date Successor for year', function () {
-    const dp = this.y_date.exec(this.ctx);
+  it('should return null for Successor greater than Integer Max value', async function () {
+    should((await this.ofr.exec(this.ctx))).be.null();
+  });
+
+  it('should be able to get Date Successor for year', async function () {
+    const dp = await this.y_date.exec(this.ctx);
     dp.year.should.equal(2016);
     should.not.exist(dp.month);
     should.not.exist(dp.day);
@@ -453,8 +456,8 @@ describe('Successor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Successor for year,month', function () {
-    const dp = this.ym_date.exec(this.ctx);
+  it('should be able to get Date Successor for year,month', async function () {
+    const dp = await this.ym_date.exec(this.ctx);
     dp.year.should.equal(2015);
     dp.month.should.equal(2);
     should.not.exist(dp.day);
@@ -464,8 +467,8 @@ describe('Successor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Successor for year,month,day', function () {
-    const dp = this.ymd_date.exec(this.ctx);
+  it('should be able to get Date Successor for year,month,day', async function () {
+    const dp = await this.ymd_date.exec(this.ctx);
     dp.year.should.equal(2015);
     dp.month.should.equal(1);
     dp.day.should.equal(2);
@@ -475,8 +478,8 @@ describe('Successor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Successor for year,month,day,hour', function () {
-    const dp = this.ymdh_date.exec(this.ctx);
+  it('should be able to get Date Successor for year,month,day,hour', async function () {
+    const dp = await this.ymdh_date.exec(this.ctx);
     dp.year.should.equal(2015);
     dp.month.should.equal(1);
     dp.day.should.equal(1);
@@ -486,8 +489,8 @@ describe('Successor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Successor for year,month,day,hour,minute', function () {
-    const dp = this.ymdhm_date.exec(this.ctx);
+  it('should be able to get Date Successor for year,month,day,hour,minute', async function () {
+    const dp = await this.ymdhm_date.exec(this.ctx);
     dp.year.should.equal(2015);
     dp.month.should.equal(1);
     dp.day.should.equal(1);
@@ -497,8 +500,8 @@ describe('Successor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Successor for year,month,day,hour,minute,seconds', function () {
-    const dp = this.ymdhms_date.exec(this.ctx);
+  it('should be able to get Date Successor for year,month,day,hour,minute,seconds', async function () {
+    const dp = await this.ymdhms_date.exec(this.ctx);
     dp.year.should.equal(2015);
     dp.month.should.equal(1);
     dp.day.should.equal(1);
@@ -508,8 +511,8 @@ describe('Successor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Successor for year,month,day,hour,minute,seconds,milliseconds', function () {
-    const dp = this.ymdhmsm_date.exec(this.ctx);
+  it('should be able to get Date Successor for year,month,day,hour,minute,seconds,milliseconds', async function () {
+    const dp = await this.ymdhmsm_date.exec(this.ctx);
     dp.year.should.equal(2015);
     dp.month.should.equal(1);
     dp.day.should.equal(1);
@@ -519,8 +522,8 @@ describe('Successor', () => {
     dp.millisecond.should.equal(1);
   });
 
-  it('should return null when attempting to get the Successor of the maximum allowed date', function () {
-    should(this.max_date.exec(this.ctx)).be.null();
+  it('should return null when attempting to get the Successor of the maximum allowed date', async function () {
+    should(await this.max_date.exec(this.ctx)).be.null();
   });
 });
 
@@ -529,18 +532,18 @@ describe('Predecessor', () => {
     setup(this, data);
   });
 
-  it('should be able to get Integer Predecessor', function () {
-    this.is.exec(this.ctx).should.equal(1);
+  it('should be able to get Integer Predecessor', async function () {
+   (await this.is.exec(this.ctx)).should.equal(1);
   });
-  it('should be able to get Real Predecessor', function () {
-    this.rs.exec(this.ctx).should.equal(2.2 - Math.pow(10, -8));
+  it('should be able to get Real Predecessor', async function () {
+    (await this.rs.exec(this.ctx)).should.equal(2.2 - Math.pow(10, -8));
   });
-  it('should return null for Predecessor greater than Integer Max value', function () {
-    should(this.ufr.exec(this.ctx)).be.null();
+  it('should return null for Predecessor greater than Integer Max value', async function () {
+    should((await this.ufr.exec(this.ctx))).be.null();
   });
 
-  it('should be able to get Date Predecessor for year', function () {
-    const dp = this.y_date.exec(this.ctx);
+  it('should be able to get Date Predecessor for year', async function () {
+    const dp = await this.y_date.exec(this.ctx);
     dp.year.should.equal(2014);
     should.not.exist(dp.month);
     should.not.exist(dp.day);
@@ -550,8 +553,8 @@ describe('Predecessor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Predecessor for year,month', function () {
-    const dp = this.ym_date.exec(this.ctx);
+  it('should be able to get Date Predecessor for year,month', async function () {
+    const dp = await this.ym_date.exec(this.ctx);
     dp.year.should.equal(2014);
     dp.month.should.equal(12);
     should.not.exist(dp.day);
@@ -561,8 +564,8 @@ describe('Predecessor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Predecessor for year,month,day', function () {
-    const dp = this.ymd_date.exec(this.ctx);
+  it('should be able to get Date Predecessor for year,month,day', async function () {
+    const dp = await this.ymd_date.exec(this.ctx);
     dp.year.should.equal(2014);
     dp.month.should.equal(12);
     dp.day.should.equal(31);
@@ -571,8 +574,8 @@ describe('Predecessor', () => {
     should.not.exist(dp.second);
     should.not.exist(dp.millisecond);
   });
-  it('should be able to get Date Predecessor for year,month,day,hour', function () {
-    const dp = this.ymdh_date.exec(this.ctx);
+  it('should be able to get Date Predecessor for year,month,day,hour', async function () {
+    const dp = await this.ymdh_date.exec(this.ctx);
     dp.year.should.equal(2014);
     dp.month.should.equal(12);
     dp.day.should.equal(31);
@@ -582,8 +585,8 @@ describe('Predecessor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Predecessor for year,month,day,hour,minute', function () {
-    const dp = this.ymdhm_date.exec(this.ctx);
+  it('should be able to get Date Predecessor for year,month,day,hour,minute', async function () {
+    const dp = await  this.ymdhm_date.exec(this.ctx);
     dp.year.should.equal(2014);
     dp.month.should.equal(12);
     dp.day.should.equal(31);
@@ -593,8 +596,8 @@ describe('Predecessor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Predecessor for year,month,day,hour,minute,seconds', function () {
-    const dp = this.ymdhms_date.exec(this.ctx);
+  it('should be able to get Date Predecessor for year,month,day,hour,minute,seconds', async function () {
+    const dp = await this.ymdhms_date.exec(this.ctx);
     dp.year.should.equal(2014);
     dp.month.should.equal(12);
     dp.day.should.equal(31);
@@ -604,8 +607,8 @@ describe('Predecessor', () => {
     should.not.exist(dp.millisecond);
   });
 
-  it('should be able to get Date Predecessor for year,month,day,hour,minute,seconds,milliseconds', function () {
-    const dp = this.ymdhmsm_date.exec(this.ctx);
+  it('should be able to get Date Predecessor for year,month,day,hour,minute,seconds,milliseconds', async function () {
+    const dp = await this.ymdhmsm_date.exec(this.ctx);
     dp.year.should.equal(2014);
     dp.month.should.equal(12);
     dp.day.should.equal(31);
@@ -614,8 +617,8 @@ describe('Predecessor', () => {
     dp.millisecond.should.equal(999);
   });
 
-  it('should return null when attempting to get the Predecessor of the minimum allowed date', function () {
-    should(this.min_date.exec(this.ctx)).be.null();
+  it('should return null when attempting to get the Predecessor of the minimum allowed date', async function () {
+    should((await this.min_date.exec(this.ctx))).be.null();
   });
 });
 
@@ -624,68 +627,69 @@ describe('Quantity', () => {
     setup(this, data);
   });
 
-  it('should be able to perform Quantity Addition', function () {
-    validateQuantity(this.add_q_q.exec(this.ctx), 20, 'days');
-    const adq = this.add_d_q.exec(this.ctx);
+  it('should be able to perform Quantity Addition', async function () {
+    //this seems like it could be off
+    validateQuantity((await this.add_q_q.exec(this.ctx)), 20, 'days');
+    const adq =await  this.add_d_q.exec(this.ctx);
     adq.isDateTime.should.be.true();
     adq.year.should.equal(2000);
     adq.month.should.equal(1);
     adq.day.should.equal(11);
-    validateQuantity(this.add_q_q_diff.exec(this.ctx), 10 + 10 / (24 * 60), 'days');
+    validateQuantity((await this.add_q_q_diff.exec(this.ctx)), 10 + 10 / (24 * 60), 'days');
   });
 
-  it('should be able to perform Quantity Subtraction', function () {
-    validateQuantity(this.sub_q_q.exec(this.ctx), 0, 'days');
-    const sdq = this.sub_d_q.exec(this.ctx);
+  it('should be able to perform Quantity Subtraction', async function () {
+    validateQuantity((await this.sub_q_q.exec(this.ctx)), 0, 'days');
+    const sdq = await this.sub_d_q.exec(this.ctx);
     sdq.isDateTime.should.be.true();
     sdq.year.should.equal(1999);
     sdq.month.should.equal(12);
     sdq.day.should.equal(22);
-    validateQuantity(this.sub_q_q_diff.exec(this.ctx), 10 - 10 / (24 * 60), 'days');
+    validateQuantity((await this.sub_q_q_diff.exec(this.ctx)), 10 - 10 / (24 * 60), 'days');
   });
 
-  it('should be able to perform Quantity Division', function () {
-    validateQuantity(this.div_q_d.exec(this.ctx), 5, 'days');
-    validateQuantity(this.div_q_q.exec(this.ctx), 1, '1');
+  it('should be able to perform Quantity Division', async function () {
+    validateQuantity((await this.div_q_d.exec(this.ctx)), 5, 'days');
+    validateQuantity((await this.div_q_q.exec(this.ctx)), 1, '1');
   });
 
-  it('should be able to perform Quantity Multiplication', function () {
+  it('should be able to perform Quantity Multiplication', async function () {
     // decimal to quantity multiplication results in decimal value only
-    validateQuantity(this.mul_d_q.exec(this.ctx), 20, 'days');
-    validateQuantity(this.mul_q_d.exec(this.ctx), 20, 'days');
-    validateQuantity(this.mul_q_q.exec(this.ctx), 20, 'm2');
-    validateQuantity(this.mul_q_q_diff.exec(this.ctx), 20, 'm/d');
+    validateQuantity((await this.mul_d_q.exec(this.ctx)), 20, 'days');
+    validateQuantity((await this.mul_q_d.exec(this.ctx)), 20, 'days');
+    validateQuantity((await this.mul_q_q.exec(this.ctx)), 20, 'm2');
+    validateQuantity((await this.mul_q_q_diff.exec(this.ctx)), 20, 'm/d');
   });
 
-  it('should be able to perform Quantity Absolution', function () {
-    const q = this.abs.exec(this.ctx);
+  it('should be able to perform Quantity Absolution', async function () {
+    const q = await this.abs.exec(this.ctx);
     q.value.should.equal(10);
     q.unit.should.equal('days');
   });
 
-  it('should be able to perform Quantity Negation', function () {
-    const q = this.neg.exec(this.ctx);
+  it('should be able to perform Quantity Negation', async function () {
+    const q =await this.neg.exec(this.ctx);
     q.value.should.equal(-10);
     q.unit.should.equal('days');
   });
 
-  it('should be able to perform ucum multiplication in cql', function () {
-    this.multiplyUcum.exec(this.ctx).should.be.true();
+  it('should be able to perform ucum multiplication in cql', async function () {
+    (await this.multiplyUcum.exec(this.ctx)).should.be.true();
   });
 
-  it('should be able to perform ucum division in cql', function () {
-    this.divideUcum.exec(this.ctx).should.be.true();
+  it('should be able to perform ucum division in cql', async function () {
+    (await this.divideUcum.exec(this.ctx)).should.be.true();
   });
 
-  it('should be able to perform ucum addition in cql', function () {
-    this.addUcum.exec(this.ctx).should.be.true();
+  it('should be able to perform ucum addition in cql', async function () {
+    (await this.addUcum.exec(this.ctx)).should.be.true();
   });
 
-  it('should be able to perform ucum subtraction in cql', function () {
-    this.subtractUcum.exec(this.ctx).should.be.true();
+  it('should be able to perform ucum subtraction in cql', async function () {
+    (await this.subtractUcum.exec(this.ctx)).should.be.true();
   });
 
-  it('should be able to perform ucum multiplication', function () {
+  it('should be able to perform ucum multiplication', async function () {
     const tests = [
       ["10 'm'", "20 'm'", "200 'm2'"],
       ["25 'km'", "5 'm'", "125000 'm2'"],
@@ -694,7 +698,7 @@ describe('Quantity', () => {
     doQuantityMathTests(tests, '*');
   });
 
-  it('should be able to perform ucum division', function () {
+  it('should be able to perform ucum division', async function () {
     const tests = [
       ["10 'cm2'", "5 'cm'", "2 'cm'"],
       ["10 'm2'", "5 'm'", "2 'm'"],
@@ -708,7 +712,7 @@ describe('Quantity', () => {
     // has any particular unit.  12 cm^2 / 4 cm = 0.03 m rather than 3 cm.
     doQuantityMathTests(tests, '/');
   });
-  it('should be able to perform ucum addition', function () {
+  it('should be able to perform ucum addition', async function () {
     const tests = [
       ["10 'm'", "20 'm'", "30 'm'"],
       ["25 'km'", "5 'm'", "25005 'm'"],
@@ -717,7 +721,7 @@ describe('Quantity', () => {
     doQuantityMathTests(tests, '+');
   });
 
-  it('should be able to perform ucum subtraction', function () {
+  it('should be able to perform ucum subtraction', async function () {
     const tests = [
       ["10 'd'", "20 'd'", "-10 'd'"],
       ["25 'km'", "5 'm'", "24995 'm'"],
@@ -733,256 +737,256 @@ describe('OutOfBounds', () => {
   });
 
   describe('Integer', () => {
-    it('should return null for Add overflow', function () {
-      should(this.integerAddOverflow.exec(this.ctx)).be.null();
+    it('should return null for Add overflow', async function () {
+      should((await this.integerAddOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Add underflow', function () {
-      should(this.integerAddUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Add underflow', async function () {
+      should((await this.integerAddUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract overflow', function () {
-      should(this.integerSubtractOverflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract overflow', async function () {
+      should((await this.integerSubtractOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract underflow', function () {
-      should(this.integerSubtractUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract underflow', async function () {
+      should((await this.integerSubtractUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Multiply overflow', function () {
-      should(this.integerMultiplyOverflow.exec(this.ctx)).be.null();
+    it('should return null for Multiply overflow', async function () {
+      should((await this.integerMultiplyOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Multiply underflow', function () {
-      should(this.integerMultiplyUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Multiply underflow', async function () {
+      should((await this.integerMultiplyUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Divide overflow', function () {
-      should(this.integerDivideOverflow.exec(this.ctx)).be.null();
+    it('should return null for Divide overflow', async function () {
+      should((await this.integerDivideOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Divide underflow', function () {
-      should(this.integerDivideUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Divide underflow', async function () {
+      should((await this.integerDivideUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Divide By Zero', function () {
-      should(this.integerDivideByZero.exec(this.ctx)).be.null();
+    it('should return null for Divide By Zero', async function () {
+      should((await this.integerDivideByZero.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Power overflow', function () {
-      should(this.integerPowerOverflow.exec(this.ctx)).be.null();
+    it('should return null for Power overflow', async function () {
+      should((await this.integerPowerOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Power underflow', function () {
-      should(this.integerPowerUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Power underflow', async function () {
+      should((await this.integerPowerUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for successor overflow', function () {
-      should(this.integerSuccessorOverflow.exec(this.ctx)).be.null();
+    it('should return null for successor overflow', async function () {
+      should((await this.integerSuccessorOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for predecessor underflow', function () {
-      should(this.integerPredecessorUnderflow.exec(this.ctx)).be.null();
+    it('should return null for predecessor underflow', async function () {
+      should((await this.integerPredecessorUnderflow.exec(this.ctx))).be.null();
     });
   });
 
   describe('Decimal', () => {
-    it('should return null for Add overflow', function () {
-      should(this.decimalAddOverflow.exec(this.ctx)).be.null();
+    it('should return null for Add overflow', async function () {
+      should((await this.decimalAddOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Add underflow', function () {
-      should(this.decimalAddUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Add underflow', async function () {
+      should((await this.decimalAddUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract overflow', function () {
-      should(this.decimalSubtractOverflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract overflow', async function () {
+      should((await this.decimalSubtractOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract underflow', function () {
-      should(this.decimalSubtractUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract underflow', async function () {
+      should((await this.decimalSubtractUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Multiply overflow', function () {
-      should(this.decimalMultiplyOverflow.exec(this.ctx)).be.null();
+    it('should return null for Multiply overflow', async function () {
+      should((await this.decimalMultiplyOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Multiply underflow', function () {
-      should(this.decimalMultiplyUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Multiply underflow', async function () {
+      should((await this.decimalMultiplyUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Divide overflow', function () {
-      should(this.decimalDivideOverflow.exec(this.ctx)).be.null();
+    it('should return null for Divide overflow', async function () {
+      should((await this.decimalDivideOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Divide underflow', function () {
-      should(this.decimalDivideUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Divide underflow', async function () {
+      should((await this.decimalDivideUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Divide By Zero', function () {
-      should(this.decimalDivideByZero.exec(this.ctx)).be.null();
+    it('should return null for Divide By Zero', async function () {
+      should((await this.decimalDivideByZero.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Power overflow', function () {
-      should(this.decimalPowerOverflow.exec(this.ctx)).be.null();
+    it('should return null for Power overflow', async function () {
+      should((await this.decimalPowerOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Power underflow', function () {
-      should(this.decimalPowerUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Power underflow', async function () {
+      should((await this.decimalPowerUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for successor overflow', function () {
-      should(this.decimalSuccessorOverflow.exec(this.ctx)).be.null();
+    it('should return null for successor overflow', async function () {
+      should((await this.decimalSuccessorOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for predecessor underflow', function () {
-      should(this.decimalPredecessorUnderflow.exec(this.ctx)).be.null();
+    it('should return null for predecessor underflow', async function () {
+      should((await this.decimalPredecessorUnderflow.exec(this.ctx))).be.null();
     });
   });
 
   describe('Quantity', () => {
-    it('should return null for Add overflow', function () {
-      should(this.quantityAddOverflow.exec(this.ctx)).be.null();
+    it('should return null for Add overflow', async function () {
+      should((await this.quantityAddOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Add underflow', function () {
-      should(this.quantityAddUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Add underflow', async function () {
+      should((await this.quantityAddUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract overflow', function () {
-      should(this.quantitySubtractOverflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract overflow', async function () {
+      should((await this.quantitySubtractOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract underflow', function () {
-      should(this.quantitySubtractUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract underflow', async function () {
+      should((await this.quantitySubtractUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Multiply overflow', function () {
-      should(this.quantityMultiplyOverflow.exec(this.ctx)).be.null();
+    it('should return null for Multiply overflow', async function () {
+      should((await this.quantityMultiplyOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Multiply underflow', function () {
-      should(this.quantityMultiplyUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Multiply underflow', async function () {
+      should((await this.quantityMultiplyUnderflow.exec(this.ctx)).be.null();
     });
 
-    it('should return null for Divide overflow', function () {
-      should(this.quantityDivideOverflow.exec(this.ctx)).be.null();
+    it('should return null for Divide overflow', async function () {
+      should((await this.quantityDivideOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Divide underflow', function () {
-      should(this.quantityDivideUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Divide underflow', async function () {
+      should((await this.quantityDivideUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Divide By Zero', function () {
-      should(this.quantityDivideByZero.exec(this.ctx)).be.null();
+    it('should return null for Divide By Zero', async function () {
+      should((await this.quantityDivideByZero.exec(this.ctx))).be.null();
     });
 
-    it('should return null for successor overflow', function () {
-      should(this.quantitySuccessorOverflow.exec(this.ctx)).be.null();
+    it('should return null for successor overflow', async function () {
+      should((await this.quantitySuccessorOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for predecessor underflow', function () {
-      should(this.quantityPredecessorUnderflow.exec(this.ctx)).be.null();
+    it('should return null for predecessor underflow', async function () {
+      should((await this.quantityPredecessorUnderflow.exec(this.ctx))).be.null();
     });
   });
 
   describe('DateTime', () => {
-    it('should return null for Add overflow', function () {
-      should(this.dateTimeAddOverflow.exec(this.ctx)).be.null();
+    it('should return null for Add overflow', async function () {
+      should((await this.dateTimeAddOverflow.exec(this.ctx))).be.null();
     });
 
     // TODO: Fix the logic so this test passes. It's been broken for a long time, but due to a
     // faulty test, this was not noticed until now. The cause of the failure is not obvious, so
     // this should be revisited (but is lower priority since it's an extremely rare use case).
-    it.skip('should return null for Add underflow', function () {
-      should(this.dateTimeAddUnderflow.exec(this.ctx)).be.null();
+    it.skip('should return null for Add underflow', async function () {
+      should((await this.dateTimeAddUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract overflow', function () {
-      should(this.dateTimeSubtractOverflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract overflow', async function () {
+      should((await this.dateTimeSubtractOverflow.exec(this.ctx))).be.null();
     });
 
     // TODO: Fix the logic so this test passes. It's been broken for a long time, but due to a
     // faulty test, this was not noticed until now. The cause of the failure is not obvious, so
     // this should be revisited (but is lower priority since it's an extremely rare use case).
-    it.skip('should return null for Subtract underflow', function () {
-      should(this.dateTimeSubtractUnderflow.exec(this.ctx)).be.null();
+    it.skip('should return null for Subtract underflow', async function () {
+      should((await this.dateTimeSubtractUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for successor overflow', function () {
-      should(this.dateTimeSuccessorOverflow.exec(this.ctx)).be.null();
+    it('should return null for successor overflow', async function () {
+      should((await this.dateTimeSuccessorOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for predecessor underflow', function () {
-      should(this.dateTimePredecessorUnderflow.exec(this.ctx)).be.null();
+    it('should return null for predecessor underflow', async function () {
+      should((await this.dateTimePredecessorUnderflow.exec(this.ctx))).be.null();
     });
 
     // Tests for Precision are include in the spec tests
   });
 
   describe('Date', () => {
-    it('should return null for Add overflow', function () {
-      should(this.dateAddOverflow.exec(this.ctx)).be.null();
+    it('should return null for Add overflow', async function () {
+      should((await this.dateAddOverflow.exec(this.ctx))).be.null();
     });
 
     // TODO: Fix the logic so this test passes. It's been broken for a long time, but due to a
     // faulty test, this was not noticed until now. The cause of the failure is not obvious, so
     // this should be revisited (but is lower priority since it's an extremely rare use case).
-    it.skip('should return null for Add underflow', function () {
-      should(this.dateAddUnderflow.exec(this.ctx)).be.null();
+    it.skip('should return null for Add underflow', async function () {
+      should((await this.dateAddUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract overflow', function () {
-      should(this.dateSubtractOverflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract overflow', async function () {
+      should((await this.dateSubtractOverflow.exec(this.ctx)).be.null();
     });
 
     // TODO: Fix the logic so this test passes. It's been broken for a long time, but due to a
     // faulty test, this was not noticed until now. The cause of the failure is not obvious, so
     // this should be revisited (but is lower priority since it's an extremely rare use case).
-    it.skip('should return null for Subtract underflow', function () {
-      should(this.dateSubtractUnderflow.exec(this.ctx)).be.null();
+    it.skip('should return null for Subtract underflow', async function () {
+      should((await this.dateSubtractUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for successor overflow', function () {
-      should(this.dateSuccessorOverflow.exec(this.ctx)).be.null();
+    it('should return null for successor overflow', async function () {
+      should(await this.dateSuccessorOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for predecessor underflow', function () {
-      should(this.datePredecessorUnderflow.exec(this.ctx)).be.null();
+    it('should return null for predecessor underflow', async function () {
+      should((await this.datePredecessorUnderflow.exec(this.ctx))).be.null();
     });
 
     // Tests for Precision are include in the spec tests
   });
 
   describe('Time', () => {
-    it('should return null for Add overflow', function () {
-      should(this.timeAddOverflow.exec(this.ctx)).be.null();
+    it('should return null for Add overflow', async function () {
+      should((await this.timeAddOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Add underflow', function () {
-      should(this.timeAddUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Add underflow', async function () {
+      should((await this.timeAddUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract overflow', function () {
-      should(this.timeSubtractOverflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract overflow', async function () {
+      should((await this.timeSubtractOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for Subtract underflow', function () {
-      should(this.timeSubtractUnderflow.exec(this.ctx)).be.null();
+    it('should return null for Subtract underflow', async function () {
+      should((await this.timeSubtractUnderflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for successor overflow', function () {
-      should(this.timeSuccessorOverflow.exec(this.ctx)).be.null();
+    it('should return null for successor overflow', async function () {
+      should((this.timeSuccessorOverflow.exec(this.ctx))).be.null();
     });
 
-    it('should return null for predecessor underflow', function () {
-      should(this.timePredecessorUnderflow.exec(this.ctx)).be.null();
+    it('should return null for predecessor underflow', async function () {
+      should((await this.timePredecessorUnderflow.exec(this.ctx))).be.null();
     });
 
     // Tests for Precision are include in the spec tests
   });
 
-  it('Exp should return null for overflow', function () {
-    should(this.expOverflow.exec(this.ctx)).be.null();
+  it('Exp should return null for overflow', async function () {
+    should((await this.expOverflow.exec(this.ctx))).be.null();
   });
 });

--- a/test/elm/arithmetic/arithmetic-test.ts
+++ b/test/elm/arithmetic/arithmetic-test.ts
@@ -264,7 +264,7 @@ describe('MinValue', () => {
   });
 
   it('of types other than Integer/Decimal/DateTime/Time should throw an error', async function () {
-   return this.minWrongType.exec(this.ctx).should.be.rejected();
+    return this.minWrongType.exec(this.ctx).should.be.rejected();
   });
 });
 

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -38,8 +38,8 @@ describe('ValueSetRef', () => {
     setup(this, data);
   });
 
-  it('should have a name', async function () {
-    (await this.foo.name).should.equal('Acute Pharyngitis');
+  it('should have a name', function () {
+    this.foo.name.should.equal('Acute Pharyngitis');
   });
 
   it('should execute to the defined value set', async function () {
@@ -156,14 +156,14 @@ describe('CodeDef', () => {
     setup(this, data, []);
   });
 
-  it('should return a CodeDef', async function () {
-    const codeDef = await this.lib.getCode('Tobacco smoking status code');
+  it('should return a CodeDef', function () {
+    const codeDef = this.lib.getCode('Tobacco smoking status code');
     codeDef.constructor.name.should.equal('CodeDef');
     codeDef.name.should.equal('Tobacco smoking status code');
   });
 
   it('should execute to a Code datatype', async function () {
-    const codeDef = await this.lib.getCode('Tobacco smoking status code');
+    const codeDef = this.lib.getCode('Tobacco smoking status code');
     const code = await codeDef.exec(this.ctx);
     code.code.should.equal('72166-2');
     code.system.should.equal('http://loinc.org');
@@ -173,12 +173,12 @@ describe('CodeDef', () => {
 });
 
 describe('CodeRef', () => {
-  beforeEach(async function () {
+  beforeEach(function () {
     setup(this, data);
   });
 
-  it('should have a name', async function () {
-    (await this.foo.name).should.equal('Tobacco smoking status code');
+  it('should have a name', function () {
+    this.foo.name.should.equal('Tobacco smoking status code');
   });
 
   it('should execute to the defined code', async function () {
@@ -195,8 +195,8 @@ describe('ConceptDef', () => {
     setup(this, data, []);
   });
 
-  it('should return a ConceptDef', async function () {
-    const conceptDef = await this.lib.getConcept('Tobacco smoking status');
+  it('should return a ConceptDef', function () {
+    const conceptDef = this.lib.getConcept('Tobacco smoking status');
     conceptDef.constructor.name.should.equal('ConceptDef');
     conceptDef.name.should.equal('Tobacco smoking status');
   });
@@ -218,8 +218,8 @@ describe('ConceptRef', () => {
     setup(this, data);
   });
 
-  it('should have a name', async function () {
-    (await this.foo.name).should.equal('Tobacco smoking status');
+  it('should have a name', function () {
+    this.foo.name.should.equal('Tobacco smoking status');
   });
 
   it('should execute to the defined concept', async function () {
@@ -233,8 +233,8 @@ describe('ConceptRef', () => {
   });
 });
 
-describe('CalculateAge', () => {
-  beforeEach(async function () {
+describe('CalculateAge', function () {
+  beforeEach(function () {
     setup(this, data, [p1]);
     // Note, tests are inexact (otherwise test needs to repeat exact logic we're testing)
     // p1 birth date is 1980-06-17
@@ -248,11 +248,10 @@ describe('CalculateAge', () => {
       DT.DateTime.fromJSDate(this.bdayPlus20)
     );
 
-    this.today = await this.ctx.getExecutionDateTime();
+    this.today = this.ctx.getExecutionDateTime();
     // according to spec, dates without timezones are in *current* time offset, so need to adjust
-    const offsetDiff =
-      (await this.today.toJSDate().getTimezoneOffset()) - this.bday.getTimezoneOffset();
-    await this.bday.setMinutes(this.bday.getMinutes() + offsetDiff);
+    const offsetDiff = this.today.toJSDate().getTimezoneOffset() - this.bday.getTimezoneOffset();
+    this.bday.setMinutes(this.bday.getMinutes() + offsetDiff);
 
     // this is getting the possible number of months in years with the addtion of an offset
     // to get the correct number of months

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -57,10 +57,11 @@ describe('InValueSet', () => {
   });
 
   it('should throw an error when codes are in several codesystems', async function () {
-    const c = await this.sharedCodesFoo.exec(this.ctx);
-    should(c).throw(
-      'In (valueset) is ambiguous -- multiple codes with multiple code systems exist in value set.'
-    );
+    return this.sharedCodesFoo
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        'In (valueset) is ambiguous -- multiple codes with multiple code systems exist in value set.'
+      );
   });
 
   it('should return false when there are multiple codesystems in a valueset but the string does not match any codes in valueset', async function () {
@@ -68,10 +69,11 @@ describe('InValueSet', () => {
   });
 
   it('should throw an error if not all codes have the same codesystem', async function () {
-    const c = await this.improperSharedCodesCodeValue.exec(this.ctx);
-    should(c).throw(
-      'In (valueset) is ambiguous -- multiple codes with multiple code systems exist in value set.'
-    );
+    return this.improperSharedCodesCodeValue
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        'In (valueset) is ambiguous -- multiple codes with multiple code systems exist in value set.'
+      );
   });
 
   it('should find string code in versioned value set', async function () {

--- a/test/elm/clinical/clinical-test.ts
+++ b/test/elm/clinical/clinical-test.ts
@@ -13,21 +13,21 @@ describe('ValueSetDef', () => {
     setup(this, data, [], vsets);
   });
 
-  it('should return a resolved value set when the codeService knows about it', function () {
-    const vs = this.known.exec(this.ctx);
+  it('should return a resolved value set when the codeService knows about it', async function () {
+    const vs = await this.known.exec(this.ctx);
     vs.oid.should.equal('2.16.840.1.113883.3.464.1003.101.12.1061');
     vs.version.should.equal('20140501');
     vs.codes.length.should.equal(3);
   });
 
-  it('should execute one-arg to ValueSet with ID', function () {
-    const vs = this['unknown One Arg'].exec(this.ctx);
+  it('should execute one-arg to ValueSet with ID', async function () {
+    const vs = await this['unknown One Arg'].exec(this.ctx);
     vs.oid.should.equal('1.2.3.4.5.6.7.8.9');
     should.not.exist(vs.version);
   });
 
-  it('should execute two-arg to ValueSet with ID and version', function () {
-    const vs = this['unknown Two Arg'].exec(this.ctx);
+  it('should execute two-arg to ValueSet with ID and version', async function () {
+    const vs = await this['unknown Two Arg'].exec(this.ctx);
     vs.oid.should.equal('1.2.3.4.5.6.7.8.9');
     vs.version.should.equal('1');
   });
@@ -38,12 +38,12 @@ describe('ValueSetRef', () => {
     setup(this, data);
   });
 
-  it('should have a name', function () {
-    this.foo.name.should.equal('Acute Pharyngitis');
+  it('should have a name', async function () {
+    (await this.foo.name).should.equal('Acute Pharyngitis');
   });
 
-  it('should execute to the defined value set', function () {
-    this.foo.exec(this.ctx).oid.should.equal('2.16.840.1.113883.3.464.1003.101.12.1001');
+  it('should execute to the defined value set', async function () {
+    (await this.foo.exec(this.ctx)).oid.should.equal('2.16.840.1.113883.3.464.1003.101.12.1001');
   });
 });
 
@@ -52,84 +52,86 @@ describe('InValueSet', () => {
     setup(this, data, [], vsets);
   });
 
-  it('should find string code in value set', function () {
-    this.string.exec(this.ctx).should.be.true();
+  it('should find string code in value set', async function () {
+    (await this.string.exec(this.ctx)).should.be.true();
   });
 
-  it('should throw an error when codes are in several codesystems', function () {
-    should(() => this.sharedCodesFoo.exec(this.ctx)).throw(
+  it('should throw an error when codes are in several codesystems', async function () {
+    const c = await this.sharedCodesFoo.exec(this.ctx);
+    should(c).throw(
       'In (valueset) is ambiguous -- multiple codes with multiple code systems exist in value set.'
     );
   });
 
-  it('should return false when there are multiple codesystems in a valueset but the string does not match any codes in valueset', function () {
-    this.sharedCodesNoMatch.exec(this.ctx).should.be.false();
+  it('should return false when there are multiple codesystems in a valueset but the string does not match any codes in valueset', async function () {
+    (await this.sharedCodesNoMatch.exec(this.ctx)).should.be.false();
   });
 
-  it('should throw an error if not all codes have the same codesystem', function () {
-    should(() => this.improperSharedCodesCodeValue.exec(this.ctx)).throw(
+  it('should throw an error if not all codes have the same codesystem', async function () {
+    const c = await this.improperSharedCodesCodeValue.exec(this.ctx);
+    should(c).throw(
       'In (valueset) is ambiguous -- multiple codes with multiple code systems exist in value set.'
     );
   });
 
-  it('should find string code in versioned value set', function () {
-    this.stringInVersionedValueSet.exec(this.ctx).should.be.true();
+  it('should find string code in versioned value set', async function () {
+    (await this.stringInVersionedValueSet.exec(this.ctx)).should.be.true();
   });
 
-  it('should not find short code in value set (missing code system)', function () {
-    this.shortCode.exec(this.ctx).should.be.false();
+  it('should not find short code in value set (missing code system)', async function () {
+    (await this.shortCode.exec(this.ctx)).should.be.false();
   });
 
-  it('should find medium code in value set', function () {
-    this.mediumCode.exec(this.ctx).should.be.true();
+  it('should find medium code in value set', async function () {
+    (await this.mediumCode.exec(this.ctx)).should.be.true();
   });
 
-  it('should find long code in value set', function () {
-    this.longCode.exec(this.ctx).should.be.true();
+  it('should find long code in value set', async function () {
+    (await this.longCode.exec(this.ctx)).should.be.true();
   });
 
-  it('should not find string code in value set', function () {
-    this.wrongString.exec(this.ctx).should.be.false();
+  it('should not find string code in value set', async function () {
+    (await this.wrongString.exec(this.ctx)).should.be.false();
   });
 
-  it('should not find string code in versioned value set', function () {
-    this.wrongStringInVersionedValueSet.exec(this.ctx).should.be.false();
+  it('should not find string code in versioned value set', async function () {
+    (await this.wrongStringInVersionedValueSet.exec(this.ctx)).should.be.false();
   });
 
-  it('should not find short code in value set (missing code system)', function () {
-    this.wrongShortCode.exec(this.ctx).should.be.false();
+  it('should not find short code in value set (missing code system)', async function () {
+    (await this.wrongShortCode.exec(this.ctx)).should.be.false();
   });
 
-  it('should not find medium code in value set', function () {
-    this.wrongMediumCode.exec(this.ctx).should.be.false();
+  it('should not find medium code in value set', async function () {
+    (await this.wrongMediumCode.exec(this.ctx)).should.be.false();
   });
 
-  it('should find long code with different version in value set', function () {
-    this.longCodeDifferentVersion.exec(this.ctx).should.be.true();
+  it('should find long code with different version in value set', async function () {
+    (await this.longCodeDifferentVersion.exec(this.ctx)).should.be.true();
   });
 
-  it('should not find code if it is null', function () {
-    this.nullCode.exec(this.ctx).should.be.false();
+  it('should not find code if it is null', async function () {
+    (await this.nullCode.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true if code in list is equivalent', function () {
-    this.inListOfCodes.exec(this.ctx).should.be.true();
+  it('should return true if code in list is equivalent', async function () {
+    (await this.inListOfCodes.exec(this.ctx)).should.be.true();
   });
 
-  it('should return true if code in list is equivalent using ExpressionRef', function () {
-    this.inListOfCodesExpressionRef.exec(this.ctx).should.be.true();
+  it('should return true if code in list is equivalent using ExpressionRef', async function () {
+    (await this.inListOfCodesExpressionRef.exec(this.ctx)).should.be.true();
   });
 
-  it('should return false if no code in list is equivalent', function () {
-    this.inWrongListOfCodes.exec(this.ctx).should.be.false();
+  it('should return false if no code in list is equivalent', async function () {
+    (await this.inWrongListOfCodes.exec(this.ctx)).should.be.false();
   });
 
-  it('should ignore null codes in list', function () {
-    this.listOfCodesWithNull.exec(this.ctx).should.be.true();
+  it('should ignore null codes in list', async function () {
+    (await this.listOfCodesWithNull.exec(this.ctx)).should.be.true();
   });
 
-  it('should return false for null list of codes', function () {
-    this.listOfCodesNull.exec(this.ctx).should.be.false();
+  it('should return false for null list of codes', async function () {
+    (await this.listOfCodesNull.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -138,14 +140,14 @@ describe('Patient Property In ValueSet', () => {
     setup(this, data, [], vsets);
   });
 
-  it('should find that John is not female', function () {
+  it('should find that John is not female', async function () {
     this.ctx.patient = new PatientSource([p1]).currentPatient();
-    this.isFemale.exec(this.ctx).should.be.false();
+    (await this.isFemale.exec(this.ctx)).should.be.false();
   });
 
-  it('should find that Sally is female', function () {
+  it('should find that Sally is female', async function () {
     this.ctx.patient = new PatientSource([p2]).currentPatient();
-    this.isFemale.exec(this.ctx).should.be.true();
+    (await this.isFemale.exec(this.ctx)).should.be.true();
   });
 });
 
@@ -154,15 +156,15 @@ describe('CodeDef', () => {
     setup(this, data, []);
   });
 
-  it('should return a CodeDef', function () {
-    const codeDef = this.lib.getCode('Tobacco smoking status code');
+  it('should return a CodeDef', async function () {
+    const codeDef = await this.lib.getCode('Tobacco smoking status code');
     codeDef.constructor.name.should.equal('CodeDef');
     codeDef.name.should.equal('Tobacco smoking status code');
   });
 
-  it('should execute to a Code datatype', function () {
-    const codeDef = this.lib.getCode('Tobacco smoking status code');
-    const code = codeDef.exec(this.ctx);
+  it('should execute to a Code datatype', async function () {
+    const codeDef = await this.lib.getCode('Tobacco smoking status code');
+    const code = await codeDef.exec(this.ctx);
     code.code.should.equal('72166-2');
     code.system.should.equal('http://loinc.org');
     should.not.exist(code.version);
@@ -171,16 +173,16 @@ describe('CodeDef', () => {
 });
 
 describe('CodeRef', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, data);
   });
 
-  it('should have a name', function () {
-    this.foo.name.should.equal('Tobacco smoking status code');
+  it('should have a name', async function () {
+    (await this.foo.name).should.equal('Tobacco smoking status code');
   });
 
-  it('should execute to the defined code', function () {
-    const code = this.foo.exec(this.ctx);
+  it('should execute to the defined code', async function () {
+    const code = await this.foo.exec(this.ctx);
     code.code.should.equal('72166-2');
     code.system.should.equal('http://loinc.org');
     should.not.exist(code.version);
@@ -193,15 +195,15 @@ describe('ConceptDef', () => {
     setup(this, data, []);
   });
 
-  it('should return a ConceptDef', function () {
-    const conceptDef = this.lib.getConcept('Tobacco smoking status');
+  it('should return a ConceptDef', async function () {
+    const conceptDef = await this.lib.getConcept('Tobacco smoking status');
     conceptDef.constructor.name.should.equal('ConceptDef');
     conceptDef.name.should.equal('Tobacco smoking status');
   });
 
-  it('should execute to a Concept datatype', function () {
-    const conceptDef = this.lib.getConcept('Tobacco smoking status');
-    const concept = conceptDef.exec(this.ctx);
+  it('should execute to a Concept datatype', async function () {
+    const conceptDef = await this.lib.getConcept('Tobacco smoking status');
+    const concept = await conceptDef.exec(this.ctx);
     concept.display.should.equal('Tobacco smoking status');
     concept.codes.should.have.length(1);
     concept.codes[0].code.should.equal('72166-2');
@@ -216,12 +218,12 @@ describe('ConceptRef', () => {
     setup(this, data);
   });
 
-  it('should have a name', function () {
-    this.foo.name.should.equal('Tobacco smoking status');
+  it('should have a name', async function () {
+    (await this.foo.name).should.equal('Tobacco smoking status');
   });
 
-  it('should execute to the defined concept', function () {
-    const concept = this.foo.exec(this.ctx);
+  it('should execute to the defined concept', async function () {
+    const concept = await this.foo.exec(this.ctx);
     concept.display.should.equal('Tobacco smoking status');
     concept.codes.should.have.length(1);
     concept.codes[0].code.should.equal('72166-2');
@@ -232,7 +234,7 @@ describe('ConceptRef', () => {
 });
 
 describe('CalculateAge', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, data, [p1]);
     // Note, tests are inexact (otherwise test needs to repeat exact logic we're testing)
     // p1 birth date is 1980-06-17
@@ -246,10 +248,11 @@ describe('CalculateAge', () => {
       DT.DateTime.fromJSDate(this.bdayPlus20)
     );
 
-    this.today = this.ctx.getExecutionDateTime();
+    this.today = await this.ctx.getExecutionDateTime();
     // according to spec, dates without timezones are in *current* time offset, so need to adjust
-    const offsetDiff = this.today.toJSDate().getTimezoneOffset() - this.bday.getTimezoneOffset();
-    this.bday.setMinutes(this.bday.getMinutes() + offsetDiff);
+    const offsetDiff =
+      (await this.today.toJSDate().getTimezoneOffset()) - this.bday.getTimezoneOffset();
+    await this.bday.setMinutes(this.bday.getMinutes() + offsetDiff);
 
     // this is getting the possible number of months in years with the addtion of an offset
     // to get the correct number of months
@@ -259,11 +262,11 @@ describe('CalculateAge', () => {
     this.timediff = this.today.toJSDate() - this.bday;
   }); // diff in milliseconds
 
-  it('should execute age in years', function () {
-    this.years.exec(this.ctx).should.equal(Math.floor(this.full_months / 12));
+  it('should execute age in years', async function () {
+    (await this.years.exec(this.ctx)).should.equal(Math.floor(this.full_months / 12));
   });
 
-  it.skip('should execute age in months', function () {
+  it.skip('should execute age in months', async function () {
     // This test is failing if you run it in the first half of any
     // given month and passing for the second half.
 
@@ -276,50 +279,50 @@ describe('CalculateAge', () => {
       const month_offset = dayOfMonth.getMonth() === 5 && dayOfMonth.getDate() < 17 ? 6 : 5;
       const full_months =
         (dayOfMonth.getFullYear() - 1980) * 12 + (dayOfMonth.getMonth() - month_offset);
-      [full_months, full_months + 1].indexOf(this.months.exec(this.ctx)).should.not.equal(-1);
+      [full_months, full_months + 1].indexOf(await this.months.exec(this.ctx)).should.not.equal(-1);
     }
   });
 
-  it('should execute age in weeks', function () {
+  it('should execute age in weeks', async function () {
     // this is an uncertainty since birthdate is only specfied to days
-    this.weeks
-      .exec(this.ctx)
-      .should.eql(
+    (await this.weeks.exec(this.ctx)).should.eql(
+      Math.floor(
         Math.floor(
-          Math.floor(
-            Math.floor(Math.floor(Math.floor(Math.floor(this.timediff / 1000) / 60) / 60) / 24) / 7
-          )
+          Math.floor(Math.floor(Math.floor(Math.floor(this.timediff / 1000) / 60) / 60) / 24) / 7
         )
-      );
+      )
+    );
   });
 
-  it('should execute age in days', function () {
+  it('should execute age in days', async function () {
     // this is an uncertainty since birthdate is only specfied to days
     const days = Math.floor(
       Math.floor(Math.floor(Math.floor(this.timediff / 1000) / 60) / 60) / 24
     );
-    this.days.exec(this.ctx).should.eql(new Uncertainty(days - 1, days));
+    (await this.days.exec(this.ctx)).should.eql(new Uncertainty(days - 1, days));
   });
 
   // temporarily skip since this test only works when DST is in effect
-  it.skip('should execute age in hours', function () {
+  it.skip('should execute age in hours', async function () {
     // this is an uncertainty since birthdate is only specfied to days
     const hours = Math.floor(Math.floor(Math.floor(this.timediff / 1000) / 60) / 60);
-    this.hours.exec(this.ctx).should.eql(new Uncertainty(hours - 24, hours));
+    (await this.hours.exec(this.ctx)).should.eql(new Uncertainty(hours - 24, hours));
   });
 
   // temporarily skip since this test only works when DST is in effect
-  it.skip('should execute age in minutes', function () {
+  it.skip('should execute age in minutes', async function () {
     // this is an uncertainty since birthdate is only specfied to days
     const minutes = Math.floor(Math.floor(this.timediff / 1000) / 60);
-    this.minutes.exec(this.ctx).should.eql(new Uncertainty(minutes - 24 * 60, minutes));
+    (await this.minutes.exec(this.ctx)).should.eql(new Uncertainty(minutes - 24 * 60, minutes));
   });
 
   // temporarily skip since this test only works when DST is in effect
-  it.skip('should execute age in seconds', function () {
+  it.skip('should execute age in seconds', async function () {
     // this is an uncertainty since birthdate is only specfied to days
     const seconds = Math.floor(this.timediff / 1000);
-    this.seconds.exec(this.ctx).should.eql(new Uncertainty(seconds - 24 * 60 * 60, seconds));
+    (await this.seconds.exec(this.ctx)).should.eql(
+      new Uncertainty(seconds - 24 * 60 * 60, seconds)
+    );
   });
 });
 
@@ -328,35 +331,35 @@ describe('CalculateAgeAt', () => {
     setup(this, data, [p1]);
   });
 
-  it('should execute age at 2012 as 31 - 32 (since 2012 is not precise to days)', function () {
-    this.ageAt2012.exec(this.ctx).should.eql(new Uncertainty(31, 32));
+  it('should execute age at 2012 as 31 - 32 (since 2012 is not precise to days)', async function () {
+    (await this.ageAt2012.exec(this.ctx)).should.eql(new Uncertainty(31, 32));
   });
 
-  it('should execute age at 19810216 as 0', function () {
-    this.ageAt19810216.exec(this.ctx).should.equal(0);
+  it('should execute age at 19810216 as 0', async function () {
+    (await this.ageAt19810216.exec(this.ctx)).should.equal(0);
   });
 
-  it('should execute age at 1975 as -5 to -4 (since 1975 is not precise to days)', function () {
-    this.ageAt1975.exec(this.ctx).should.eql(new Uncertainty(-5, -4));
+  it('should execute age at 1975 as -5 to -4 (since 1975 is not precise to days)', async function () {
+    (await this.ageAt1975.exec(this.ctx)).should.eql(new Uncertainty(-5, -4));
   });
 
-  it('should give an uncertainty due to birthdate time component with (using AgeInYearsAt)', function () {
+  it('should give an uncertainty due to birthdate time component with (using AgeInYearsAt)', async function () {
     setup(this, data, [p3]);
-    this.ageInYearsDateTimeArg.exec(this.ctx).should.eql(new Uncertainty(17, 18));
+    (await this.ageInYearsDateTimeArg.exec(this.ctx)).should.eql(new Uncertainty(17, 18));
   });
 
-  it('should give an uncertainty due to birthdate time component (using CalculateAgeInYearsAt)', function () {
+  it('should give an uncertainty due to birthdate time component (using CalculateAgeInYearsAt)', async function () {
     setup(this, data, [p3]);
-    this.calculateAgeInYearsDateTimeArg.exec(this.ctx).should.eql(new Uncertainty(17, 18));
+    (await this.calculateAgeInYearsDateTimeArg.exec(this.ctx)).should.eql(new Uncertainty(17, 18));
   });
 
-  it('should convert birthdate to date, give 18 (using AgeInYearsAt)', function () {
+  it('should convert birthdate to date, give 18 (using AgeInYearsAt)', async function () {
     setup(this, data, [p3]);
-    this.ageInYearsDateArg.exec(this.ctx).should.eql(18);
+    (await this.ageInYearsDateArg.exec(this.ctx)).should.eql(18);
   });
 
-  it('should convert date to DateTime, give 17 (using CalculateAgeInYearsAt)', function () {
+  it('should convert date to DateTime, give 17 (using CalculateAgeInYearsAt)', async function () {
     setup(this, data, [p3]);
-    this.calculateAgeInYearsDateArg.exec(this.ctx).should.eql(17);
+    (await this.calculateAgeInYearsDateArg.exec(this.ctx)).should.eql(17);
   });
 });

--- a/test/elm/comparison/comparison-test.ts
+++ b/test/elm/comparison/comparison-test.ts
@@ -9,134 +9,134 @@ describe('Equal', () => {
     setup(this, data);
   });
 
-  it('should be false for 5 = 4', function () {
-    this.aGtB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 = 4', async function () {
+    await this.aGtB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 = 5', function () {
-    this.aEqB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 = 5', async function () {
+    await this.aEqB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 = 6', function () {
-    this.aLtB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 = 6', async function () {
+    await this.aLtB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should identify equal/unequal tuples', function () {
-    this.eqTuples.exec(this.ctx).should.be.true();
-    this.uneqTuples.exec(this.ctx).should.be.false();
+  it('should identify equal/unequal tuples', async function () {
+    await this.eqTuples.exec(this.ctx).should.be.true();
+    await this.uneqTuples.exec(this.ctx).should.be.false();
   });
 
-  it('should identify equal tuples with same fields null', function () {
-    should(this.eqTuplesWithNullFields.exec(this.ctx)).be.true();
+  it('should identify equal tuples with same fields null', async function () {
+    should(await this.eqTuplesWithNullFields.exec(this.ctx)).be.true();
   });
 
-  it('should identify unequal tuples with same fields null', function () {
-    should(this.uneqTuplesWithNullFields.exec(this.ctx)).be.false();
+  it('should identify unequal tuples with same fields null', async function () {
+    should(await this.uneqTuplesWithNullFields.exec(this.ctx)).be.false();
   });
 
-  it('should identify uncertian tuples with same fields but one has a null field', function () {
-    should(this.uncertTuplesWithNullFieldOnOne.exec(this.ctx)).be.null();
+  it('should identify uncertian tuples with same fields but one has a null field', async function () {
+    should(await this.uncertTuplesWithNullFieldOnOne.exec(this.ctx)).be.null();
   });
 
-  it('should identify equal/unequal DateTimes in same timezone', function () {
-    this.eqDateTimes.exec(this.ctx).should.be.true();
-    this.uneqDateTimes.exec(this.ctx).should.be.false();
+  it('should identify equal/unequal DateTimes in same timezone', async function () {
+    await this.eqDateTimes.exec(this.ctx).should.be.true();
+    await this.uneqDateTimes.exec(this.ctx).should.be.false();
   });
 
-  it('should identify equal/unequal DateTimes in different timezones', function () {
-    this.eqDateTimesTZ.exec(this.ctx).should.be.true();
-    this.uneqDateTimesTZ.exec(this.ctx).should.be.false();
+  it('should identify equal/unequal DateTimes in different timezones', async function () {
+    await this.eqDateTimesTZ.exec(this.ctx).should.be.true();
+    await this.uneqDateTimesTZ.exec(this.ctx).should.be.false();
   });
 
-  it('should identify equal/unequal DateTimes with null milliseconds', function () {
-    this.eqDateTimesNullMs.exec(this.ctx).should.be.true();
-    this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.true();
+  it('should identify equal/unequal DateTimes with null milliseconds', async function () {
+    await this.eqDateTimesNullMs.exec(this.ctx).should.be.true();
+    await this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.true();
   });
 
-  it('should identify equal/unequal date times specified to only date level', function () {
-    should(this.eqDateTimesOnlyDate.exec(this.ctx)).be.true();
-    should(this.uneqDateTimesOnlyDate.exec(this.ctx)).be.false();
+  it('should identify equal/unequal date times specified to only date level', async function () {
+    should(await this.eqDateTimesOnlyDate.exec(this.ctx)).be.true();
+    should(await this.uneqDateTimesOnlyDate.exec(this.ctx)).be.false();
   });
 
-  it('should identify case of a possibly equal date times with differing precisions', function () {
-    should(this.possiblyEqDateTimesOnlyDateOnOne.exec(this.ctx)).be.null();
+  it('should identify case of a possibly equal date times with differing precisions', async function () {
+    should(await this.possiblyEqDateTimesOnlyDateOnOne.exec(this.ctx)).be.null();
   });
 
-  it('should identify unequal date times with differing precisions', function () {
-    should(this.uneqDateTimesOnlyDateOnOne.exec(this.ctx)).be.false();
+  it('should identify unequal date times with differing precisions', async function () {
+    should(await this.uneqDateTimesOnlyDateOnOne.exec(this.ctx)).be.false();
   });
 
-  it('should identify uncertain/unequal DateTimes when there is imprecision', function () {
-    should(this.possiblyEqualDateTimes.exec(this.ctx)).be.null();
-    this.impossiblyEqualDateTimes.exec(this.ctx).should.be.false();
+  it('should identify uncertain/unequal DateTimes when there is imprecision', async function () {
+    should(await this.possiblyEqualDateTimes.exec(this.ctx)).be.null();
+    await this.impossiblyEqualDateTimes.exec(this.ctx).should.be.false();
   });
 
-  it('should be null for Date and DateTime equality with same year, month, hour', function () {
-    should(this.dateAndDateTimeNull.exec(this.ctx)).be.null();
+  it('should be null for Date and DateTime equality with same year, month, hour', async function () {
+    should(await this.dateAndDateTimeNull.exec(this.ctx)).be.null();
   });
 
-  it('should be false for Date and DateTime equality with same year, month, hour and additional fields', function () {
-    this.dateAndDateTimeUncertainFalse.exec(this.ctx).should.be.false();
+  it('should be false for Date and DateTime equality with same year, month, hour and additional fields', async function () {
+    await this.dateAndDateTimeUncertainFalse.exec(this.ctx).should.be.false();
   });
 
-  it('should be null for DateTime and Date equality with same year, month, hour', function () {
-    should(this.dateTimeAndDateNull.exec(this.ctx)).be.null();
+  it('should be null for DateTime and Date equality with same year, month, hour', async function () {
+    should(await this.dateTimeAndDateNull.exec(this.ctx)).be.null();
   });
 
-  it('should be null for DateTime and Date equality with same year, month, hour and additional fields', function () {
-    this.dateTimeAndDateUncertainFalse.exec(this.ctx).should.be.false();
+  it('should be null for DateTime and Date equality with same year, month, hour and additional fields', async function () {
+    await this.dateTimeAndDateUncertainFalse.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for Date and DateTime equality with different hour', function () {
-    this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.false();
+  it('should be false for Date and DateTime equality with different hour', async function () {
+    await this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for DateTime and Date equality with different hour', function () {
-    this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.false();
+  it('should be false for DateTime and Date equality with different hour', async function () {
+    await this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m = 4 m', function () {
-    this.aGtB_Quantity.exec(this.ctx).should.be.false();
+  it('should be false for 5 m = 4 m', async function () {
+    await this.aGtB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 m = 5 m', function () {
-    this.aEqB_Quantity.exec(this.ctx).should.be.true();
+  it('should be true for 5 m = 5 m', async function () {
+    await this.aEqB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m = 6 m', function () {
-    this.aLtB_Quantity.exec(this.ctx).should.be.false();
+  it('should be false for 5 m = 6 m', async function () {
+    await this.aLtB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m = 5 cm', function () {
-    this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be false for 5 m = 5 cm', async function () {
+    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 m = 500 cm', function () {
-    this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be true for 5 m = 500 cm', async function () {
+    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m = 5 km', function () {
-    this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be false for 5 m = 5 km', async function () {
+    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be null for 5 Cel = 4 m', function () {
-    should(this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel = 4 m', async function () {
+    should(await this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel = 5 m', function () {
-    should(this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel = 5 m', async function () {
+    should(await this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel = 40 m', function () {
-    should(this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel = 40 m', async function () {
+    should(await this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be true for 10mg:2dL = 15mg:3dL', function () {
-    this.eqRatios.exec(this.ctx).should.be.true();
+  it('should be true for 10mg:2dL = 15mg:3dL', async function () {
+    await this.eqRatios.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 10mg:2dL = 15mg:4dL', function () {
-    this.uneqRatios.exec(this.ctx).should.be.false();
+  it('should be false for 10mg:2dL = 15mg:4dL', async function () {
+    await this.uneqRatios.exec(this.ctx).should.be.false();
   });
 });
 
@@ -145,122 +145,122 @@ describe('NotEqual', () => {
     setup(this, data);
   });
 
-  it('should be true for 5 <> 4', function () {
-    this.aGtB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 <> 4', async function () {
+    await this.aGtB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 <> 5', function () {
-    this.aEqB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 <> 5', async function () {
+    await this.aEqB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 <> 6', function () {
-    this.aLtB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 <> 6', async function () {
+    await this.aLtB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should identify equal/unequal tuples', function () {
-    this.eqTuples.exec(this.ctx).should.be.false();
-    this.uneqTuples.exec(this.ctx).should.be.true();
+  it('should identify equal/unequal tuples', async function () {
+    await this.eqTuples.exec(this.ctx).should.be.false();
+    await this.uneqTuples.exec(this.ctx).should.be.true();
   });
 
-  it('should identify equal tuples with same fields null', function () {
-    should(this.eqTuplesWithNullFields.exec(this.ctx)).be.false();
+  it('should identify equal tuples with same fields null', async function () {
+    should(await this.eqTuplesWithNullFields.exec(this.ctx)).be.false();
   });
 
-  it('should identify unequal tuples with same fields null', function () {
-    should(this.uneqTuplesWithNullFields.exec(this.ctx)).be.true();
+  it('should identify unequal tuples with same fields null', async function () {
+    should(await this.uneqTuplesWithNullFields.exec(this.ctx)).be.true();
   });
 
-  it('should identify uncertian tuples with same fields but one has a null field', function () {
-    should(this.uncertTuplesWithNullFieldOnOne.exec(this.ctx)).be.null();
+  it('should identify uncertian tuples with same fields but one has a null field', async function () {
+    should(await this.uncertTuplesWithNullFieldOnOne.exec(this.ctx)).be.null();
   });
 
-  it('should identify equal/unequal DateTimes in same timezone', function () {
-    this.eqDateTimes.exec(this.ctx).should.be.false();
-    this.uneqDateTimes.exec(this.ctx).should.be.true();
+  it('should identify equal/unequal DateTimes in same timezone', async function () {
+    await this.eqDateTimes.exec(this.ctx).should.be.false();
+    await this.uneqDateTimes.exec(this.ctx).should.be.true();
   });
 
-  it('should identify equal/unequal DateTimes in different timezones', function () {
-    this.eqDateTimesTZ.exec(this.ctx).should.be.false();
-    this.uneqDateTimesTZ.exec(this.ctx).should.be.true();
+  it('should identify equal/unequal DateTimes in different timezones', async function () {
+    await this.eqDateTimesTZ.exec(this.ctx).should.be.false();
+    await this.uneqDateTimesTZ.exec(this.ctx).should.be.true();
   });
 
-  it('should identify equal/unequal DateTimes with null milliseconds', function () {
-    this.eqDateTimesNullMs.exec(this.ctx).should.be.false();
-    this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.false();
+  it('should identify equal/unequal DateTimes with null milliseconds', async function () {
+    await this.eqDateTimesNullMs.exec(this.ctx).should.be.false();
+    await this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.false();
   });
 
-  it('should identify equal/unequal date times specified to only date level', function () {
-    should(this.eqDateTimesOnlyDate.exec(this.ctx)).be.false();
-    should(this.uneqDateTimesOnlyDate.exec(this.ctx)).be.true();
+  it('should identify equal/unequal date times specified to only date level', async function () {
+    should(await this.eqDateTimesOnlyDate.exec(this.ctx)).be.false();
+    should(await this.uneqDateTimesOnlyDate.exec(this.ctx)).be.true();
   });
 
-  it('should identify case of a possibly equal date times with differing precisions', function () {
-    should(this.possiblyEqDateTimesOnlyDateOnOne.exec(this.ctx)).be.null();
+  it('should identify case of a possibly equal date times with differing precisions', async function () {
+    should(await this.possiblyEqDateTimesOnlyDateOnOne.exec(this.ctx)).be.null();
   });
 
-  it('should identify unequal date times with differing precisions', function () {
-    should(this.uneqDateTimesOnlyDateOnOne.exec(this.ctx)).be.true();
+  it('should identify unequal date times with differing precisions', async function () {
+    should(await this.uneqDateTimesOnlyDateOnOne.exec(this.ctx)).be.true();
   });
 
-  it('should identify uncertain/unequal DateTimes when there is imprecision', function () {
-    should(this.possiblyEqualDateTimes.exec(this.ctx)).be.null();
-    this.impossiblyEqualDateTimes.exec(this.ctx).should.be.true();
+  it('should identify uncertain/unequal DateTimes when there is imprecision', async function () {
+    should(await this.possiblyEqualDateTimes.exec(this.ctx)).be.null();
+    await this.impossiblyEqualDateTimes.exec(this.ctx).should.be.true();
   });
 
-  it('should be null for Date and DateTime equality with same year, month, hour', function () {
-    should(this.dateAndDateTimeNull.exec(this.ctx)).be.null();
+  it('should be null for Date and DateTime equality with same year, month, hour', async function () {
+    should(await this.dateAndDateTimeNull.exec(this.ctx)).be.null();
   });
 
-  it('should be true for date and DateTime with additional fields', function () {
-    this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.true();
+  it('should be true for date and DateTime with additional fields', async function () {
+    await this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for DateTime and Date equality with same year, month, hour', function () {
-    this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.true();
+  it('should be true for DateTime and Date equality with same year, month, hour', async function () {
+    await this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.true();
   });
 
-  it('should be null for all DateTime and Date equality with same year, month, hour', function () {
-    should(this.dateTimeAndDateNull.exec(this.ctx)).be.null();
+  it('should be null for all DateTime and Date equality with same year, month, hour', async function () {
+    should(await this.dateTimeAndDateNull.exec(this.ctx)).be.null();
   });
 
-  it('should be true for DateTime and Date equality with same year, month, hour and additional fields', function () {
-    this.dateTimeAndDateUncertainTrue.exec(this.ctx).should.be.true();
+  it('should be true for DateTime and Date equality with same year, month, hour and additional fields', async function () {
+    await this.dateTimeAndDateUncertainTrue.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for 5 m != 4 m', function () {
-    this.aGtB_Quantity.exec(this.ctx).should.be.true();
+  it('should be true for 5 m != 4 m', async function () {
+    await this.aGtB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m != 5 m', function () {
-    this.aEqB_Quantity.exec(this.ctx).should.be.false();
+  it('should be false for 5 m != 5 m', async function () {
+    await this.aEqB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 m != 6 m', function () {
-    this.aLtB_Quantity.exec(this.ctx).should.be.true();
+  it('should be true for 5 m != 6 m', async function () {
+    await this.aLtB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for 5 m != 5 cm', function () {
-    this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be true for 5 m != 5 cm', async function () {
+    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m != 500 cm ', function () {
-    this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be false for 5 m != 500 cm ', async function () {
+    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 m != 5 km', function () {
-    this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be true for 5 m != 5 km', async function () {
+    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be null for 5 Cel != 4 m', function () {
-    should(this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel != 4 m', async function () {
+    should(await this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel != 5 m', function () {
-    should(this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel != 5 m', async function () {
+    should(await this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel != 40 m', function () {
-    should(this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel != 40 m', async function () {
+    should(await this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 });
 
@@ -269,252 +269,252 @@ describe('Equivalent', () => {
     setup(this, data);
   });
 
-  it('should be false for null ~ 4', function () {
-    this.aNull_BDefined.exec(this.ctx).should.be.false();
+  it('should be false for null ~ 4', async function () {
+    await this.aNull_BDefined.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for ratio compared to date', function () {
-    this.uneqRatioTypes.exec(this.ctx).should.be.false();
+  it('should be false for ratio compared to date', async function () {
+    await this.uneqRatioTypes.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 ~ null', function () {
-    this.aDefined_BNull.exec(this.ctx).should.be.false();
+  it('should be false for 5 ~ null', async function () {
+    await this.aDefined_BNull.exec(this.ctx).should.be.false();
   });
 
-  it.skip('should be true for null ~ null', function () {
+  it.skip('should be true for null ~ null', async function () {
     // Skipping because of cql-to-elm issue that will be fixed in 1.4
-    this.aNull_BNull.exec(this.ctx).should.be.true();
+    await this.aNull_BNull.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for 3 ~ 3', function () {
-    this.aDefined_BDefined.exec(this.ctx).should.be.true();
+  it('should be true for 3 ~ 3', async function () {
+    await this.aDefined_BDefined.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for FOO ~ foo', function () {
-    this.caseInsensitiveStrings.exec(this.ctx).should.be.true();
+  it('should be true for FOO ~ foo', async function () {
+    await this.caseInsensitiveStrings.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for foo bar ~ foo\tbar', function () {
-    this.whiteSpaceTabTrue.exec(this.ctx).should.be.true();
+  it('should be true for foo bar ~ foo\tbar', async function () {
+    await this.whiteSpaceTabTrue.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for foo\tbar ~ foo\nbar', function () {
-    this.whiteSpaceTabReturnTrue.exec(this.ctx).should.be.true();
+  it('should be true for foo\tbar ~ foo\nbar', async function () {
+    await this.whiteSpaceTabReturnTrue.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for foo bar ~ foo\t\tbar', function () {
-    this.whiteSpaceIncorrectSpaceFalse.exec(this.ctx).should.be.false();
+  it('should be false for foo bar ~ foo\t\tbar', async function () {
+    await this.whiteSpaceIncorrectSpaceFalse.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for foo\t\tbar ~ foo\tbar', function () {
-    this.whiteSpaceIncorrectNumberTabsFalse.exec(this.ctx).should.be.false();
+  it('should be false for foo\t\tbar ~ foo\tbar', async function () {
+    await this.whiteSpaceIncorrectNumberTabsFalse.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for foo bar ~ foobar', function () {
-    this.whiteSpaceNoSpaceFalse.exec(this.ctx).should.be.false();
+  it('should be false for foo bar ~ foobar', async function () {
+    await this.whiteSpaceNoSpaceFalse.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 10mg:2dL ~ 15mg:3dL', function () {
-    this.eqRatios.exec(this.ctx).should.be.true();
+  it('should be true for 10mg:2dL ~ 15mg:3dL', async function () {
+    await this.eqRatios.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 10mg:2dL ~ 15mg:4dL', function () {
-    this.uneqRatios.exec(this.ctx).should.be.false();
+  it('should be false for 10mg:2dL ~ 15mg:4dL', async function () {
+    await this.uneqRatios.exec(this.ctx).should.be.false();
   });
 
-  it('should identify equal/unequal DateTimes in same timezone', function () {
-    this.eqDateTimes.exec(this.ctx).should.be.true();
-    this.uneqDateTimes.exec(this.ctx).should.be.false();
+  it('should identify equal/unequal DateTimes in same timezone', async function () {
+    await this.eqDateTimes.exec(this.ctx).should.be.true();
+    await this.uneqDateTimes.exec(this.ctx).should.be.false();
   });
 
-  it('should identify equal/unequal DateTimes in different timezones', function () {
-    this.eqDateTimesTZ.exec(this.ctx).should.be.true();
-    this.uneqDateTimesTZ.exec(this.ctx).should.be.false();
+  it('should identify equal/unequal DateTimes in different timezones', async function () {
+    await this.eqDateTimesTZ.exec(this.ctx).should.be.true();
+    await this.uneqDateTimesTZ.exec(this.ctx).should.be.false();
   });
 
-  it('should identify equal/unequal DateTimes with null milliseconds', function () {
-    this.eqDateTimesNullMs.exec(this.ctx).should.be.true();
-    this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.true();
+  it('should identify equal/unequal DateTimes with null milliseconds', async function () {
+    await this.eqDateTimesNullMs.exec(this.ctx).should.be.true();
+    await this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.true();
   });
 
-  it('should identify equal/unequal date times specified to only date level', function () {
-    should(this.eqDateTimesOnlyDate.exec(this.ctx)).be.true();
-    should(this.uneqDateTimesOnlyDate.exec(this.ctx)).be.false();
+  it('should identify equal/unequal date times specified to only date level', async function () {
+    should(await this.eqDateTimesOnlyDate.exec(this.ctx)).be.true();
+    should(await this.uneqDateTimesOnlyDate.exec(this.ctx)).be.false();
   });
 
-  it('should identify case of a possibly equal date times with differing precisions', function () {
-    this.possiblyEqDateTimesOnlyDateOnOne.exec(this.ctx).should.be.false();
+  it('should identify case of a possibly equal date times with differing precisions', async function () {
+    await this.possiblyEqDateTimesOnlyDateOnOne.exec(this.ctx).should.be.false();
   });
 
-  it('should identify unequal date times with differing precisions', function () {
-    should(this.uneqDateTimesOnlyDateOnOne.exec(this.ctx)).be.false();
+  it('should identify unequal date times with differing precisions', async function () {
+    should(await this.uneqDateTimesOnlyDateOnOne.exec(this.ctx)).be.false();
   });
 
-  it('should identify uncertain/unequal DateTimes when there is imprecision', function () {
-    this.possiblyEqualDateTimes.exec(this.ctx).should.be.false();
-    this.impossiblyEqualDateTimes.exec(this.ctx).should.be.false();
+  it('should identify uncertain/unequal DateTimes when there is imprecision', async function () {
+    await this.possiblyEqualDateTimes.exec(this.ctx).should.be.false();
+    await this.impossiblyEqualDateTimes.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for Date and DateTime equality with same year, month, hour', function () {
-    this.dateAndDateTimeNull.exec(this.ctx).should.be.false();
+  it('should be false for Date and DateTime equality with same year, month, hour', async function () {
+    await this.dateAndDateTimeNull.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for Date and DateTime equality with same year, month, hour and additional fields', function () {
-    this.dateAndDateTimeUncertainFalse.exec(this.ctx).should.be.false();
+  it('should be false for Date and DateTime equality with same year, month, hour and additional fields', async function () {
+    await this.dateAndDateTimeUncertainFalse.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for DateTime and Date equality with same year, month, hour', function () {
-    this.dateTimeAndDateNull.exec(this.ctx).should.be.false();
+  it('should be false for DateTime and Date equality with same year, month, hour', async function () {
+    await this.dateTimeAndDateNull.exec(this.ctx).should.be.false();
   });
 
-  it('should be null for DateTime and Date equality with same year, month, hour and additional fields', function () {
-    this.dateTimeAndDateUncertainFalse.exec(this.ctx).should.be.false();
+  it('should be null for DateTime and Date equality with same year, month, hour and additional fields', async function () {
+    await this.dateTimeAndDateUncertainFalse.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for Date and DateTime equality with different hour', function () {
-    this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.false();
+  it('should be false for Date and DateTime equality with different hour', async function () {
+    await this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for DateTime and Date equality with different hour', function () {
-    this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.false();
+  it('should be false for DateTime and Date equality with different hour', async function () {
+    await this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.false();
   });
 
   describe('Tuples', () => {
-    it.skip('should return true for empty tuples', function () {
+    it.skip('should return true for empty tuples', async function () {
       // Note: the spec doesn't explicitly define this, expecting behavior to match null ~ null
-      this.emptyTuples.exec(this.ctx).should.be.true();
+      await this.emptyTuples.exec(this.ctx).should.be.true();
     });
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    it.skip('should return false if Tuples are not of the same type', function () {});
+    it.skip('should return false if Tuples are not of the same type', async function () {});
     // Note: There is currently no way to tell the type of Tuples as they are all treated as Objects
 
-    it('should return true if Tuples are elementwise identical', function () {
-      this.sameTuples.exec(this.ctx).should.be.true();
+    it('should return true if Tuples are elementwise identical', async function () {
+      await this.sameTuples.exec(this.ctx).should.be.true();
     });
 
-    it('should return true if Tuples are elementwise identical and null', function () {
-      this.sameTuplesNull.exec(this.ctx).should.be.true();
+    it('should return true if Tuples are elementwise identical and null', async function () {
+      await this.sameTuplesNull.exec(this.ctx).should.be.true();
     });
 
-    it('should return false if Tuples are not elementwise identical', function () {
-      this.differentTuples.exec(this.ctx).should.be.false();
+    it('should return false if Tuples are not elementwise identical', async function () {
+      await this.differentTuples.exec(this.ctx).should.be.false();
     });
 
-    it('should return true for nested tuples', function () {
-      this.sameNestedTuples.exec(this.ctx).should.be.true();
+    it('should return true for nested tuples', async function () {
+      await this.sameNestedTuples.exec(this.ctx).should.be.true();
     });
 
-    it('should return true for nested tuples', function () {
-      this.sameNestedTuplesNull.exec(this.ctx).should.be.true();
+    it('should return true for nested tuples', async function () {
+      await this.sameNestedTuplesNull.exec(this.ctx).should.be.true();
     });
   });
 
   describe('Lists', () => {
-    it('should return true for empty lists', function () {
-      this.emptyLists.exec(this.ctx).should.be.true();
+    it('should return true for empty lists', async function () {
+      await this.emptyLists.exec(this.ctx).should.be.true();
     });
 
-    it('should return false for lists with different types', function () {
-      this.differentTypesLists.exec(this.ctx).should.be.false();
+    it('should return false for lists with different types', async function () {
+      await this.differentTypesLists.exec(this.ctx).should.be.false();
     });
 
-    it('should return false for lists with different number of elements', function () {
-      this.differentLengthLists.exec(this.ctx).should.be.false();
+    it('should return false for lists with different number of elements', async function () {
+      await this.differentLengthLists.exec(this.ctx).should.be.false();
     });
 
-    it('should return false for lists with same elements in different order', function () {
-      this.differentOrderLists.exec(this.ctx).should.be.false();
+    it('should return false for lists with same elements in different order', async function () {
+      await this.differentOrderLists.exec(this.ctx).should.be.false();
     });
 
-    it('should return true for lists with same elements in same order', function () {
-      this.sameLists.exec(this.ctx).should.be.true();
+    it('should return true for lists with same elements in same order', async function () {
+      await this.sameLists.exec(this.ctx).should.be.true();
     });
 
-    it('should return true for lists with same elements in same order including nulls', function () {
-      this.sameListsNull.exec(this.ctx).should.be.true();
+    it('should return true for lists with same elements in same order including nulls', async function () {
+      await this.sameListsNull.exec(this.ctx).should.be.true();
     });
 
-    it('should return true for nested lists with same elements in same order', function () {
-      this.sameNestedLists.exec(this.ctx).should.be.true();
+    it('should return true for nested lists with same elements in same order', async function () {
+      await this.sameNestedLists.exec(this.ctx).should.be.true();
     });
 
-    it('should return true for nested lists with same elements in same order including nulls', function () {
-      this.sameNestedListsNull.exec(this.ctx).should.be.true();
+    it('should return true for nested lists with same elements in same order including nulls', async function () {
+      await this.sameNestedListsNull.exec(this.ctx).should.be.true();
     });
   });
 
   describe('Intervals', () => {
-    it('should return true for null low/high', function () {
-      this.emptyInterval.exec(this.ctx).should.be.true();
+    it('should return true for null low/high', async function () {
+      await this.emptyInterval.exec(this.ctx).should.be.true();
     });
 
-    it('should return false for different Interval point types', function () {
-      this.intervalDifferentPointTypes.exec(this.ctx).should.be.false();
+    it('should return false for different Interval point types', async function () {
+      await this.intervalDifferentPointTypes.exec(this.ctx).should.be.false();
     });
 
-    it('should return false if different starting points', function () {
-      this.intervalDifferentStarts.exec(this.ctx).should.be.false();
+    it('should return false if different starting points', async function () {
+      await this.intervalDifferentStarts.exec(this.ctx).should.be.false();
     });
 
-    it('should return false if different ending points', function () {
-      this.intervalDifferentEndings.exec(this.ctx).should.be.false();
+    it('should return false if different ending points', async function () {
+      await this.intervalDifferentEndings.exec(this.ctx).should.be.false();
     });
 
-    it('should return true for identical Intervals', function () {
-      this.sameIntervals.exec(this.ctx).should.be.true();
+    it('should return true for identical Intervals', async function () {
+      await this.sameIntervals.exec(this.ctx).should.be.true();
     });
   });
 
   describe('Lists and Tuples', () => {
-    it('should return false for List ~ Tuple', function () {
-      this.listAndTuple.exec(this.ctx).should.be.false();
+    it('should return false for List ~ Tuple', async function () {
+      await this.listAndTuple.exec(this.ctx).should.be.false();
     });
 
-    it('should return false for Tuple ~ List', function () {
-      this.tupleAndList.exec(this.ctx).should.be.false();
+    it('should return false for Tuple ~ List', async function () {
+      await this.tupleAndList.exec(this.ctx).should.be.false();
     });
 
-    it('should return false for List ~ Tuple with null', function () {
-      this.nullListAndTuple.exec(this.ctx).should.be.false();
+    it('should return false for List ~ Tuple with null', async function () {
+      await this.nullListAndTuple.exec(this.ctx).should.be.false();
     });
 
-    it('should return false for Tuple with null ~ List', function () {
-      this.tupleAndNullList.exec(this.ctx).should.be.false();
+    it('should return false for Tuple with null ~ List', async function () {
+      await this.tupleAndNullList.exec(this.ctx).should.be.false();
     });
   });
 
   describe('Codes and Concepts', () => {
-    it('should return true for same Codes', function () {
-      this.sameCodeAndCode.exec(this.ctx).should.be.true();
+    it('should return true for same Codes', async function () {
+      await this.sameCodeAndCode.exec(this.ctx).should.be.true();
     });
 
-    it('should return true for same Code and Concept', function () {
-      this.sameCodeAndConcept.exec(this.ctx).should.be.true();
+    it('should return true for same Code and Concept', async function () {
+      await this.sameCodeAndConcept.exec(this.ctx).should.be.true();
     });
 
-    it('should return true for same Concept and Code', function () {
-      this.sameConceptAndCode.exec(this.ctx).should.be.true();
+    it('should return true for same Concept and Code', async function () {
+      await this.sameConceptAndCode.exec(this.ctx).should.be.true();
     });
 
-    it('should return true for same Concept and Concept', function () {
-      this.sameConceptAndConcept.exec(this.ctx).should.be.true();
+    it('should return true for same Concept and Concept', async function () {
+      await this.sameConceptAndConcept.exec(this.ctx).should.be.true();
     });
 
-    it('should return false for same Codes', function () {
-      this.diffCodeAndCode.exec(this.ctx).should.be.false();
+    it('should return false for same Codes', async function () {
+      await this.diffCodeAndCode.exec(this.ctx).should.be.false();
     });
 
-    it('should return false for same Code and Concept', function () {
-      this.diffCodeAndConcept.exec(this.ctx).should.be.false();
+    it('should return false for same Code and Concept', async function () {
+      await this.diffCodeAndConcept.exec(this.ctx).should.be.false();
     });
 
-    it('should return false for same Concept and Code', function () {
-      this.diffConceptAndCode.exec(this.ctx).should.be.false();
+    it('should return false for same Concept and Code', async function () {
+      await this.diffConceptAndCode.exec(this.ctx).should.be.false();
     });
 
-    it('should return false for same Concept and Concept', function () {
-      this.diffConceptAndConcept.exec(this.ctx).should.be.false();
+    it('should return false for same Concept and Concept', async function () {
+      await this.diffConceptAndConcept.exec(this.ctx).should.be.false();
     });
   });
 });
@@ -524,52 +524,52 @@ describe('Less', () => {
     setup(this, data);
   });
 
-  it('should be false for 5 < 4', function () {
-    this.aGtB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 < 4', async function () {
+    await this.aGtB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 < 5', function () {
-    this.aEqB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 < 5', async function () {
+    await this.aEqB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 < 6', function () {
-    this.aLtB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 < 6', async function () {
+    await this.aLtB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m < 4 m', function () {
-    this.aGtB_Quantity.exec(this.ctx).should.be.false();
+  it('should be false for 5 m < 4 m', async function () {
+    await this.aGtB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m < 5 m', function () {
-    this.aEqB_Quantity.exec(this.ctx).should.be.false();
+  it('should be false for 5 m < 5 m', async function () {
+    await this.aEqB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m < 6 m', function () {
-    this.aLtB_Quantity.exec(this.ctx).should.be.true();
+  it('should be false for 5 m < 6 m', async function () {
+    await this.aLtB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for 5 m < 5 cm', function () {
-    this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be true for 5 m < 5 cm', async function () {
+    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m < 50 cm ', function () {
-    this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be false for 5 m < 50 cm ', async function () {
+    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m < 5 km', function () {
-    this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be false for 5 m < 5 km', async function () {
+    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be null for 5 Cel < 4 m', function () {
-    should(this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel < 4 m', async function () {
+    should(await this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel < 5 m', function () {
-    should(this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel < 5 m', async function () {
+    should(await this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel < 40 m', function () {
-    should(this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel < 40 m', async function () {
+    should(await this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 });
 
@@ -578,52 +578,52 @@ describe('LessOrEqual', () => {
     setup(this, data);
   });
 
-  it('should be false for 5 <= 4', function () {
-    this.aGtB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 <= 4', async function () {
+    await this.aGtB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 <= 5', function () {
-    this.aEqB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 <= 5', async function () {
+    await this.aEqB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for 5 <= 6', function () {
-    this.aLtB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 <= 6', async function () {
+    await this.aLtB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for 5 m <= 4 m', function () {
-    this.aGtB_Quantity.exec(this.ctx).should.be.false();
+  it('should be true for 5 m <= 4 m', async function () {
+    await this.aGtB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m <= 5 m', function () {
-    this.aEqB_Quantity.exec(this.ctx).should.be.true();
+  it('should be false for 5 m <= 5 m', async function () {
+    await this.aEqB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m <= 6 m', function () {
-    this.aLtB_Quantity.exec(this.ctx).should.be.true();
+  it('should be false for 5 m <= 6 m', async function () {
+    await this.aLtB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for 5 m <= 5 cm', function () {
-    this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be true for 5 m <= 5 cm', async function () {
+    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m <= 500 cm ', function () {
-    this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be false for 5 m <= 500 cm ', async function () {
+    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m <= 5 km', function () {
-    this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be false for 5 m <= 5 km', async function () {
+    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be null for 5 Cel <= 4 m', function () {
-    should(this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel <= 4 m', async function () {
+    should(await this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel <= 5 m', function () {
-    should(this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel <= 5 m', async function () {
+    should(await this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel <= 40 m', function () {
-    should(this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel <= 40 m', async function () {
+    should(await this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 });
 
@@ -632,52 +632,52 @@ describe('Greater', () => {
     setup(this, data);
   });
 
-  it('should be true for 5 > 4', function () {
-    this.aGtB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 > 4', async function () {
+    await this.aGtB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 > 5', function () {
-    this.aEqB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 > 5', async function () {
+    await this.aEqB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 > 6', function () {
-    this.aLtB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 > 6', async function () {
+    await this.aLtB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 m > 4 m', function () {
-    this.aGtB_Quantity.exec(this.ctx).should.be.true();
+  it('should be true for 5 m > 4 m', async function () {
+    await this.aGtB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m > 5 m', function () {
-    this.aEqB_Quantity.exec(this.ctx).should.be.false();
+  it('should be false for 5 m > 5 m', async function () {
+    await this.aEqB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m > 6 m', function () {
-    this.aLtB_Quantity.exec(this.ctx).should.be.false();
+  it('should be false for 5 m > 6 m', async function () {
+    await this.aLtB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 m > 5 cm', function () {
-    this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be true for 5 m > 5 cm', async function () {
+    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m > 50 cm ', function () {
-    this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be false for 5 m > 50 cm ', async function () {
+    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be false for 5 m > 5 km', function () {
-    this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be false for 5 m > 5 km', async function () {
+    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be null for 5 Cel > 4 m', function () {
-    should(this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel > 4 m', async function () {
+    should(await this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel > 5 m', function () {
-    should(this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel > 5 m', async function () {
+    should(await this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel > 40 m', function () {
-    should(this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel > 40 m', async function () {
+    should(await this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 });
 
@@ -686,59 +686,59 @@ describe('GreaterOrEqual', () => {
     setup(this, data);
   });
 
-  it('should be true for 5 >= 4', function () {
-    this.aGtB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 >= 4', async function () {
+    await this.aGtB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should be true for 5 >= 5', function () {
-    this.aEqB_Int.exec(this.ctx).should.be.true();
+  it('should be true for 5 >= 5', async function () {
+    await this.aEqB_Int.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 >= 6', function () {
-    this.aLtB_Int.exec(this.ctx).should.be.false();
+  it('should be false for 5 >= 6', async function () {
+    await this.aLtB_Int.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 m >= 4 m', function () {
-    this.aGtB_Quantity.exec(this.ctx).should.be.true();
+  it('should be true for 5 m >= 4 m', async function () {
+    await this.aGtB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m  >= 5 m', function () {
-    this.aEqB_Quantity.exec(this.ctx).should.be.true();
+  it('should be false for 5 m  >= 5 m', async function () {
+    await this.aEqB_Quantity.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m >= 6 m', function () {
-    this.aLtB_Quantity.exec(this.ctx).should.be.false();
+  it('should be false for 5 m >= 6 m', async function () {
+    await this.aLtB_Quantity.exec(this.ctx).should.be.false();
   });
 
-  it('should be true for 5 m >= 5 cm', function () {
-    this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be true for 5 m >= 5 cm', async function () {
+    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m  >= 50 cm ', function () {
-    this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
+  it('should be false for 5 m  >= 50 cm ', async function () {
+    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
   });
 
-  it('should be false for 5 m  >=5 km', function () {
-    this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
+  it('should be false for 5 m  >=5 km', async function () {
+    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
   });
 
-  it('should be null for 5 Cel >= 4 m', function () {
-    should(this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel >= 4 m', async function () {
+    should(await this.aGtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel >= 5 m', function () {
-    should(this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel >= 5 m', async function () {
+    should(await this.aEqB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 5 Cel >= 40 m', function () {
-    should(this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 5 Cel >= 40 m', async function () {
+    should(await this.aLtB_Quantity_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be null for 100 [nmi_i] / 2 h > 49 mg/[lb_av]', function () {
-    should(this.divideUcum_incompatible.exec(this.ctx)).be.null();
+  it('should be null for 100 [nmi_i] / 2 h > 49 mg/[lb_av]', async function () {
+    should(await this.divideUcum_incompatible.exec(this.ctx)).be.null();
   });
 
-  it('should be true for 100 mg / 2 [lb_av]  > 49 mg/[lb_av]', function () {
-    this.divideUcum.exec(this.ctx).should.be.true();
+  it('should be true for 100 mg / 2 [lb_av]  > 49 mg/[lb_av]', async function () {
+    await this.divideUcum.exec(this.ctx).should.be.true();
   });
 });

--- a/test/elm/comparison/comparison-test.ts
+++ b/test/elm/comparison/comparison-test.ts
@@ -10,20 +10,20 @@ describe('Equal', () => {
   });
 
   it('should be false for 5 = 4', async function () {
-    await this.aGtB_Int.exec(this.ctx).should.be.false();
+    (await this.aGtB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 = 5', async function () {
-    await this.aEqB_Int.exec(this.ctx).should.be.true();
+    (await this.aEqB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 = 6', async function () {
-    await this.aLtB_Int.exec(this.ctx).should.be.false();
+    (await this.aLtB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should identify equal/unequal tuples', async function () {
-    await this.eqTuples.exec(this.ctx).should.be.true();
-    await this.uneqTuples.exec(this.ctx).should.be.false();
+    (await this.eqTuples.exec(this.ctx)).should.be.true();
+    (await this.uneqTuples.exec(this.ctx)).should.be.false();
   });
 
   it('should identify equal tuples with same fields null', async function () {
@@ -39,18 +39,18 @@ describe('Equal', () => {
   });
 
   it('should identify equal/unequal DateTimes in same timezone', async function () {
-    await this.eqDateTimes.exec(this.ctx).should.be.true();
-    await this.uneqDateTimes.exec(this.ctx).should.be.false();
+    (await this.eqDateTimes.exec(this.ctx)).should.be.true();
+    (await this.uneqDateTimes.exec(this.ctx)).should.be.false();
   });
 
   it('should identify equal/unequal DateTimes in different timezones', async function () {
-    await this.eqDateTimesTZ.exec(this.ctx).should.be.true();
-    await this.uneqDateTimesTZ.exec(this.ctx).should.be.false();
+    (await this.eqDateTimesTZ.exec(this.ctx)).should.be.true();
+    (await this.uneqDateTimesTZ.exec(this.ctx)).should.be.false();
   });
 
   it('should identify equal/unequal DateTimes with null milliseconds', async function () {
-    await this.eqDateTimesNullMs.exec(this.ctx).should.be.true();
-    await this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.true();
+    (await this.eqDateTimesNullMs.exec(this.ctx)).should.be.true();
+    (await this.eqDateTimesNullOtherMs.exec(this.ctx)).should.be.true();
   });
 
   it('should identify equal/unequal date times specified to only date level', async function () {
@@ -68,7 +68,7 @@ describe('Equal', () => {
 
   it('should identify uncertain/unequal DateTimes when there is imprecision', async function () {
     should(await this.possiblyEqualDateTimes.exec(this.ctx)).be.null();
-    await this.impossiblyEqualDateTimes.exec(this.ctx).should.be.false();
+    (await this.impossiblyEqualDateTimes.exec(this.ctx)).should.be.false();
   });
 
   it('should be null for Date and DateTime equality with same year, month, hour', async function () {
@@ -76,7 +76,7 @@ describe('Equal', () => {
   });
 
   it('should be false for Date and DateTime equality with same year, month, hour and additional fields', async function () {
-    await this.dateAndDateTimeUncertainFalse.exec(this.ctx).should.be.false();
+    (await this.dateAndDateTimeUncertainFalse.exec(this.ctx)).should.be.false();
   });
 
   it('should be null for DateTime and Date equality with same year, month, hour', async function () {
@@ -84,39 +84,39 @@ describe('Equal', () => {
   });
 
   it('should be null for DateTime and Date equality with same year, month, hour and additional fields', async function () {
-    await this.dateTimeAndDateUncertainFalse.exec(this.ctx).should.be.false();
+    (await this.dateTimeAndDateUncertainFalse.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for Date and DateTime equality with different hour', async function () {
-    await this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.false();
+    (await this.dateAndDateTimeNotEqual.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for DateTime and Date equality with different hour', async function () {
-    await this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.false();
+    (await this.dateTimeAndDateNotEqual.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m = 4 m', async function () {
-    await this.aGtB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aGtB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 m = 5 m', async function () {
-    await this.aEqB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aEqB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m = 6 m', async function () {
-    await this.aLtB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aLtB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m = 5 cm', async function () {
-    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aGtB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 m = 500 cm', async function () {
-    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aEqB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m = 5 km', async function () {
-    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aLtB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be null for 5 Cel = 4 m', async function () {
@@ -132,11 +132,11 @@ describe('Equal', () => {
   });
 
   it('should be true for 10mg:2dL = 15mg:3dL', async function () {
-    await this.eqRatios.exec(this.ctx).should.be.true();
+    (await this.eqRatios.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 10mg:2dL = 15mg:4dL', async function () {
-    await this.uneqRatios.exec(this.ctx).should.be.false();
+    (await this.uneqRatios.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -146,20 +146,20 @@ describe('NotEqual', () => {
   });
 
   it('should be true for 5 <> 4', async function () {
-    await this.aGtB_Int.exec(this.ctx).should.be.true();
+    (await this.aGtB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 <> 5', async function () {
-    await this.aEqB_Int.exec(this.ctx).should.be.false();
+    (await this.aEqB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 <> 6', async function () {
-    await this.aLtB_Int.exec(this.ctx).should.be.true();
+    (await this.aLtB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should identify equal/unequal tuples', async function () {
-    await this.eqTuples.exec(this.ctx).should.be.false();
-    await this.uneqTuples.exec(this.ctx).should.be.true();
+    (await this.eqTuples.exec(this.ctx)).should.be.false();
+    (await this.uneqTuples.exec(this.ctx)).should.be.true();
   });
 
   it('should identify equal tuples with same fields null', async function () {
@@ -175,18 +175,18 @@ describe('NotEqual', () => {
   });
 
   it('should identify equal/unequal DateTimes in same timezone', async function () {
-    await this.eqDateTimes.exec(this.ctx).should.be.false();
-    await this.uneqDateTimes.exec(this.ctx).should.be.true();
+    (await this.eqDateTimes.exec(this.ctx)).should.be.false();
+    (await this.uneqDateTimes.exec(this.ctx)).should.be.true();
   });
 
   it('should identify equal/unequal DateTimes in different timezones', async function () {
-    await this.eqDateTimesTZ.exec(this.ctx).should.be.false();
-    await this.uneqDateTimesTZ.exec(this.ctx).should.be.true();
+    (await this.eqDateTimesTZ.exec(this.ctx)).should.be.false();
+    (await this.uneqDateTimesTZ.exec(this.ctx)).should.be.true();
   });
 
   it('should identify equal/unequal DateTimes with null milliseconds', async function () {
-    await this.eqDateTimesNullMs.exec(this.ctx).should.be.false();
-    await this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.false();
+    (await this.eqDateTimesNullMs.exec(this.ctx)).should.be.false();
+    (await this.eqDateTimesNullOtherMs.exec(this.ctx)).should.be.false();
   });
 
   it('should identify equal/unequal date times specified to only date level', async function () {
@@ -204,7 +204,7 @@ describe('NotEqual', () => {
 
   it('should identify uncertain/unequal DateTimes when there is imprecision', async function () {
     should(await this.possiblyEqualDateTimes.exec(this.ctx)).be.null();
-    await this.impossiblyEqualDateTimes.exec(this.ctx).should.be.true();
+    (await this.impossiblyEqualDateTimes.exec(this.ctx)).should.be.true();
   });
 
   it('should be null for Date and DateTime equality with same year, month, hour', async function () {
@@ -212,11 +212,11 @@ describe('NotEqual', () => {
   });
 
   it('should be true for date and DateTime with additional fields', async function () {
-    await this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.true();
+    (await this.dateAndDateTimeNotEqual.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for DateTime and Date equality with same year, month, hour', async function () {
-    await this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.true();
+    (await this.dateTimeAndDateNotEqual.exec(this.ctx)).should.be.true();
   });
 
   it('should be null for all DateTime and Date equality with same year, month, hour', async function () {
@@ -224,31 +224,31 @@ describe('NotEqual', () => {
   });
 
   it('should be true for DateTime and Date equality with same year, month, hour and additional fields', async function () {
-    await this.dateTimeAndDateUncertainTrue.exec(this.ctx).should.be.true();
+    (await this.dateTimeAndDateUncertainTrue.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for 5 m != 4 m', async function () {
-    await this.aGtB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aGtB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m != 5 m', async function () {
-    await this.aEqB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aEqB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 m != 6 m', async function () {
-    await this.aLtB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aLtB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for 5 m != 5 cm', async function () {
-    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aGtB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m != 500 cm ', async function () {
-    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aEqB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 m != 5 km', async function () {
-    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aLtB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be null for 5 Cel != 4 m', async function () {
@@ -270,71 +270,71 @@ describe('Equivalent', () => {
   });
 
   it('should be false for null ~ 4', async function () {
-    await this.aNull_BDefined.exec(this.ctx).should.be.false();
+    (await this.aNull_BDefined.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for ratio compared to date', async function () {
-    await this.uneqRatioTypes.exec(this.ctx).should.be.false();
+    (await this.uneqRatioTypes.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 ~ null', async function () {
-    await this.aDefined_BNull.exec(this.ctx).should.be.false();
+    (await this.aDefined_BNull.exec(this.ctx)).should.be.false();
   });
 
   it.skip('should be true for null ~ null', async function () {
     // Skipping because of cql-to-elm issue that will be fixed in 1.4
-    await this.aNull_BNull.exec(this.ctx).should.be.true();
+    (await this.aNull_BNull.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for 3 ~ 3', async function () {
-    await this.aDefined_BDefined.exec(this.ctx).should.be.true();
+    (await this.aDefined_BDefined.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for FOO ~ foo', async function () {
-    await this.caseInsensitiveStrings.exec(this.ctx).should.be.true();
+    (await this.caseInsensitiveStrings.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for foo bar ~ foo\tbar', async function () {
-    await this.whiteSpaceTabTrue.exec(this.ctx).should.be.true();
+    (await this.whiteSpaceTabTrue.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for foo\tbar ~ foo\nbar', async function () {
-    await this.whiteSpaceTabReturnTrue.exec(this.ctx).should.be.true();
+    (await this.whiteSpaceTabReturnTrue.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for foo bar ~ foo\t\tbar', async function () {
-    await this.whiteSpaceIncorrectSpaceFalse.exec(this.ctx).should.be.false();
+    (await this.whiteSpaceIncorrectSpaceFalse.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for foo\t\tbar ~ foo\tbar', async function () {
-    await this.whiteSpaceIncorrectNumberTabsFalse.exec(this.ctx).should.be.false();
+    (await this.whiteSpaceIncorrectNumberTabsFalse.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for foo bar ~ foobar', async function () {
-    await this.whiteSpaceNoSpaceFalse.exec(this.ctx).should.be.false();
+    (await this.whiteSpaceNoSpaceFalse.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 10mg:2dL ~ 15mg:3dL', async function () {
-    await this.eqRatios.exec(this.ctx).should.be.true();
+    (await this.eqRatios.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 10mg:2dL ~ 15mg:4dL', async function () {
-    await this.uneqRatios.exec(this.ctx).should.be.false();
+    (await this.uneqRatios.exec(this.ctx)).should.be.false();
   });
 
   it('should identify equal/unequal DateTimes in same timezone', async function () {
-    await this.eqDateTimes.exec(this.ctx).should.be.true();
-    await this.uneqDateTimes.exec(this.ctx).should.be.false();
+    (await this.eqDateTimes.exec(this.ctx)).should.be.true();
+    (await this.uneqDateTimes.exec(this.ctx)).should.be.false();
   });
 
   it('should identify equal/unequal DateTimes in different timezones', async function () {
-    await this.eqDateTimesTZ.exec(this.ctx).should.be.true();
-    await this.uneqDateTimesTZ.exec(this.ctx).should.be.false();
+    (await this.eqDateTimesTZ.exec(this.ctx)).should.be.true();
+    (await this.uneqDateTimesTZ.exec(this.ctx)).should.be.false();
   });
 
   it('should identify equal/unequal DateTimes with null milliseconds', async function () {
-    await this.eqDateTimesNullMs.exec(this.ctx).should.be.true();
-    await this.eqDateTimesNullOtherMs.exec(this.ctx).should.be.true();
+    (await this.eqDateTimesNullMs.exec(this.ctx)).should.be.true();
+    (await this.eqDateTimesNullOtherMs.exec(this.ctx)).should.be.true();
   });
 
   it('should identify equal/unequal date times specified to only date level', async function () {
@@ -343,7 +343,7 @@ describe('Equivalent', () => {
   });
 
   it('should identify case of a possibly equal date times with differing precisions', async function () {
-    await this.possiblyEqDateTimesOnlyDateOnOne.exec(this.ctx).should.be.false();
+    (await this.possiblyEqDateTimesOnlyDateOnOne.exec(this.ctx)).should.be.false();
   });
 
   it('should identify unequal date times with differing precisions', async function () {
@@ -351,38 +351,38 @@ describe('Equivalent', () => {
   });
 
   it('should identify uncertain/unequal DateTimes when there is imprecision', async function () {
-    await this.possiblyEqualDateTimes.exec(this.ctx).should.be.false();
-    await this.impossiblyEqualDateTimes.exec(this.ctx).should.be.false();
+    (await this.possiblyEqualDateTimes.exec(this.ctx)).should.be.false();
+    (await this.impossiblyEqualDateTimes.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for Date and DateTime equality with same year, month, hour', async function () {
-    await this.dateAndDateTimeNull.exec(this.ctx).should.be.false();
+    (await this.dateAndDateTimeNull.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for Date and DateTime equality with same year, month, hour and additional fields', async function () {
-    await this.dateAndDateTimeUncertainFalse.exec(this.ctx).should.be.false();
+    (await this.dateAndDateTimeUncertainFalse.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for DateTime and Date equality with same year, month, hour', async function () {
-    await this.dateTimeAndDateNull.exec(this.ctx).should.be.false();
+    (await this.dateTimeAndDateNull.exec(this.ctx)).should.be.false();
   });
 
   it('should be null for DateTime and Date equality with same year, month, hour and additional fields', async function () {
-    await this.dateTimeAndDateUncertainFalse.exec(this.ctx).should.be.false();
+    (await this.dateTimeAndDateUncertainFalse.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for Date and DateTime equality with different hour', async function () {
-    await this.dateAndDateTimeNotEqual.exec(this.ctx).should.be.false();
+    (await this.dateAndDateTimeNotEqual.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for DateTime and Date equality with different hour', async function () {
-    await this.dateTimeAndDateNotEqual.exec(this.ctx).should.be.false();
+    (await this.dateTimeAndDateNotEqual.exec(this.ctx)).should.be.false();
   });
 
   describe('Tuples', () => {
     it.skip('should return true for empty tuples', async function () {
       // Note: the spec doesn't explicitly define this, expecting behavior to match null ~ null
-      await this.emptyTuples.exec(this.ctx).should.be.true();
+      (await this.emptyTuples.exec(this.ctx)).should.be.true();
     });
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -390,131 +390,131 @@ describe('Equivalent', () => {
     // Note: There is currently no way to tell the type of Tuples as they are all treated as Objects
 
     it('should return true if Tuples are elementwise identical', async function () {
-      await this.sameTuples.exec(this.ctx).should.be.true();
+      (await this.sameTuples.exec(this.ctx)).should.be.true();
     });
 
     it('should return true if Tuples are elementwise identical and null', async function () {
-      await this.sameTuplesNull.exec(this.ctx).should.be.true();
+      (await this.sameTuplesNull.exec(this.ctx)).should.be.true();
     });
 
     it('should return false if Tuples are not elementwise identical', async function () {
-      await this.differentTuples.exec(this.ctx).should.be.false();
+      (await this.differentTuples.exec(this.ctx)).should.be.false();
     });
 
     it('should return true for nested tuples', async function () {
-      await this.sameNestedTuples.exec(this.ctx).should.be.true();
+      (await this.sameNestedTuples.exec(this.ctx)).should.be.true();
     });
 
     it('should return true for nested tuples', async function () {
-      await this.sameNestedTuplesNull.exec(this.ctx).should.be.true();
+      (await this.sameNestedTuplesNull.exec(this.ctx)).should.be.true();
     });
   });
 
   describe('Lists', () => {
     it('should return true for empty lists', async function () {
-      await this.emptyLists.exec(this.ctx).should.be.true();
+      (await this.emptyLists.exec(this.ctx)).should.be.true();
     });
 
     it('should return false for lists with different types', async function () {
-      await this.differentTypesLists.exec(this.ctx).should.be.false();
+      (await this.differentTypesLists.exec(this.ctx)).should.be.false();
     });
 
     it('should return false for lists with different number of elements', async function () {
-      await this.differentLengthLists.exec(this.ctx).should.be.false();
+      (await this.differentLengthLists.exec(this.ctx)).should.be.false();
     });
 
     it('should return false for lists with same elements in different order', async function () {
-      await this.differentOrderLists.exec(this.ctx).should.be.false();
+      (await this.differentOrderLists.exec(this.ctx)).should.be.false();
     });
 
     it('should return true for lists with same elements in same order', async function () {
-      await this.sameLists.exec(this.ctx).should.be.true();
+      (await this.sameLists.exec(this.ctx)).should.be.true();
     });
 
     it('should return true for lists with same elements in same order including nulls', async function () {
-      await this.sameListsNull.exec(this.ctx).should.be.true();
+      (await this.sameListsNull.exec(this.ctx)).should.be.true();
     });
 
     it('should return true for nested lists with same elements in same order', async function () {
-      await this.sameNestedLists.exec(this.ctx).should.be.true();
+      (await this.sameNestedLists.exec(this.ctx)).should.be.true();
     });
 
     it('should return true for nested lists with same elements in same order including nulls', async function () {
-      await this.sameNestedListsNull.exec(this.ctx).should.be.true();
+      (await this.sameNestedListsNull.exec(this.ctx)).should.be.true();
     });
   });
 
   describe('Intervals', () => {
     it('should return true for null low/high', async function () {
-      await this.emptyInterval.exec(this.ctx).should.be.true();
+      (await this.emptyInterval.exec(this.ctx)).should.be.true();
     });
 
     it('should return false for different Interval point types', async function () {
-      await this.intervalDifferentPointTypes.exec(this.ctx).should.be.false();
+      (await this.intervalDifferentPointTypes.exec(this.ctx)).should.be.false();
     });
 
     it('should return false if different starting points', async function () {
-      await this.intervalDifferentStarts.exec(this.ctx).should.be.false();
+      (await this.intervalDifferentStarts.exec(this.ctx)).should.be.false();
     });
 
     it('should return false if different ending points', async function () {
-      await this.intervalDifferentEndings.exec(this.ctx).should.be.false();
+      (await this.intervalDifferentEndings.exec(this.ctx)).should.be.false();
     });
 
     it('should return true for identical Intervals', async function () {
-      await this.sameIntervals.exec(this.ctx).should.be.true();
+      (await this.sameIntervals.exec(this.ctx)).should.be.true();
     });
   });
 
   describe('Lists and Tuples', () => {
     it('should return false for List ~ Tuple', async function () {
-      await this.listAndTuple.exec(this.ctx).should.be.false();
+      (await this.listAndTuple.exec(this.ctx)).should.be.false();
     });
 
     it('should return false for Tuple ~ List', async function () {
-      await this.tupleAndList.exec(this.ctx).should.be.false();
+      (await this.tupleAndList.exec(this.ctx)).should.be.false();
     });
 
     it('should return false for List ~ Tuple with null', async function () {
-      await this.nullListAndTuple.exec(this.ctx).should.be.false();
+      (await this.nullListAndTuple.exec(this.ctx)).should.be.false();
     });
 
     it('should return false for Tuple with null ~ List', async function () {
-      await this.tupleAndNullList.exec(this.ctx).should.be.false();
+      (await this.tupleAndNullList.exec(this.ctx)).should.be.false();
     });
   });
 
   describe('Codes and Concepts', () => {
     it('should return true for same Codes', async function () {
-      await this.sameCodeAndCode.exec(this.ctx).should.be.true();
+      (await this.sameCodeAndCode.exec(this.ctx)).should.be.true();
     });
 
     it('should return true for same Code and Concept', async function () {
-      await this.sameCodeAndConcept.exec(this.ctx).should.be.true();
+      (await this.sameCodeAndConcept.exec(this.ctx)).should.be.true();
     });
 
     it('should return true for same Concept and Code', async function () {
-      await this.sameConceptAndCode.exec(this.ctx).should.be.true();
+      (await this.sameConceptAndCode.exec(this.ctx)).should.be.true();
     });
 
     it('should return true for same Concept and Concept', async function () {
-      await this.sameConceptAndConcept.exec(this.ctx).should.be.true();
+      (await this.sameConceptAndConcept.exec(this.ctx)).should.be.true();
     });
 
     it('should return false for same Codes', async function () {
-      await this.diffCodeAndCode.exec(this.ctx).should.be.false();
+      (await this.diffCodeAndCode.exec(this.ctx)).should.be.false();
     });
 
     it('should return false for same Code and Concept', async function () {
-      await this.diffCodeAndConcept.exec(this.ctx).should.be.false();
+      (await this.diffCodeAndConcept.exec(this.ctx)).should.be.false();
     });
 
     it('should return false for same Concept and Code', async function () {
-      await this.diffConceptAndCode.exec(this.ctx).should.be.false();
+      (await this.diffConceptAndCode.exec(this.ctx)).should.be.false();
     });
 
     it('should return false for same Concept and Concept', async function () {
-      await this.diffConceptAndConcept.exec(this.ctx).should.be.false();
+      (await this.diffConceptAndConcept.exec(this.ctx)).should.be.false();
     });
   });
 });
@@ -525,39 +525,39 @@ describe('Less', () => {
   });
 
   it('should be false for 5 < 4', async function () {
-    await this.aGtB_Int.exec(this.ctx).should.be.false();
+    (await this.aGtB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 < 5', async function () {
-    await this.aEqB_Int.exec(this.ctx).should.be.false();
+    (await this.aEqB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 < 6', async function () {
-    await this.aLtB_Int.exec(this.ctx).should.be.true();
+    (await this.aLtB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m < 4 m', async function () {
-    await this.aGtB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aGtB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m < 5 m', async function () {
-    await this.aEqB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aEqB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m < 6 m', async function () {
-    await this.aLtB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aLtB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for 5 m < 5 cm', async function () {
-    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aGtB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m < 50 cm ', async function () {
-    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aEqB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m < 5 km', async function () {
-    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aLtB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be null for 5 Cel < 4 m', async function () {
@@ -579,39 +579,39 @@ describe('LessOrEqual', () => {
   });
 
   it('should be false for 5 <= 4', async function () {
-    await this.aGtB_Int.exec(this.ctx).should.be.false();
+    (await this.aGtB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 <= 5', async function () {
-    await this.aEqB_Int.exec(this.ctx).should.be.true();
+    (await this.aEqB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for 5 <= 6', async function () {
-    await this.aLtB_Int.exec(this.ctx).should.be.true();
+    (await this.aLtB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for 5 m <= 4 m', async function () {
-    await this.aGtB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aGtB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m <= 5 m', async function () {
-    await this.aEqB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aEqB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m <= 6 m', async function () {
-    await this.aLtB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aLtB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for 5 m <= 5 cm', async function () {
-    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aGtB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m <= 500 cm ', async function () {
-    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aEqB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m <= 5 km', async function () {
-    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aLtB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be null for 5 Cel <= 4 m', async function () {
@@ -633,39 +633,39 @@ describe('Greater', () => {
   });
 
   it('should be true for 5 > 4', async function () {
-    await this.aGtB_Int.exec(this.ctx).should.be.true();
+    (await this.aGtB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 > 5', async function () {
-    await this.aEqB_Int.exec(this.ctx).should.be.false();
+    (await this.aEqB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 > 6', async function () {
-    await this.aLtB_Int.exec(this.ctx).should.be.false();
+    (await this.aLtB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 m > 4 m', async function () {
-    await this.aGtB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aGtB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m > 5 m', async function () {
-    await this.aEqB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aEqB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m > 6 m', async function () {
-    await this.aLtB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aLtB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 m > 5 cm', async function () {
-    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aGtB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m > 50 cm ', async function () {
-    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aEqB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be false for 5 m > 5 km', async function () {
-    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aLtB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be null for 5 Cel > 4 m', async function () {
@@ -687,39 +687,39 @@ describe('GreaterOrEqual', () => {
   });
 
   it('should be true for 5 >= 4', async function () {
-    await this.aGtB_Int.exec(this.ctx).should.be.true();
+    (await this.aGtB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should be true for 5 >= 5', async function () {
-    await this.aEqB_Int.exec(this.ctx).should.be.true();
+    (await this.aEqB_Int.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 >= 6', async function () {
-    await this.aLtB_Int.exec(this.ctx).should.be.false();
+    (await this.aLtB_Int.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 m >= 4 m', async function () {
-    await this.aGtB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aGtB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m  >= 5 m', async function () {
-    await this.aEqB_Quantity.exec(this.ctx).should.be.true();
+    (await this.aEqB_Quantity.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m >= 6 m', async function () {
-    await this.aLtB_Quantity.exec(this.ctx).should.be.false();
+    (await this.aLtB_Quantity.exec(this.ctx)).should.be.false();
   });
 
   it('should be true for 5 m >= 5 cm', async function () {
-    await this.aGtB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aGtB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m  >= 50 cm ', async function () {
-    await this.aEqB_Quantity_diff.exec(this.ctx).should.be.true();
+    (await this.aEqB_Quantity_diff.exec(this.ctx)).should.be.true();
   });
 
   it('should be false for 5 m  >=5 km', async function () {
-    await this.aLtB_Quantity_diff.exec(this.ctx).should.be.false();
+    (await this.aLtB_Quantity_diff.exec(this.ctx)).should.be.false();
   });
 
   it('should be null for 5 Cel >= 4 m', async function () {
@@ -739,6 +739,6 @@ describe('GreaterOrEqual', () => {
   });
 
   it('should be true for 100 mg / 2 [lb_av]  > 49 mg/[lb_av]', async function () {
-    await this.divideUcum.exec(this.ctx).should.be.true();
+    (await this.divideUcum.exec(this.ctx)).should.be.true();
   });
 });

--- a/test/elm/conditional/conditional-test.ts
+++ b/test/elm/conditional/conditional-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 
@@ -6,12 +7,12 @@ describe('If', () => {
     setup(this, data);
   });
 
-  it('should return the correct value when the expression is true', function () {
-    this.exp.exec(this.ctx.withParameters({ var: true })).should.equal('true return');
+  it('should return the correct value when the expression is true', async function () {
+    should(await this.exp.exec(this.ctx.withParameters({ var: true }))).equal('true return');
   });
 
-  it('should return the correct value when the expression is false', function () {
-    this.exp.exec(this.ctx.withParameters({ var: false })).should.equal('false return');
+  it('should return the correct value when the expression is false', async function () {
+    should(await this.exp.exec(this.ctx.withParameters({ var: false }))).equal('false return');
   });
 });
 
@@ -20,7 +21,7 @@ describe('Case', () => {
     setup(this, data);
   });
 
-  it('should be able to execute a standard case statement', function () {
+  it('should be able to execute a standard case statement', async function () {
     const vals = [
       { x: 1, y: 2, message: 'X < Y' },
       { x: 2, y: 1, message: 'X > Y' },
@@ -28,11 +29,11 @@ describe('Case', () => {
     ];
     for (const item of vals) {
       this.ctx.withParameters({ X: item.x, Y: item.y });
-      this.standard.exec(this.ctx).should.equal(item.message);
+      should(await this.standard.exec(this.ctx)).equal(item.message);
     }
   });
 
-  it('should be able to execute a selected case statement', function () {
+  it('should be able to execute a selected case statement', async function () {
     const vals = [
       { var: 1, message: 'one' },
       { var: 2, message: 'two' },
@@ -40,7 +41,7 @@ describe('Case', () => {
     ];
     for (const item of vals) {
       this.ctx.withParameters({ var: item.var });
-      this.selected.exec(this.ctx).should.equal(item.message);
+      should(await this.selected.exec(this.ctx)).equal(item.message);
     }
   });
 });

--- a/test/elm/convert/convert-test.ts
+++ b/test/elm/convert/convert-test.ts
@@ -11,94 +11,94 @@ describe('FromString', () => {
     setup(this, data);
   });
 
-  it("should convert 'str' to 'str'", function () {
-    this.stringStr.exec(this.ctx).should.equal('str');
+  it("should convert 'str' to 'str'", async function () {
+    (await this.stringStr.exec(this.ctx)).should.equal('str');
   });
 
-  it('should convert null to null', function () {
-    isNull(this.stringNull.exec(this.ctx)).should.equal(true);
+  it('should convert null to null', async function () {
+    isNull(await this.stringNull.exec(this.ctx)).should.equal(true);
   });
 
-  it("should convert 'true' to true", function () {
-    this.boolTrue.exec(this.ctx).should.equal(true);
+  it("should convert 'true' to true", async function () {
+    (await this.boolTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it("should convert 'false' to false", function () {
-    this.boolFalse.exec(this.ctx).should.equal(false);
+  it("should convert 'false' to false", async function () {
+    (await this.boolFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it("should convert '10.2' to Decimal", function () {
-    this.decimalValid.exec(this.ctx).should.equal(10.2);
+  it("should convert '10.2' to Decimal", async function () {
+    (await this.decimalValid.exec(this.ctx)).should.equal(10.2);
   });
 
-  it("should be null trying to convert 'abc' to Decimal", function () {
-    should(this.decimalInvalid.exec(this.ctx)).be.null();
+  it("should be null trying to convert 'abc' to Decimal", async function () {
+    should(await this.decimalInvalid.exec(this.ctx)).be.null();
   });
 
-  it("should convert '10' to Integer", function () {
-    this.integerValid.exec(this.ctx).should.equal(10);
+  it("should convert '10' to Integer", async function () {
+    (await this.integerValid.exec(this.ctx)).should.equal(10);
   });
 
-  it("should convert '10.2' to Integer 10", function () {
-    this.integerDropDecimal.exec(this.ctx).should.equal(10);
+  it("should convert '10.2' to Integer 10", async function () {
+    (await this.integerDropDecimal.exec(this.ctx)).should.equal(10);
   });
 
-  it("should be null trying to convert 'abc' to Integer", function () {
-    should(this.integerInvalid.exec(this.ctx)).be.null();
+  it("should be null trying to convert 'abc' to Integer", async function () {
+    should(await this.integerInvalid.exec(this.ctx)).be.null();
   });
 
-  it('should convert "10 \'A\'" to Quantity', function () {
-    const quantity = this.quantityStr.exec(this.ctx);
+  it('should convert "10 \'A\'" to Quantity', async function () {
+    const quantity = await this.quantityStr.exec(this.ctx);
     quantity.value.should.equal(10);
     quantity.unit.should.equal('A');
   });
 
-  it('should convert "+10 \'A\'" to Quantity', function () {
-    const quantity = this.posQuantityStr.exec(this.ctx);
+  it('should convert "+10 \'A\'" to Quantity', async function () {
+    const quantity = await this.posQuantityStr.exec(this.ctx);
     quantity.value.should.equal(10);
     quantity.unit.should.equal('A');
   });
 
-  it('should convert "-10 \'A\'" to Quantity', function () {
-    const quantity = this.negQuantityStr.exec(this.ctx);
+  it('should convert "-10 \'A\'" to Quantity', async function () {
+    const quantity = await this.negQuantityStr.exec(this.ctx);
     quantity.value.should.equal(-10);
     quantity.unit.should.equal('A');
   });
 
-  it('should convert "10.0\'mA\'" to Quantity', function () {
-    const quantity = this.quantityStrDecimal.exec(this.ctx);
+  it('should convert "10.0\'mA\'" to Quantity', async function () {
+    const quantity = await this.quantityStrDecimal.exec(this.ctx);
     quantity.value.should.equal(10.0);
     quantity.unit.should.equal('mA');
   });
 
-  it("should convert '2015-01-02' to DateTime", function () {
-    const date = this.dateTimeStr.exec(this.ctx);
+  it("should convert '2015-01-02' to DateTime", async function () {
+    const date = await this.dateTimeStr.exec(this.ctx);
     date.year.should.equal(2015);
     date.month.should.equal(1);
     date.day.should.equal(2);
     date.isDateTime.should.equal.true;
   });
 
-  it("should convert '2015-01-02' to Date", function () {
-    const date = this.dateStr.exec(this.ctx);
+  it("should convert '2015-01-02' to Date", async function () {
+    const date = await this.dateStr.exec(this.ctx);
     date.year.should.equal(2015);
     date.month.should.equal(1);
     date.day.should.equal(2);
     date.isDate.should.equal.true;
   });
 
-  it('should be null if cannot convert', function () {
-    should(this.nullConvert.exec(this.ctx)).be.null();
+  it('should be null if cannot convert', async function () {
+    should(await this.nullConvert.exec(this.ctx)).be.null();
   });
 
-  it('should convert DateTime string with Z', function () {
+  it('should convert DateTime string with Z', async function () {
     const expectedDateTime = new DateTime(2014, 1, 1, 14, 30, 0, 0, 0);
-    this.zDateTime.exec(this.ctx).equals(expectedDateTime).should.be.true();
+    (await this.zDateTime.exec(this.ctx)).equals(expectedDateTime).should.be.true();
   });
 
-  it('should convert DateTime string with timezone offset', function () {
+  it('should convert DateTime string with timezone offset', async function () {
     const expectedDateTime = new DateTime(2014, 1, 1, 14, 30, 0, 0, -7);
-    this.timezoneDateTime.exec(this.ctx).equals(expectedDateTime).should.be.true();
+    (await this.timezoneDateTime.exec(this.ctx)).equals(expectedDateTime).should.be.true();
   });
 });
 
@@ -107,20 +107,20 @@ describe('FromInteger', () => {
     setup(this, data);
   });
 
-  it("should convert 10 to '10'", function () {
-    this.string10.exec(this.ctx).should.equal('10');
+  it("should convert 10 to '10'", async function () {
+    (await this.string10.exec(this.ctx)).should.equal('10');
   });
 
-  it('should convert 10 to 10.0', function () {
-    this.decimal10.exec(this.ctx).should.equal(10.0);
+  it('should convert 10 to 10.0', async function () {
+    (await this.decimal10.exec(this.ctx)).should.equal(10.0);
   });
 
-  it('should convert null to null', function () {
-    isNull(this.intNull.exec(this.ctx)).should.equal(true);
+  it('should convert null to null', async function () {
+    isNull(await this.intNull.exec(this.ctx)).should.equal(true);
   });
 
-  it('should convert 10 to 10', function () {
-    this.intInt.exec(this.ctx).should.equal(10);
+  it('should convert 10 to 10', async function () {
+    (await this.intInt.exec(this.ctx)).should.equal(10);
   });
 });
 
@@ -129,20 +129,20 @@ describe('FromQuantity', () => {
     setup(this, data);
   });
 
-  it('should convert "10 \'A\'" to "10 \'A\'"', function () {
-    this.quantityStr.exec(this.ctx).should.equal("10 'A'");
+  it('should convert "10 \'A\'" to "10 \'A\'"', async function () {
+    (await this.quantityStr.exec(this.ctx)).should.equal("10 'A'");
   });
 
-  it('should convert "+10 \'A\'" to "10 \'A\'"', function () {
-    this.posQuantityStr.exec(this.ctx).should.equal("10 'A'");
+  it('should convert "+10 \'A\'" to "10 \'A\'"', async function () {
+    (await this.posQuantityStr.exec(this.ctx)).should.equal("10 'A'");
   });
 
-  it('should convert "-10 \'A\'" to "10 \'A\'"', function () {
-    this.negQuantityStr.exec(this.ctx).should.equal("-10 'A'");
+  it('should convert "-10 \'A\'" to "10 \'A\'"', async function () {
+    (await this.negQuantityStr.exec(this.ctx)).should.equal("-10 'A'");
   });
 
-  it('should convert "10 \'A\'" to "10 \'A\'"', function () {
-    const quantity = this.quantityQuantity.exec(this.ctx);
+  it('should convert "10 \'A\'" to "10 \'A\'"', async function () {
+    const quantity = await this.quantityQuantity.exec(this.ctx);
     quantity.value.should.equal(10);
     quantity.unit.should.equal('A');
   });
@@ -153,20 +153,20 @@ describe('FromBoolean', () => {
     setup(this, data);
   });
 
-  it("should convert true to 'true'", function () {
-    this.booleanTrueStr.exec(this.ctx).should.equal('true');
+  it("should convert true to 'true'", async function () {
+    (await this.booleanTrueStr.exec(this.ctx)).should.equal('true');
   });
 
-  it("should convert false to 'false'", function () {
-    this.booleanFalseStr.exec(this.ctx).should.equal('false');
+  it("should convert false to 'false'", async function () {
+    (await this.booleanFalseStr.exec(this.ctx)).should.equal('false');
   });
 
-  it('should convert true to true', function () {
-    this.booleanTrueBool.exec(this.ctx).should.equal(true);
+  it('should convert true to true', async function () {
+    (await this.booleanTrueBool.exec(this.ctx)).should.equal(true);
   });
 
-  it('should convert false to false', function () {
-    this.booleanFalseBool.exec(this.ctx).should.equal(false);
+  it('should convert false to false', async function () {
+    (await this.booleanFalseBool.exec(this.ctx)).should.equal(false);
   });
 });
 
@@ -175,12 +175,12 @@ describe('FromDateTime', () => {
     setup(this, data);
   });
 
-  it("should convert @2015-01-02T12:01:02.321-06:00 to '2015-01-02T12:01:02.321-06:00'", function () {
-    this.dateTimeToStr.exec(this.ctx).should.equal('2015-01-02T12:01:02.321-06:00');
+  it("should convert @2015-01-02T12:01:02.321-06:00 to '2015-01-02T12:01:02.321-06:00'", async function () {
+    (await this.dateTimeToStr.exec(this.ctx)).should.equal('2015-01-02T12:01:02.321-06:00');
   });
 
-  it('should convert @2015-01-02T12:01:02.321-06:00 to Date', function () {
-    const date = this.dateTimeToDate.exec(this.ctx);
+  it('should convert @2015-01-02T12:01:02.321-06:00 to Date', async function () {
+    const date = await this.dateTimeToDate.exec(this.ctx);
     date.isDate.should.be.true();
     date.year.should.equal(2015);
     date.month.should.equal(1);
@@ -190,8 +190,8 @@ describe('FromDateTime', () => {
     );
   });
 
-  it('should convert @2015-01-02T12:01:02.321-06:00 to DateTime', function () {
-    const dateTime = this.dateTimeToDateTime.exec(this.ctx);
+  it('should convert @2015-01-02T12:01:02.321-06:00 to DateTime', async function () {
+    const dateTime = await this.dateTimeToDateTime.exec(this.ctx);
     dateTime.isDateTime.should.be.true();
     dateTime.year.should.equal(2015);
     dateTime.month.should.equal(1);
@@ -209,8 +209,8 @@ describe('FromDate', () => {
     setup(this, data);
   });
 
-  it('should convert @2015-01-01 to DateTime with 0 for time components', function () {
-    const dateTime = this.dateYMDToDateTime.exec(this.ctx);
+  it('should convert @2015-01-01 to DateTime with 0 for time components', async function () {
+    const dateTime = await this.dateYMDToDateTime.exec(this.ctx);
     dateTime.year.should.equal(2015);
     dateTime.month.should.equal(1);
     dateTime.day.should.equal(1);
@@ -222,9 +222,9 @@ describe('FromDate', () => {
     dateTime.isDateTime.should.equal.true;
   });
 
-  it('should convert @2015-01 to DateTime with null for day and time components', function () {
+  it('should convert @2015-01 to DateTime with null for day and time components', async function () {
     let field: string;
-    const dateTime = this.dateYMToDateTime.exec(this.ctx);
+    const dateTime = await this.dateYMToDateTime.exec(this.ctx);
     dateTime.year.should.equal(2015);
     dateTime.month.should.equal(1);
     should.not.exist(dateTime.day);
@@ -235,9 +235,9 @@ describe('FromDate', () => {
     dateTime.isDateTime.should.equal.true;
   });
 
-  it('should convert @2015-01 to DateTime with null for day, month, and time components', function () {
+  it('should convert @2015-01 to DateTime with null for day, month, and time components', async function () {
     let field: string;
-    const dateTime = this.dateYToDateTime.exec(this.ctx);
+    const dateTime = await this.dateYToDateTime.exec(this.ctx);
     dateTime.year.should.equal(2015);
     should.not.exist(dateTime.month);
     should.not.exist(dateTime.day);
@@ -248,8 +248,8 @@ describe('FromDate', () => {
     dateTime.isDateTime.should.equal.true;
   });
 
-  it('should convert @2015-01-01 to Date', function () {
-    const date = this.dateToDate.exec(this.ctx);
+  it('should convert @2015-01-01 to Date', async function () {
+    const date = await this.dateToDate.exec(this.ctx);
     date.year.should.equal(2015);
     date.month.should.equal(1);
     date.day.should.equal(1);
@@ -259,8 +259,8 @@ describe('FromDate', () => {
     date.isDate.should.equal.true;
   });
 
-  it("should convert @2015-01-01 to '2015-01-01'", function () {
-    this.dateToStr.exec(this.ctx).should.equal('2015-01-01');
+  it("should convert @2015-01-01 to '2015-01-01'", async function () {
+    (await this.dateToStr.exec(this.ctx)).should.equal('2015-01-01');
   });
 });
 
@@ -269,12 +269,12 @@ describe('FromTime', () => {
     setup(this, data);
   });
 
-  it.skip("should convert @T11:57 to '11:57'", function () {
-    this.timeStr.exec(this.ctx).should.equal('11:57');
+  it.skip("should convert @T11:57 to '11:57'", async function () {
+    (await this.timeStr.exec(this.ctx)).should.equal('11:57');
   });
 
-  it.skip('should convert @T11:57 to @11:57', function () {
-    const time = this.timeTime.exec(this.ctx);
+  it.skip('should convert @T11:57 to @11:57', async function () {
+    const time = await this.timeTime.exec(this.ctx);
     time.hour.should.equal(11);
     time.minute.should.equal(57);
   });
@@ -285,13 +285,13 @@ describe('FromCode', () => {
     setup(this, data);
   });
 
-  it('should convert hepB to a concept', function () {
-    const concept = this.codeConcept.exec(this.ctx);
+  it('should convert hepB to a concept', async function () {
+    const concept = await this.codeConcept.exec(this.ctx);
     concept.isConcept.should.be.true();
   });
 
-  it('should convert hepB to a code', function () {
-    const code = this.codeCode.exec(this.ctx);
+  it('should convert hepB to a code', async function () {
+    const code = await this.codeCode.exec(this.ctx);
     code.isCode.should.be.true();
   });
 });
@@ -301,37 +301,37 @@ describe('ToDecimal', () => {
     setup(this, data);
   });
 
-  it("should convert '0.0' to 0.0", function () {
-    this.noSign.exec(this.ctx).should.equal(0.0);
+  it("should convert '0.0' to 0.0", async function () {
+    (await this.noSign.exec(this.ctx)).should.equal(0.0);
   });
 
-  it("should convert '+1.1' to 1.1", function () {
-    this.positiveSign.exec(this.ctx).should.equal(1.1);
+  it("should convert '+1.1' to 1.1", async function () {
+    (await this.positiveSign.exec(this.ctx)).should.equal(1.1);
   });
 
-  it("should convert '-1.1' to -1.1", function () {
-    this.negativeSign.exec(this.ctx).should.equal(-1.1);
+  it("should convert '-1.1' to -1.1", async function () {
+    (await this.negativeSign.exec(this.ctx)).should.equal(-1.1);
   });
 
-  it('should truncate decimal to 8 digits after decimal point', function () {
-    this.tooPrecise.exec(this.ctx).should.equal(0.44444444);
+  it('should truncate decimal to 8 digits after decimal point', async function () {
+    (await this.tooPrecise.exec(this.ctx)).should.equal(0.44444444);
   });
 
-  it('should be null for decimal that is above max decimal value', function () {
-    should(this.tooLargeDec.exec(this.ctx)).be.null();
+  it('should be null for decimal that is above max decimal value', async function () {
+    should(await this.tooLargeDec.exec(this.ctx)).be.null();
   });
 
-  it('should return null for decimal that is below min decimal value', function () {
-    should(this.tooSmallDec.exec(this.ctx)).be.null();
+  it('should return null for decimal that is below min decimal value', async function () {
+    should(await this.tooSmallDec.exec(this.ctx)).be.null();
   });
 
-  it('should convert null to null', function () {
-    should.not.exist(this.nullDecimal.exec(this.ctx));
+  it('should convert null to null', async function () {
+    should.not.exist(await this.nullDecimal.exec(this.ctx));
   });
 
-  it.skip('should be null if wrong format (+.1)', function () {
+  it.skip('should be null if wrong format (+.1)', async function () {
     // TODO: parseFloat is more forgiving than the CQL spec, so this does get converted
-    should(this.wrongFormat.exec(this.ctx)).be.null();
+    should(await this.wrongFormat.exec(this.ctx)).be.null();
   });
 });
 
@@ -340,32 +340,32 @@ describe('ToInteger', () => {
     setup(this, data);
   });
 
-  it('should return positive integer without polarity sign', function () {
-    this.noSign.exec(this.ctx).should.equal(12345);
+  it('should return positive integer without polarity sign', async function () {
+    (await this.noSign.exec(this.ctx)).should.equal(12345);
   });
 
-  it('should return positive integer with polarity sign', function () {
-    this.positiveSign.exec(this.ctx).should.equal(12345);
+  it('should return positive integer with polarity sign', async function () {
+    (await this.positiveSign.exec(this.ctx)).should.equal(12345);
   });
 
-  it('should return negative integer', function () {
-    this.negativeSign.exec(this.ctx).should.equal(-12345);
+  it('should return negative integer', async function () {
+    (await this.negativeSign.exec(this.ctx)).should.equal(-12345);
   });
 
-  it('should return null if integer larger than max', function () {
-    should(this.tooLargeInt.exec(this.ctx)).be.null();
+  it('should return null if integer larger than max', async function () {
+    should(await this.tooLargeInt.exec(this.ctx)).be.null();
   });
 
-  it('should return null if integer smaller than min', function () {
-    should(this.tooSmallInt.exec(this.ctx)).be.null();
+  it('should return null if integer smaller than min', async function () {
+    should(await this.tooSmallInt.exec(this.ctx)).be.null();
   });
 
-  it('should return 1 for boolean true', function () {
-    this.booleanTrue.exec(this.ctx).should.equal(1);
+  it('should return 1 for boolean true', async function () {
+    (await this.booleanTrue.exec(this.ctx)).should.equal(1);
   });
 
-  it('should return 0 for boolean false', function () {
-    this.booleanFalse.exec(this.ctx).should.equal(0);
+  it('should return 0 for boolean false', async function () {
+    (await this.booleanFalse.exec(this.ctx)).should.equal(0);
   });
 });
 
@@ -374,42 +374,42 @@ describe('ToQuantity', () => {
     setup(this, data);
   });
 
-  it('should convert a decimal to a quantity with unit 1', function () {
-    this.decimalOverload.exec(this.ctx).should.eql(new Quantity(0.1, '1'));
+  it('should convert a decimal to a quantity with unit 1', async function () {
+    (await this.decimalOverload.exec(this.ctx)).should.eql(new Quantity(0.1, '1'));
   });
 
-  it('should convert an integer to a quantity with unit 1', function () {
-    this.integerOverload.exec(this.ctx).should.eql(new Quantity(13, '1'));
+  it('should convert an integer to a quantity with unit 1', async function () {
+    (await this.integerOverload.exec(this.ctx)).should.eql(new Quantity(13, '1'));
   });
 
-  it('should convert an integer uncertainty to a quantity uncertainty', function () {
-    this.uncertaintyOverload
-      .exec(this.ctx)
-      .should.eql(new Uncertainty(new Quantity(6, '1'), new Quantity(18, '1')));
+  it('should convert an integer uncertainty to a quantity uncertainty', async function () {
+    (await this.uncertaintyOverload.exec(this.ctx)).should.eql(
+      new Uncertainty(new Quantity(6, '1'), new Quantity(18, '1'))
+    );
   });
 
-  it('should convert a string to a quantity with the specified unit', function () {
-    this.stringOverload.exec(this.ctx).should.eql(new Quantity(-0.1, 'mg'));
+  it('should convert a string to a quantity with the specified unit', async function () {
+    (await this.stringOverload.exec(this.ctx)).should.eql(new Quantity(-0.1, 'mg'));
   });
 
-  it('should convert a ratio to a quantity by dividing numerator by denominator', function () {
-    this.ratioOverload.exec(this.ctx).should.eql(new Quantity(0.5, 'mg/mL'));
+  it('should convert a ratio to a quantity by dividing numerator by denominator', async function () {
+    (await this.ratioOverload.exec(this.ctx)).should.eql(new Quantity(0.5, 'mg/mL'));
   });
 
-  it('should be null if string is not formatted properly', function () {
-    should(this.wrongFormatQuantity.exec(this.ctx)).be.null();
+  it('should be null if string is not formatted properly', async function () {
+    should(await this.wrongFormatQuantity.exec(this.ctx)).be.null();
   });
 
-  it('should be null if invalid positive Quantity', function () {
-    should(this.tooLargeQuantity.exec(this.ctx)).be.null();
+  it('should be null if invalid positive Quantity', async function () {
+    should(await this.tooLargeQuantity.exec(this.ctx)).be.null();
   });
 
-  it('should be null if invalid negative Quantity', function () {
-    should(this.tooSmallQuantity.exec(this.ctx)).be.null();
+  it('should be null if invalid negative Quantity', async function () {
+    should(await this.tooSmallQuantity.exec(this.ctx)).be.null();
   });
 
-  it('should return null for null argument', function () {
-    should.not.exist(this.nullArg.exec(this.ctx));
+  it('should return null for null argument', async function () {
+    should.not.exist(await this.nullArg.exec(this.ctx));
   });
 });
 
@@ -418,32 +418,32 @@ describe('ToRatio', () => {
     setup(this, data);
   });
 
-  it('should be null if string is null', function () {
-    should(this.nullArg.exec(this.ctx)).be.null();
+  it('should be null if string is null', async function () {
+    should(await this.nullArg.exec(this.ctx)).be.null();
   });
 
-  it('should be null if string separator is invalid', function () {
-    should(this.invalidSeparator.exec(this.ctx)).be.null();
+  it('should be null if string separator is invalid', async function () {
+    should(await this.invalidSeparator.exec(this.ctx)).be.null();
   });
 
-  it('should be null if numerator is invalid', function () {
-    should(this.invalidNumerator.exec(this.ctx)).be.null();
+  it('should be null if numerator is invalid', async function () {
+    should(await this.invalidNumerator.exec(this.ctx)).be.null();
   });
 
-  it('should be null if denominator is invalid', function () {
-    should(this.invalidDenominator.exec(this.ctx)).be.null();
+  it('should be null if denominator is invalid', async function () {
+    should(await this.invalidDenominator.exec(this.ctx)).be.null();
   });
 
-  it('should be valid given quantities with custom UCUM units', function () {
-    const ratio = this.isValidWithCustomUCUM.exec(this.ctx);
+  it('should be valid given quantities with custom UCUM units', async function () {
+    const ratio = await this.isValidWithCustomUCUM.exec(this.ctx);
     ratio.numerator.value.should.eql(1.0);
     ratio.numerator.unit.should.eql('{foo:bar }');
     ratio.denominator.value.should.eql(2.0);
     ratio.denominator.unit.should.eql('mg');
   });
 
-  it('should create valid ratio', function () {
-    const ratio = this.isValid.exec(this.ctx);
+  it('should create valid ratio', async function () {
+    const ratio = await this.isValid.exec(this.ctx);
     ratio.numerator.value.should.eql(1.0);
     ratio.numerator.unit.should.eql('mg');
     ratio.denominator.value.should.eql(2.0);
@@ -456,51 +456,51 @@ describe('ToTime', () => {
     setup(this, data);
   });
 
-  it('should return null if arg is null', function () {
-    should.not.exist(this.nullArgTime.exec(this.ctx));
+  it('should return null if arg is null', async function () {
+    should.not.exist(await this.nullArgTime.exec(this.ctx));
   });
 
-  it('should be null for incorrect format', function () {
-    should(this.incorrectFormatTime.exec(this.ctx)).be.null();
+  it('should be null for incorrect format', async function () {
+    should(await this.incorrectFormatTime.exec(this.ctx)).be.null();
   });
 
-  it('should be null for invalid time-of-day', function () {
-    should(this.invalidTime.exec(this.ctx)).be.null();
+  it('should be null for invalid time-of-day', async function () {
+    should(await this.invalidTime.exec(this.ctx)).be.null();
   });
 
-  it('should work with hh', function () {
+  it('should work with hh', async function () {
     // NOTE: We need to pass in null timezoneOffset because DateTime assumes
     // execution context timezoneOffset while time does not have a
     // timezoneOffset
     const expectedDateTime = new DateTime(0, 1, 1, 2, null, null, null, null);
-    this.timeH.exec(this.ctx).equals(expectedDateTime).should.be.true();
+    (await this.timeH.exec(this.ctx)).equals(expectedDateTime).should.be.true();
   });
 
-  it('should work with hh:mm', function () {
+  it('should work with hh:mm', async function () {
     const expectedDateTime = new DateTime(0, 1, 1, 2, 4, null, null, null);
-    this.timeHM.exec(this.ctx).equals(expectedDateTime).should.be.true();
+    (await this.timeHM.exec(this.ctx)).equals(expectedDateTime).should.be.true();
   });
 
-  it('should work with hh:mm:ss', function () {
+  it('should work with hh:mm:ss', async function () {
     const expectedDateTime = new DateTime(0, 1, 1, 2, 4, 59, null, null);
-    this.timeHMS.exec(this.ctx).equals(expectedDateTime).should.be.true();
+    (await this.timeHMS.exec(this.ctx)).equals(expectedDateTime).should.be.true();
   });
 
-  it('should work with hh:mm:ss.fff', function () {
+  it('should work with hh:mm:ss.fff', async function () {
     const expectedDateTime = new DateTime(0, 1, 1, 2, 4, 59, 123, null);
-    this.timeHMSMs.exec(this.ctx).equals(expectedDateTime).should.be.true();
+    (await this.timeHMSMs.exec(this.ctx)).equals(expectedDateTime).should.be.true();
   });
 
-  it('should be null for hour over 24', function () {
-    should(this.hourTooHigh.exec(this.ctx)).be.null();
+  it('should be null for hour over 24', async function () {
+    should(await this.hourTooHigh.exec(this.ctx)).be.null();
   });
 
-  it('should be null for minute over 59', function () {
-    should(this.minuteTooHigh.exec(this.ctx)).be.null();
+  it('should be null for minute over 59', async function () {
+    should(await this.minuteTooHigh.exec(this.ctx)).be.null();
   });
 
-  it('should be null for second over 59', function () {
-    should(this.secondTooHigh.exec(this.ctx)).be.null();
+  it('should be null for second over 59', async function () {
+    should(await this.secondTooHigh.exec(this.ctx)).be.null();
   });
 });
 
@@ -509,28 +509,28 @@ describe('ToBoolean', () => {
     setup(this, data);
   });
 
-  it('should return true for TRUE', function () {
-    this.upperCaseTrue.exec(this.ctx).should.equal(true);
+  it('should return true for TRUE', async function () {
+    (await this.upperCaseTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return true for FALSE', function () {
-    this.upperCaseFalse.exec(this.ctx).should.equal(false);
+  it('should return true for FALSE', async function () {
+    (await this.upperCaseFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return true for true', function () {
-    this.lowerCaseT.exec(this.ctx).should.equal(true);
+  it('should return true for true', async function () {
+    (await this.lowerCaseT.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return true for false', function () {
-    this.lowerCaseF.exec(this.ctx).should.equal(false);
+  it('should return true for false', async function () {
+    (await this.lowerCaseF.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return true for T', function () {
-    this.upperCaseT.exec(this.ctx).should.equal(true);
+  it('should return true for T', async function () {
+    (await this.upperCaseT.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for F', function () {
-    this.upperCaseF.exec(this.ctx).should.equal(false);
+  it('should return false for F', async function () {
+    (await this.upperCaseF.exec(this.ctx)).should.equal(false);
   });
 });
 
@@ -539,8 +539,8 @@ describe('ToDate', () => {
     setup(this, data);
   });
 
-  it('should convert String 2015-01-02 to Date', function () {
-    const date = this.toDateString.exec(this.ctx);
+  it('should convert String 2015-01-02 to Date', async function () {
+    const date = await this.toDateString.exec(this.ctx);
     date.year.should.equal(2015);
     date.month.should.equal(1);
     date.day.should.equal(2);
@@ -550,8 +550,8 @@ describe('ToDate', () => {
     date.isDate.should.equal.true;
   });
 
-  it('should convert Datetime to Date', function () {
-    const date = this.toDateDateTime.exec(this.ctx);
+  it('should convert Datetime to Date', async function () {
+    const date = await this.toDateDateTime.exec(this.ctx);
     date.year.should.equal(2000);
     date.month.should.equal(3);
     date.day.should.equal(15);
@@ -561,12 +561,12 @@ describe('ToDate', () => {
     date.isDate.should.equal.true;
   });
 
-  it('should return null for null input', function () {
-    should(this.toDateNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.toDateNull.exec(this.ctx)).be.null();
   });
 
-  it('should return 2014-01-01 and ignore time', function () {
-    const date = this.toDateDateTimeString.exec(this.ctx);
+  it('should return 2014-01-01 and ignore time', async function () {
+    const date = await this.toDateDateTimeString.exec(this.ctx);
     date.year.should.equal(2014);
     date.month.should.equal(1);
     date.day.should.equal(1);
@@ -581,20 +581,20 @@ describe('ConvertsToBoolean', () => {
     setup(this, data);
   });
 
-  it('should return true for y', function () {
-    this.isTrueWithTrueValue.exec(this.ctx).should.equal(true);
+  it('should return true for y', async function () {
+    (await this.isTrueWithTrueValue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return true for 0', function () {
-    this.isTrueWithFalseValue.exec(this.ctx).should.equal(true);
+  it('should return true for 0', async function () {
+    (await this.isTrueWithFalseValue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for invalid argument', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it('should return false for invalid argument', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -603,16 +603,16 @@ describe('ConvertsToDate', () => {
     setup(this, data);
   });
 
-  it('should return true for valid date', function () {
-    this.isTrue.exec(this.ctx).should.equal(true);
+  it('should return true for valid date', async function () {
+    (await this.isTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for invalid date', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it('should return false for invalid date', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -621,20 +621,20 @@ describe('ConvertsToDateTime', () => {
     setup(this, data);
   });
 
-  it('should return true for valid datetime', function () {
-    this.isTrue.exec(this.ctx).should.equal(true);
+  it('should return true for valid datetime', async function () {
+    (await this.isTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return true for valid date', function () {
-    this.isTrueWithDateValue.exec(this.ctx).should.equal(true);
+  it('should return true for valid date', async function () {
+    (await this.isTrueWithDateValue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for invalid datetime', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it('should return false for invalid datetime', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -643,16 +643,16 @@ describe('ConvertsToDecimal', () => {
     setup(this, data);
   });
 
-  it('should return true for valid decimal', function () {
-    this.isTrue.exec(this.ctx).should.equal(true);
+  it('should return true for valid decimal', async function () {
+    (await this.isTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for invalid decimal', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it('should return false for invalid decimal', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -661,24 +661,24 @@ describe('ConvertsToInteger', () => {
     setup(this, data);
   });
 
-  it('should return true for valid integer', function () {
-    this.isTrue.exec(this.ctx).should.equal(true);
+  it('should return true for valid integer', async function () {
+    (await this.isTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return true for boolean true', function () {
-    this.isTrueWithBooleanTrue.exec(this.ctx).should.equal(true);
+  it('should return true for boolean true', async function () {
+    (await this.isTrueWithBooleanTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return true for boolean false', function () {
-    this.isTrueWithBooleanFalse.exec(this.ctx).should.equal(true);
+  it('should return true for boolean false', async function () {
+    (await this.isTrueWithBooleanFalse.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for invalid integer', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it('should return false for invalid integer', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -687,28 +687,28 @@ describe('ConvertsToQuantity', () => {
     setup(this, data);
   });
 
-  it('should return true for valid decimal', function () {
-    this.isTrueWithDecimal.exec(this.ctx).should.equal(true);
+  it('should return true for valid decimal', async function () {
+    (await this.isTrueWithDecimal.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return true for valid integer', function () {
-    this.isTrueWithInteger.exec(this.ctx).should.equal(true);
+  it('should return true for valid integer', async function () {
+    (await this.isTrueWithInteger.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return true for valid string', function () {
-    this.isTrueWithString.exec(this.ctx).should.equal(true);
+  it('should return true for valid string', async function () {
+    (await this.isTrueWithString.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for invalid ucum unit', function () {
-    this.isFalseWithInvalidUcum.exec(this.ctx).should.equal(false);
+  it('should return false for invalid ucum unit', async function () {
+    (await this.isFalseWithInvalidUcum.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return false for invalid string', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it('should return false for invalid string', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -717,20 +717,20 @@ describe('ConvertsToRatio', () => {
     setup(this, data);
   });
 
-  it('should return true for valid ratio string', function () {
-    this.isTrue.exec(this.ctx).should.equal(true);
+  it('should return true for valid ratio string', async function () {
+    (await this.isTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for invalid ratio string', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it('should return false for invalid ratio string', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return false for invalid ucum units', function () {
-    this.isFalseWithInvalidUcum.exec(this.ctx).should.equal(false);
+  it('should return false for invalid ucum units', async function () {
+    (await this.isFalseWithInvalidUcum.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -739,16 +739,16 @@ describe('ConvertsToString', () => {
     setup(this, data);
   });
 
-  it('should return true for valid Boolean', function () {
-    this.isTrue.exec(this.ctx).should.equal(true);
+  it('should return true for valid Boolean', async function () {
+    (await this.isTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it.skip('should return false for invalid type', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it.skip('should return false for invalid type', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -757,16 +757,16 @@ describe('ConvertsToTime', () => {
     setup(this, data);
   });
 
-  it('should return true for valid string', function () {
-    this.isTrue.exec(this.ctx).should.equal(true);
+  it('should return true for valid string', async function () {
+    (await this.isTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for invalid string', function () {
-    this.isFalse.exec(this.ctx).should.equal(false);
+  it('should return false for invalid string', async function () {
+    (await this.isFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for null input', function () {
-    should(this.isNull.exec(this.ctx)).be.null();
+  it('should return null for null input', async function () {
+    should(await this.isNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -775,24 +775,24 @@ describe('ConvertQuantity', () => {
     setup(this, data);
   });
 
-  it('should return converted Quantity', function () {
-    this.convertQuantityGood.exec(this.ctx).should.eql(new Quantity(0.005, 'g'));
+  it('should return converted Quantity', async function () {
+    (await this.convertQuantityGood.exec(this.ctx)).should.eql(new Quantity(0.005, 'g'));
   });
 
-  it('should return converted Quantity using new syntx', function () {
-    this.convertSyntax.exec(this.ctx).should.eql(new Quantity(0.005, 'g'));
+  it('should return converted Quantity using new syntx', async function () {
+    (await this.convertSyntax.exec(this.ctx)).should.eql(new Quantity(0.005, 'g'));
   });
 
-  it('should return converted Quantity with Kg', function () {
-    this.convertQuantityToKg.exec(this.ctx).should.eql(new Quantity(5, 'kg'));
+  it('should return converted Quantity with Kg', async function () {
+    (await this.convertQuantityToKg.exec(this.ctx)).should.eql(new Quantity(5, 'kg'));
   });
 
-  it('should return converted Quantity with weeks', function () {
-    this.convertQuantityToWeeks.exec(this.ctx).should.eql(new Quantity(4, 'weeks'));
+  it('should return converted Quantity with weeks', async function () {
+    (await this.convertQuantityToWeeks.exec(this.ctx)).should.eql(new Quantity(4, 'weeks'));
   });
 
-  it('should return null for an invalid UCUM conversion', function () {
-    should(this.nullConvertQuantity.exec(this.ctx)).be.null();
+  it('should return null for an invalid UCUM conversion', async function () {
+    should(await this.nullConvertQuantity.exec(this.ctx)).be.null();
   });
 });
 
@@ -801,19 +801,19 @@ describe('CanConvertQuantity', () => {
     setup(this, data);
   });
 
-  it('should return true for valid conversion', function () {
-    this.canConvertQuantityTrue.exec(this.ctx).should.equal(true);
+  it('should return true for valid conversion', async function () {
+    (await this.canConvertQuantityTrue.exec(this.ctx)).should.equal(true);
   });
 
-  it('should return false for valid conversion', function () {
-    this.canConvertQuantityFalse.exec(this.ctx).should.equal(false);
+  it('should return false for valid conversion', async function () {
+    (await this.canConvertQuantityFalse.exec(this.ctx)).should.equal(false);
   });
 
-  it('should return null for first argument null', function () {
-    should(this.canConvertQuantityNullFirstNull.exec(this.ctx)).be.null();
+  it('should return null for first argument null', async function () {
+    should(await this.canConvertQuantityNullFirstNull.exec(this.ctx)).be.null();
   });
 
-  it('should return null for second argument being null', function () {
-    should(this.canConvertQuantityNullSecondNUll.exec(this.ctx)).be.null();
+  it('should return null for second argument being null', async function () {
+    should(await this.canConvertQuantityNullSecondNUll.exec(this.ctx)).be.null();
   });
 });

--- a/test/elm/date/date-test.ts
+++ b/test/elm/date/date-test.ts
@@ -8,23 +8,23 @@ describe('Date', () => {
     setup(this, data);
   });
 
-  it('should execute year precision correctly', function () {
-    const d = this.year.exec(this.ctx);
+  it('should execute year precision correctly', async function () {
+    const d = await this.year.exec(this.ctx);
     d.isDate.should.be.true();
     d.year.should.equal(2012);
     ['month', 'day'].map(field => should.not.exist(d[field]));
   });
 
-  it('should execute month precision correctly', function () {
-    const d = this.month.exec(this.ctx);
+  it('should execute month precision correctly', async function () {
+    const d = await this.month.exec(this.ctx);
     d.isDate.should.be.true();
     d.year.should.equal(2012);
     d.month.should.equal(2);
     ['day'].map(field => should.not.exist(d[field]));
   });
 
-  it('should execute day precision correctly', function () {
-    const d = this.day.exec(this.ctx);
+  it('should execute day precision correctly', async function () {
+    const d = await this.day.exec(this.ctx);
     d.isDate.should.be.true();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -37,20 +37,20 @@ describe('DateComponentFrom', () => {
     setup(this, data);
   });
 
-  it('should return the year from the date', function () {
-    this.year.exec(this.ctx).should.equal(2000);
+  it('should return the year from the date', async function () {
+    (await this.year.exec(this.ctx)).should.equal(2000);
   });
 
-  it('should return the month from the date', function () {
-    this.month.exec(this.ctx).should.equal(3);
+  it('should return the month from the date', async function () {
+    (await this.month.exec(this.ctx)).should.equal(3);
   });
 
-  it('should return the day from the date', function () {
-    this.day.exec(this.ctx).should.equal(15);
+  it('should return the day from the date', async function () {
+    (await this.day.exec(this.ctx)).should.equal(15);
   });
 
-  it('should return null for imprecise components', function () {
-    const result = this.impreciseComponentTuple.exec(this.ctx);
+  it('should return null for imprecise components', async function () {
+    const result = await this.impreciseComponentTuple.exec(this.ctx);
     result.should.eql({
       Year: 2000,
       Month: 3,
@@ -58,8 +58,8 @@ describe('DateComponentFrom', () => {
     });
   });
 
-  it('should return null for null date', function () {
-    should(this.nullDate.exec(this.ctx)).be.null();
+  it('should return null for null date', async function () {
+    should(await this.nullDate.exec(this.ctx)).be.null();
   });
 });
 
@@ -68,32 +68,32 @@ describe('SameAs', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is the same', function () {
-    this.sameYear.exec(this.ctx).should.be.true();
-    this.notSameYear.exec(this.ctx).should.be.false();
+  it('should properly determine when year is the same', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.true();
+    (await this.notSameYear.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when month is the same', function () {
-    this.sameMonth.exec(this.ctx).should.be.true();
-    this.notSameMonth.exec(this.ctx).should.be.false();
-    this.sameMonthWrongYear.exec(this.ctx).should.be.false();
+  it('should properly determine when month is the same', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.true();
+    (await this.notSameMonth.exec(this.ctx)).should.be.false();
+    (await this.sameMonthWrongYear.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine same as using day', function () {
-    this.same.exec(this.ctx).should.be.true();
-    this.notSame.exec(this.ctx).should.be.false();
+  it('should properly determine same as using day', async function () {
+    (await this.same.exec(this.ctx)).should.be.true();
+    (await this.notSame.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when day is the same', function () {
-    this.sameDay.exec(this.ctx).should.be.true();
-    this.notSameDay.exec(this.ctx).should.be.false();
-    this.sameDayWrongMonth.exec(this.ctx).should.be.false();
+  it('should properly determine when day is the same', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.true();
+    (await this.notSameDay.exec(this.ctx)).should.be.false();
+    (await this.sameDayWrongMonth.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 });
 
@@ -102,46 +102,46 @@ describe('SameOrAfter', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is same or after', function () {
-    this.sameYear.exec(this.ctx).should.be.true();
-    this.yearAfter.exec(this.ctx).should.be.true();
-    this.yearBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when year is same or after', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.true();
+    (await this.yearAfter.exec(this.ctx)).should.be.true();
+    (await this.yearBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when month is same or after', function () {
-    this.sameMonth.exec(this.ctx).should.be.true();
-    this.monthAfter.exec(this.ctx).should.be.true();
-    this.monthBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when month is same or after', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.true();
+    (await this.monthAfter.exec(this.ctx)).should.be.true();
+    (await this.monthBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when day is same or after', function () {
-    this.sameDay.exec(this.ctx).should.be.true();
-    this.dayAfter.exec(this.ctx).should.be.true();
-    this.dayBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when day is same or after', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.true();
+    (await this.dayAfter.exec(this.ctx)).should.be.true();
+    (await this.dayBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine same or after using day when no precision defined', function () {
-    this.same.exec(this.ctx).should.be.true();
-    this.after.exec(this.ctx).should.be.true();
-    this.before.exec(this.ctx).should.be.false();
+  it('should properly determine same or after using day when no precision defined', async function () {
+    (await this.same.exec(this.ctx)).should.be.true();
+    (await this.after.exec(this.ctx)).should.be.true();
+    (await this.before.exec(this.ctx)).should.be.false();
   });
 
-  it('should consider precision units above the specified unit', function () {
-    this.sameDayMonthBefore.exec(this.ctx).should.be.false();
-    this.dayAfterMonthBefore.exec(this.ctx).should.be.false();
-    this.dayBeforeMonthAfter.exec(this.ctx).should.be.true();
+  it('should consider precision units above the specified unit', async function () {
+    (await this.sameDayMonthBefore.exec(this.ctx)).should.be.false();
+    (await this.dayAfterMonthBefore.exec(this.ctx)).should.be.false();
+    (await this.dayBeforeMonthAfter.exec(this.ctx)).should.be.true();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseDay.exec(this.ctx)).be.null();
-    this.impreciseDayMonthAfter.exec(this.ctx).should.be.true();
-    this.impreciseDayMonthBefore.exec(this.ctx).should.be.false();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseDay.exec(this.ctx)).be.null();
+    (await this.impreciseDayMonthAfter.exec(this.ctx)).should.be.true();
+    (await this.impreciseDayMonthBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 });
 
@@ -150,46 +150,46 @@ describe('SameOrBefore', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is same or after', function () {
-    this.sameYear.exec(this.ctx).should.be.true();
-    this.yearAfter.exec(this.ctx).should.be.false();
-    this.yearBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when year is same or after', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.true();
+    (await this.yearAfter.exec(this.ctx)).should.be.false();
+    (await this.yearBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when month is same or after', function () {
-    this.sameMonth.exec(this.ctx).should.be.true();
-    this.monthAfter.exec(this.ctx).should.be.false();
-    this.monthBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when month is same or after', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.true();
+    (await this.monthAfter.exec(this.ctx)).should.be.false();
+    (await this.monthBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when day is same or after', function () {
-    this.sameDay.exec(this.ctx).should.be.true();
-    this.dayAfter.exec(this.ctx).should.be.false();
-    this.dayBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when day is same or after', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.true();
+    (await this.dayAfter.exec(this.ctx)).should.be.false();
+    (await this.dayBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine same or after using day when no precision defined', function () {
-    this.same.exec(this.ctx).should.be.true();
-    this.after.exec(this.ctx).should.be.false();
-    this.before.exec(this.ctx).should.be.true();
+  it('should properly determine same or after using day when no precision defined', async function () {
+    (await this.same.exec(this.ctx)).should.be.true();
+    (await this.after.exec(this.ctx)).should.be.false();
+    (await this.before.exec(this.ctx)).should.be.true();
   });
 
-  it('should consider precision units above the specified unit', function () {
-    this.sameDayMonthBefore.exec(this.ctx).should.be.true();
-    this.dayAfterMonthBefore.exec(this.ctx).should.be.true();
-    this.dayBeforeMonthAfter.exec(this.ctx).should.be.false();
+  it('should consider precision units above the specified unit', async function () {
+    (await this.sameDayMonthBefore.exec(this.ctx)).should.be.true();
+    (await this.dayAfterMonthBefore.exec(this.ctx)).should.be.true();
+    (await this.dayBeforeMonthAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseDay.exec(this.ctx)).be.null();
-    this.impreciseDayMonthAfter.exec(this.ctx).should.be.false();
-    this.impreciseDayMonthBefore.exec(this.ctx).should.be.true();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseDay.exec(this.ctx)).be.null();
+    (await this.impreciseDayMonthAfter.exec(this.ctx)).should.be.false();
+    (await this.impreciseDayMonthBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 });
 
@@ -198,40 +198,40 @@ describe('After', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is same or after', function () {
-    this.sameYear.exec(this.ctx).should.be.false();
-    this.yearAfter.exec(this.ctx).should.be.true();
-    this.yearBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when year is same or after', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.false();
+    (await this.yearAfter.exec(this.ctx)).should.be.true();
+    (await this.yearBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when month is same or after', function () {
-    this.sameMonth.exec(this.ctx).should.be.false();
-    this.monthAfter.exec(this.ctx).should.be.true();
-    this.monthBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when month is same or after', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.false();
+    (await this.monthAfter.exec(this.ctx)).should.be.true();
+    (await this.monthBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when day is same or after', function () {
-    this.sameDay.exec(this.ctx).should.be.false();
-    this.dayAfter.exec(this.ctx).should.be.true();
-    this.dayBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when day is same or after', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.false();
+    (await this.dayAfter.exec(this.ctx)).should.be.true();
+    (await this.dayBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine same or after using day when no precision defined', function () {
-    this.same.exec(this.ctx).should.be.false();
-    this.after.exec(this.ctx).should.be.true();
-    this.before.exec(this.ctx).should.be.false();
+  it('should properly determine same or after using day when no precision defined', async function () {
+    (await this.same.exec(this.ctx)).should.be.false();
+    (await this.after.exec(this.ctx)).should.be.true();
+    (await this.before.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseDay.exec(this.ctx)).be.null();
-    this.impreciseDayMonthAfter.exec(this.ctx).should.be.true();
-    this.impreciseDayMonthBefore.exec(this.ctx).should.be.false();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseDay.exec(this.ctx)).be.null();
+    (await this.impreciseDayMonthAfter.exec(this.ctx)).should.be.true();
+    (await this.impreciseDayMonthBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 });
 
@@ -240,40 +240,40 @@ describe('Before', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is same or after', function () {
-    this.sameYear.exec(this.ctx).should.be.false();
-    this.yearAfter.exec(this.ctx).should.be.false();
-    this.yearBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when year is same or after', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.false();
+    (await this.yearAfter.exec(this.ctx)).should.be.false();
+    (await this.yearBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when month is same or after', function () {
-    this.sameMonth.exec(this.ctx).should.be.false();
-    this.monthAfter.exec(this.ctx).should.be.false();
-    this.monthBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when month is same or after', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.false();
+    (await this.monthAfter.exec(this.ctx)).should.be.false();
+    (await this.monthBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when day is same or after', function () {
-    this.sameDay.exec(this.ctx).should.be.false();
-    this.dayAfter.exec(this.ctx).should.be.false();
-    this.dayBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when day is same or after', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.false();
+    (await this.dayAfter.exec(this.ctx)).should.be.false();
+    (await this.dayBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine same or after using day when no precision defined', function () {
-    this.same.exec(this.ctx).should.be.false();
-    this.after.exec(this.ctx).should.be.false();
-    this.before.exec(this.ctx).should.be.true();
+  it('should properly determine same or after using day when no precision defined', async function () {
+    (await this.same.exec(this.ctx)).should.be.false();
+    (await this.after.exec(this.ctx)).should.be.false();
+    (await this.before.exec(this.ctx)).should.be.true();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseDay.exec(this.ctx)).be.null();
-    this.impreciseDayMonthAfter.exec(this.ctx).should.be.false();
-    this.impreciseDayMonthBefore.exec(this.ctx).should.be.true();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseDay.exec(this.ctx)).be.null();
+    (await this.impreciseDayMonthAfter.exec(this.ctx)).should.be.false();
+    (await this.impreciseDayMonthBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 });
 
@@ -282,36 +282,36 @@ describe('DifferenceBetween', () => {
     setup(this, data);
   });
 
-  it('should properly execute years between', function () {
-    this.yearsBetween.exec(this.ctx).should.equal(1);
+  it('should properly execute years between', async function () {
+    (await this.yearsBetween.exec(this.ctx)).should.equal(1);
   });
 
-  it('should properly execute months between', function () {
-    this.monthsBetween.exec(this.ctx).should.equal(12);
+  it('should properly execute months between', async function () {
+    (await this.monthsBetween.exec(this.ctx)).should.equal(12);
   });
 
-  it('should properly execute weeks between', function () {
-    this.weeksBetween.exec(this.ctx).should.equal(52);
+  it('should properly execute weeks between', async function () {
+    (await this.weeksBetween.exec(this.ctx)).should.equal(52);
   });
 
-  it('should properly execute days between', function () {
-    this.daysBetween.exec(this.ctx).should.equal(365);
+  it('should properly execute days between', async function () {
+    (await this.daysBetween.exec(this.ctx)).should.equal(365);
   });
 
-  it('should properly execute years between with an uncertainty', function () {
-    this.yearsBetweenUncertainty.exec(this.ctx).should.equal(0);
+  it('should properly execute years between with an uncertainty', async function () {
+    (await this.yearsBetweenUncertainty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should properly execute months between with an uncertainty', function () {
-    this.monthsBetweenUncertainty.exec(this.ctx).should.equal(0);
+  it('should properly execute months between with an uncertainty', async function () {
+    (await this.monthsBetweenUncertainty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should properly execute weeks between with an uncertainty', function () {
-    this.weeksBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 4));
+  it('should properly execute weeks between with an uncertainty', async function () {
+    (await this.weeksBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 4));
   });
 
-  it('should properly execute days between with an uncertainty', function () {
-    this.daysBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 30));
+  it('should properly execute days between with an uncertainty', async function () {
+    (await this.daysBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 30));
   });
 });
 
@@ -320,40 +320,40 @@ describe('DifferenceBetween Comparisons', () => {
     setup(this, data);
   });
 
-  it('should calculate days between > x', function () {
-    this.greaterThan25DaysAfter.exec(this.ctx).should.be.true();
-    should(this.greaterThan40DaysAfter.exec(this.ctx)).be.null();
-    this.greaterThan80DaysAfter.exec(this.ctx).should.be.false();
+  it('should calculate days between > x', async function () {
+    (await this.greaterThan25DaysAfter.exec(this.ctx)).should.be.true();
+    should(await this.greaterThan40DaysAfter.exec(this.ctx)).be.null();
+    (await this.greaterThan80DaysAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate days between >= x', function () {
-    this.greaterOrEqualTo25DaysAfter.exec(this.ctx).should.be.true();
-    should(this.greaterOrEqualTo40DaysAfter.exec(this.ctx)).be.null();
-    this.greaterOrEqualTo80DaysAfter.exec(this.ctx).should.be.false();
+  it('should calculate days between >= x', async function () {
+    (await this.greaterOrEqualTo25DaysAfter.exec(this.ctx)).should.be.true();
+    should(await this.greaterOrEqualTo40DaysAfter.exec(this.ctx)).be.null();
+    (await this.greaterOrEqualTo80DaysAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate days between = x', function () {
-    this.equalTo25DaysAfter.exec(this.ctx).should.be.false();
-    should(this.equalTo40DaysAfter.exec(this.ctx)).be.null();
-    this.equalTo80DaysAfter.exec(this.ctx).should.be.false();
+  it('should calculate days between = x', async function () {
+    (await this.equalTo25DaysAfter.exec(this.ctx)).should.be.false();
+    should(await this.equalTo40DaysAfter.exec(this.ctx)).be.null();
+    (await this.equalTo80DaysAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate days between <= x', function () {
-    this.lessOrEqualTo25DaysAfter.exec(this.ctx).should.be.false();
-    should(this.lessOrEqualTo40DaysAfter.exec(this.ctx)).be.null();
-    this.lessOrEqualTo80DaysAfter.exec(this.ctx).should.be.true();
+  it('should calculate days between <= x', async function () {
+    (await this.lessOrEqualTo25DaysAfter.exec(this.ctx)).should.be.false();
+    should(await this.lessOrEqualTo40DaysAfter.exec(this.ctx)).be.null();
+    (await this.lessOrEqualTo80DaysAfter.exec(this.ctx)).should.be.true();
   });
 
-  it('should calculate days between < x', function () {
-    this.lessThan25DaysAfter.exec(this.ctx).should.be.false();
-    should(this.lessThan40DaysAfter.exec(this.ctx)).be.null();
-    this.lessThan80DaysAfter.exec(this.ctx).should.be.true();
+  it('should calculate days between < x', async function () {
+    (await this.lessThan25DaysAfter.exec(this.ctx)).should.be.false();
+    should(await this.lessThan40DaysAfter.exec(this.ctx)).be.null();
+    (await this.lessThan80DaysAfter.exec(this.ctx)).should.be.true();
   });
 
-  it('should calculate other way too', function () {
-    this.twentyFiveDaysLessThanDaysBetween.exec(this.ctx).should.be.true();
-    should(this.fortyDaysEqualToDaysBetween.exec(this.ctx)).be.null();
-    this.twentyFiveDaysGreaterThanDaysBetween.exec(this.ctx).should.be.false();
+  it('should calculate other way too', async function () {
+    (await this.twentyFiveDaysLessThanDaysBetween.exec(this.ctx)).should.be.true();
+    should(await this.fortyDaysEqualToDaysBetween.exec(this.ctx)).be.null();
+    (await this.twentyFiveDaysGreaterThanDaysBetween.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -362,36 +362,36 @@ describe('DurationBetween', () => {
     setup(this, data);
   });
 
-  it('should properly execute years between', function () {
-    this.yearsBetween.exec(this.ctx).should.equal(1);
+  it('should properly execute years between', async function () {
+    (await this.yearsBetween.exec(this.ctx)).should.equal(1);
   });
 
-  it('should properly execute months between', function () {
-    this.monthsBetween.exec(this.ctx).should.equal(12);
+  it('should properly execute months between', async function () {
+    (await this.monthsBetween.exec(this.ctx)).should.equal(12);
   });
 
-  it('should properly execute days between', function () {
-    this.daysBetween.exec(this.ctx).should.equal(365 + 22);
+  it('should properly execute days between', async function () {
+    (await this.daysBetween.exec(this.ctx)).should.equal(365 + 22);
   });
 
-  it('should properly execute weeks between', function () {
-    this.weeksBetween.exec(this.ctx).should.equal(55);
+  it('should properly execute weeks between', async function () {
+    (await this.weeksBetween.exec(this.ctx)).should.equal(55);
   });
 
-  it('should properly execute years between with an uncertainty', function () {
-    this.yearsBetweenUncertainty.exec(this.ctx).should.equal(0);
+  it('should properly execute years between with an uncertainty', async function () {
+    (await this.yearsBetweenUncertainty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should properly execute months between with an uncertainty', function () {
-    this.monthsBetweenUncertainty.exec(this.ctx).should.equal(0);
+  it('should properly execute months between with an uncertainty', async function () {
+    (await this.monthsBetweenUncertainty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should properly execute weeks between with an uncertainty', function () {
-    this.weeksBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 4));
+  it('should properly execute weeks between with an uncertainty', async function () {
+    (await this.weeksBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 4));
   });
 
-  it('should properly execute days between with an uncertainty', function () {
-    this.daysBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 30));
+  it('should properly execute days between with an uncertainty', async function () {
+    (await this.daysBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 30));
   });
 });
 
@@ -400,31 +400,31 @@ describe('DateMath', () => {
     setup(this, data);
   });
 
-  it('should properly add and subtract years', function () {
-    let d = this.plusThreeYears.exec(this.ctx);
+  it('should properly add and subtract years', async function () {
+    let d = await this.plusThreeYears.exec(this.ctx);
     dateCheck(d, 2016, 6, 15);
-    d = this.minusThreeYears.exec(this.ctx);
+    d = await this.minusThreeYears.exec(this.ctx);
     dateCheck(d, 2010, 6, 15);
   });
 
-  it('should properly add and subtract months', function () {
-    let d = this.plusEightMonths.exec(this.ctx);
+  it('should properly add and subtract months', async function () {
+    let d = await this.plusEightMonths.exec(this.ctx);
     dateCheck(d, 2014, 2, 15);
-    d = this.minusEightMonths.exec(this.ctx);
+    d = await this.minusEightMonths.exec(this.ctx);
     dateCheck(d, 2012, 10, 15);
   });
 
-  it('should properly add and subtract weeks', function () {
-    let d = this.plusThreeWeeks.exec(this.ctx);
+  it('should properly add and subtract weeks', async function () {
+    let d = await this.plusThreeWeeks.exec(this.ctx);
     dateCheck(d, 2013, 7, 6);
-    d = this.minusThreeWeeks.exec(this.ctx);
+    d = await this.minusThreeWeeks.exec(this.ctx);
     dateCheck(d, 2013, 5, 25);
   });
 
-  it('should properly add and subtract days', function () {
-    let d = this.plusTwentyDays.exec(this.ctx);
+  it('should properly add and subtract days', async function () {
+    let d = await this.plusTwentyDays.exec(this.ctx);
     dateCheck(d, 2013, 7, 5);
-    d = this.minusTwentyDays.exec(this.ctx);
+    d = await this.minusTwentyDays.exec(this.ctx);
     dateCheck(d, 2013, 5, 26);
   });
 });

--- a/test/elm/datetime/datetime-test.ts
+++ b/test/elm/datetime/datetime-test.ts
@@ -179,6 +179,7 @@ describe('Today', () => {
     ['hour', 'minute', 'second', 'millisecond', 'timezoneOffset'].forEach(field =>
       should.not.exist(today[field])
     );
+    return this.todayVar.exec(this.ctx).should.not.be.rejected();
   });
 
   it('should throw an exception because no execution datetime has been set', async function () {
@@ -190,7 +191,9 @@ describe('Today', () => {
       DT.DateTime.fromJSDate(new Date(), '0')
     );
     this.ctx.executionDateTime = this.ctx.executionDateTime = null;
-    this.todayVar.exec(this.ctx).should.be.rejectedWith('No Execution DateTime has been set');
+    return this.todayVar
+      .exec(this.ctx)
+      .should.be.rejectedWith('No Execution DateTime has been set');
   });
 });
 

--- a/test/elm/datetime/datetime-test.ts
+++ b/test/elm/datetime/datetime-test.ts
@@ -11,8 +11,8 @@ describe('DateTime', () => {
     this.defaultOffset = (new Date().getTimezoneOffset() / 60) * -1;
   });
 
-  it('should execute year precision correctly', function () {
-    const d = this.year.exec(this.ctx);
+  it('should execute year precision correctly', async function () {
+    const d = await this.year.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.timezoneOffset.should.equal(this.defaultOffset);
@@ -21,8 +21,8 @@ describe('DateTime', () => {
     );
   });
 
-  it('should execute month precision correctly', function () {
-    const d = this.month.exec(this.ctx);
+  it('should execute month precision correctly', async function () {
+    const d = await this.month.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -30,8 +30,8 @@ describe('DateTime', () => {
     ['day', 'hour', 'minute', 'second', 'millisecond'].forEach(field => should.not.exist(d[field]));
   });
 
-  it('should execute day precision correctly', function () {
-    const d = this.day.exec(this.ctx);
+  it('should execute day precision correctly', async function () {
+    const d = await this.day.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -40,8 +40,8 @@ describe('DateTime', () => {
     ['hour', 'minute', 'second', 'millisecond'].forEach(field => should.not.exist(d[field]));
   });
 
-  it('should execute hour precision correctly', function () {
-    const d = this.hour.exec(this.ctx);
+  it('should execute hour precision correctly', async function () {
+    const d = await this.hour.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -51,8 +51,8 @@ describe('DateTime', () => {
     ['minute', 'second', 'millisecond'].forEach(field => should.not.exist(d[field]));
   });
 
-  it('should execute minute precision correctly', function () {
-    const d = this.minute.exec(this.ctx);
+  it('should execute minute precision correctly', async function () {
+    const d = await this.minute.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -63,8 +63,8 @@ describe('DateTime', () => {
     ['second', 'millisecond'].forEach(field => should.not.exist(d[field]));
   });
 
-  it('should execute second precision correctly', function () {
-    const d = this.second.exec(this.ctx);
+  it('should execute second precision correctly', async function () {
+    const d = await this.second.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -76,8 +76,8 @@ describe('DateTime', () => {
     should.not.exist(d.millisecond);
   });
 
-  it('should execute millisecond precision correctly', function () {
-    const d = this.millisecond.exec(this.ctx);
+  it('should execute millisecond precision correctly', async function () {
+    const d = await this.millisecond.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -89,8 +89,8 @@ describe('DateTime', () => {
     d.timezoneOffset.should.equal(this.defaultOffset);
   });
 
-  it('should execute timezone offsets correctly', function () {
-    const d = this.timezoneOffset.exec(this.ctx);
+  it('should execute timezone offsets correctly', async function () {
+    const d = await this.timezoneOffset.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -108,8 +108,8 @@ describe('Time', () => {
     setup(this, data);
   });
 
-  it('should execute hour precision correctly', function () {
-    const d = this.hour.exec(this.ctx);
+  it('should execute hour precision correctly', async function () {
+    const d = await this.hour.exec(this.ctx);
     d.isTime().should.be.true();
     d.year.should.equal(0);
     d.month.should.equal(1);
@@ -120,8 +120,8 @@ describe('Time', () => {
     );
   });
 
-  it('should execute minute precision correctly', function () {
-    const d = this.minute.exec(this.ctx);
+  it('should execute minute precision correctly', async function () {
+    const d = await this.minute.exec(this.ctx);
     d.isTime().should.be.true();
     d.year.should.equal(0);
     d.month.should.equal(1);
@@ -132,8 +132,8 @@ describe('Time', () => {
     ['second', 'millisecond', 'timezoneOffset'].forEach(field => should.not.exist(d[field]));
   });
 
-  it('should execute second precision correctly', function () {
-    const d = this.second.exec(this.ctx);
+  it('should execute second precision correctly', async function () {
+    const d = await this.second.exec(this.ctx);
     d.isTime().should.be.true();
     d.year.should.equal(0);
     d.month.should.equal(1);
@@ -145,8 +145,8 @@ describe('Time', () => {
     should.not.exist(d.millisecond);
   });
 
-  it('should execute millisecond precision correctly', function () {
-    const d = this.millisecond.exec(this.ctx);
+  it('should execute millisecond precision correctly', async function () {
+    const d = await this.millisecond.exec(this.ctx);
     d.isTime().should.be.true();
     d.year.should.equal(0);
     d.month.should.equal(1);
@@ -170,8 +170,8 @@ describe('Today', () => {
     );
   });
 
-  it('should return date of today', function () {
-    const today = this.todayVar.exec(this.ctx);
+  it('should return date of today', async function () {
+    const today = await this.todayVar.exec(this.ctx);
     today.isDate.should.be.true();
     today.year.should.equal(this.ctx.getExecutionDateTime().year);
     today.month.should.equal(this.ctx.getExecutionDateTime().month);
@@ -181,7 +181,7 @@ describe('Today', () => {
     );
   });
 
-  it('should throw an exception because no execution datetime has been set', function () {
+  it('should throw an exception because no execution datetime has been set', async function () {
     this.ctx = new PatientContext(
       this.ctx.library,
       this.ctx.patient,
@@ -190,7 +190,7 @@ describe('Today', () => {
       DT.DateTime.fromJSDate(new Date(), '0')
     );
     this.ctx.executionDateTime = this.ctx.executionDateTime = null;
-    should(() => this.todayVar.exec(this.ctx)).throw('No Execution DateTime has been set');
+    this.todayVar.exec(this.ctx).should.be.rejectedWith('No Execution DateTime has been set');
   });
 });
 
@@ -205,8 +205,8 @@ describe('Now', () => {
     );
   });
 
-  it('should return all date components representing now', function () {
-    const now = this.nowVar.exec(this.ctx);
+  it('should return all date components representing now', async function () {
+    const now = await this.nowVar.exec(this.ctx);
     now.isTime().should.be.false();
     now.year.should.equal(this.ctx.getExecutionDateTime().year);
     now.month.should.equal(this.ctx.getExecutionDateTime().month);
@@ -218,7 +218,7 @@ describe('Now', () => {
     now.timezoneOffset.should.equal(this.ctx.getTimezoneOffset());
   });
 
-  it('should return all date components representing now using a passed in timezone', function () {
+  it('should return all date components representing now using a passed in timezone', async function () {
     this.ctx = new PatientContext(
       this.ctx.library,
       this.ctx.patient,
@@ -226,7 +226,7 @@ describe('Now', () => {
       this.ctx.parameters,
       DT.DateTime.fromJSDate(new Date(), '0')
     );
-    const now = this.nowVar.exec(this.ctx);
+    const now = await this.nowVar.exec(this.ctx);
     now.isTime().should.be.false();
     now.year.should.equal(this.ctx.getExecutionDateTime().year);
     now.month.should.equal(this.ctx.getExecutionDateTime().month);
@@ -238,7 +238,7 @@ describe('Now', () => {
     now.timezoneOffset.should.equal('0');
   });
 
-  it('should return all date components representing now using a passed in timezone using a child context', function () {
+  it('should return all date components representing now using a passed in timezone using a child context', async function () {
     this.ctx = new PatientContext(
       this.ctx.library,
       this.ctx.patient,
@@ -247,7 +247,7 @@ describe('Now', () => {
       DT.DateTime.fromJSDate(new Date(), '0')
     );
     this.child_ctx = this.ctx.childContext();
-    const now = this.nowVar.exec(this.child_ctx);
+    const now = await this.nowVar.exec(this.child_ctx);
     now.isTime().should.be.false();
     now.year.should.equal(this.child_ctx.getExecutionDateTime().year);
     now.month.should.equal(this.child_ctx.getExecutionDateTime().month);
@@ -266,9 +266,9 @@ describe('TimeOfDay', () => {
     setup(this, data);
   });
 
-  it('should return all date components representing now', function () {
+  it('should return all date components representing now', async function () {
     const jsDate = new Date();
-    const tod = this.timeOfDayVar.exec(this.ctx);
+    const tod = await this.timeOfDayVar.exec(this.ctx);
     tod.isTime().should.be.true();
     tod.year.should.equal(0);
     tod.month.should.equal(1);
@@ -286,36 +286,36 @@ describe('DateTimeComponentFrom', () => {
     setup(this, data);
   });
 
-  it('should return the year from the date', function () {
-    this.year.exec(this.ctx).should.equal(2000);
+  it('should return the year from the date', async function () {
+    (await this.year.exec(this.ctx)).should.equal(2000);
   });
 
-  it('should return the month from the date', function () {
-    this.month.exec(this.ctx).should.equal(3);
+  it('should return the month from the date', async function () {
+    (await this.month.exec(this.ctx)).should.equal(3);
   });
 
-  it('should return the day from the date', function () {
-    this.day.exec(this.ctx).should.equal(15);
+  it('should return the day from the date', async function () {
+    (await this.day.exec(this.ctx)).should.equal(15);
   });
 
-  it('should return the hour from the date', function () {
-    this.hour.exec(this.ctx).should.equal(13);
+  it('should return the hour from the date', async function () {
+    (await this.hour.exec(this.ctx)).should.equal(13);
   });
 
-  it('should return the minute from the date', function () {
-    this.minute.exec(this.ctx).should.equal(30);
+  it('should return the minute from the date', async function () {
+    (await this.minute.exec(this.ctx)).should.equal(30);
   });
 
-  it('should return the second from the date', function () {
-    this.second.exec(this.ctx).should.equal(25);
+  it('should return the second from the date', async function () {
+    (await this.second.exec(this.ctx)).should.equal(25);
   });
 
-  it('should return the millisecond from the date', function () {
-    this.millisecond.exec(this.ctx).should.equal(200);
+  it('should return the millisecond from the date', async function () {
+    (await this.millisecond.exec(this.ctx)).should.equal(200);
   });
 
-  it('should return null for imprecise components', function () {
-    const result = this.impreciseComponentTuple.exec(this.ctx);
+  it('should return null for imprecise components', async function () {
+    const result = await this.impreciseComponentTuple.exec(this.ctx);
     result.should.eql({
       Year: 2000,
       Month: 3,
@@ -327,8 +327,8 @@ describe('DateTimeComponentFrom', () => {
     });
   });
 
-  it('should return null for null date', function () {
-    should(this.nullDate.exec(this.ctx)).be.null();
+  it('should return null for null date', async function () {
+    should(await this.nullDate.exec(this.ctx)).be.null();
   });
 });
 
@@ -337,8 +337,8 @@ describe('DateFrom', () => {
     setup(this, data);
   });
 
-  it('should return the date from a fully defined DateTime', function () {
-    const date = this.date.exec(this.ctx);
+  it('should return the date from a fully defined DateTime', async function () {
+    const date = await this.date.exec(this.ctx);
     date.year.should.equal(2000);
     date.month.should.equal(3);
     date.day.should.equal(15);
@@ -349,8 +349,8 @@ describe('DateFrom', () => {
     should.not.exist(date.millisecond);
   });
 
-  it('should return the defined date components from an imprecise date', function () {
-    const date = this.impreciseDate.exec(this.ctx);
+  it('should return the defined date components from an imprecise date', async function () {
+    const date = await this.impreciseDate.exec(this.ctx);
     date.year.should.equal(2000);
     should.not.exist(date.month);
     should.not.exist(date.day);
@@ -360,8 +360,8 @@ describe('DateFrom', () => {
     should.not.exist(date.millisecond);
   });
 
-  it('should return null for null date', function () {
-    should(this.nullDate.exec(this.ctx)).be.null();
+  it('should return null for null date', async function () {
+    should(await this.nullDate.exec(this.ctx)).be.null();
   });
 });
 
@@ -370,8 +370,8 @@ describe('TimeFrom', () => {
     setup(this, data);
   });
 
-  it('should return the time from a fully defined DateTime (and date should be lowest expressible date)', function () {
-    const time = this.time.exec(this.ctx);
+  it('should return the time from a fully defined DateTime (and date should be lowest expressible date)', async function () {
+    const time = await this.time.exec(this.ctx);
     time.year.should.equal(0);
     time.month.should.equal(1);
     time.day.should.equal(1);
@@ -382,8 +382,8 @@ describe('TimeFrom', () => {
     should(time.timezoneOffset).be.null();
   });
 
-  it('should return the null time components from a date with no time', function () {
-    const noTime = this.noTime.exec(this.ctx);
+  it('should return the null time components from a date with no time', async function () {
+    const noTime = await this.noTime.exec(this.ctx);
     noTime.year.should.equal(0);
     noTime.month.should.equal(1);
     noTime.day.should.equal(1);
@@ -394,8 +394,8 @@ describe('TimeFrom', () => {
     should(noTime.timezoneOffset).be.null();
   });
 
-  it('should return null for null date', function () {
-    should(this.nullDate.exec(this.ctx)).be.null();
+  it('should return null for null date', async function () {
+    should(await this.nullDate.exec(this.ctx)).be.null();
   });
 });
 
@@ -404,17 +404,19 @@ describe('TimezoneOffsetFrom', () => {
     setup(this, data);
   });
 
-  it('should return the timezoneoffset from a fully defined DateTime', function () {
-    this.centralEuropean.exec(this.ctx).should.equal(1);
-    this.easternStandard.exec(this.ctx).should.equal(-5);
+  it('should return the timezoneoffset from a fully defined DateTime', async function () {
+    (await this.centralEuropean.exec(this.ctx)).should.equal(1);
+    (await this.easternStandard.exec(this.ctx)).should.equal(-5);
   });
 
-  it('should return the default timezone when not specified', function () {
-    this.defaultTimezone.exec(this.ctx).should.equal((new Date().getTimezoneOffset() / 60) * -1);
+  it('should return the default timezone when not specified', async function () {
+    (await this.defaultTimezone.exec(this.ctx)).should.equal(
+      (new Date().getTimezoneOffset() / 60) * -1
+    );
   });
 
-  it('should return null for null date', function () {
-    should(this.nullDate.exec(this.ctx)).be.null();
+  it('should return null for null date', async function () {
+    should(await this.nullDate.exec(this.ctx)).be.null();
   });
 });
 
@@ -423,66 +425,66 @@ describe('SameAs', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is the same', function () {
-    this.sameYear.exec(this.ctx).should.be.true();
-    this.notSameYear.exec(this.ctx).should.be.false();
+  it('should properly determine when year is the same', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.true();
+    (await this.notSameYear.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when month is the same', function () {
-    this.sameMonth.exec(this.ctx).should.be.true();
-    this.notSameMonth.exec(this.ctx).should.be.false();
-    this.sameMonthWrongYear.exec(this.ctx).should.be.false();
+  it('should properly determine when month is the same', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.true();
+    (await this.notSameMonth.exec(this.ctx)).should.be.false();
+    (await this.sameMonthWrongYear.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when day is the same', function () {
-    this.sameDay.exec(this.ctx).should.be.true();
-    this.notSameDay.exec(this.ctx).should.be.false();
-    this.sameDayWrongMonth.exec(this.ctx).should.be.false();
+  it('should properly determine when day is the same', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.true();
+    (await this.notSameDay.exec(this.ctx)).should.be.false();
+    (await this.sameDayWrongMonth.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when hour is the same', function () {
-    this.sameHour.exec(this.ctx).should.be.true();
-    this.notSameHour.exec(this.ctx).should.be.false();
-    this.sameHourWrongDay.exec(this.ctx).should.be.false();
+  it('should properly determine when hour is the same', async function () {
+    (await this.sameHour.exec(this.ctx)).should.be.true();
+    (await this.notSameHour.exec(this.ctx)).should.be.false();
+    (await this.sameHourWrongDay.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when minute is the same', function () {
-    this.sameMinute.exec(this.ctx).should.be.true();
-    this.notSameMinute.exec(this.ctx).should.be.false();
-    this.sameMinuteWrongHour.exec(this.ctx).should.be.false();
+  it('should properly determine when minute is the same', async function () {
+    (await this.sameMinute.exec(this.ctx)).should.be.true();
+    (await this.notSameMinute.exec(this.ctx)).should.be.false();
+    (await this.sameMinuteWrongHour.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when second is the same', function () {
-    this.sameSecond.exec(this.ctx).should.be.true();
-    this.notSameSecond.exec(this.ctx).should.be.false();
-    this.sameSecondWrongMinute.exec(this.ctx).should.be.false();
+  it('should properly determine when second is the same', async function () {
+    (await this.sameSecond.exec(this.ctx)).should.be.true();
+    (await this.notSameSecond.exec(this.ctx)).should.be.false();
+    (await this.sameSecondWrongMinute.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when millisecond is the same', function () {
-    this.sameMillisecond.exec(this.ctx).should.be.true();
-    this.notSameMillisecond.exec(this.ctx).should.be.false();
-    this.sameMillisecondWrongSecond.exec(this.ctx).should.be.false();
+  it('should properly determine when millisecond is the same', async function () {
+    (await this.sameMillisecond.exec(this.ctx)).should.be.true();
+    (await this.notSameMillisecond.exec(this.ctx)).should.be.false();
+    (await this.sameMillisecondWrongSecond.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine same as using milliseconds', function () {
-    this.same.exec(this.ctx).should.be.true();
-    this.notSame.exec(this.ctx).should.be.false();
+  it('should properly determine same as using milliseconds', async function () {
+    (await this.same.exec(this.ctx)).should.be.true();
+    (await this.notSame.exec(this.ctx)).should.be.false();
   });
 
-  it('should normalize timezones when determining sameness', function () {
-    this.sameNormalized.exec(this.ctx).should.be.true();
-    this.sameHourWrongTimezone.exec(this.ctx).should.be.false();
+  it('should normalize timezones when determining sameness', async function () {
+    (await this.sameNormalized.exec(this.ctx)).should.be.true();
+    (await this.sameHourWrongTimezone.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseHour.exec(this.ctx)).be.null();
-    this.impreciseHourWrongDay.exec(this.ctx).should.be.false();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseHour.exec(this.ctx)).be.null();
+    (await this.impreciseHourWrongDay.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 });
 
@@ -491,94 +493,94 @@ describe('SameOrAfter', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is same or after', function () {
-    this.sameYear.exec(this.ctx).should.be.true();
-    this.yearAfter.exec(this.ctx).should.be.true();
-    this.yearBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when year is same or after', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.true();
+    (await this.yearAfter.exec(this.ctx)).should.be.true();
+    (await this.yearBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when month is same or after', function () {
-    this.sameMonth.exec(this.ctx).should.be.true();
-    this.monthAfter.exec(this.ctx).should.be.true();
-    this.monthBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when month is same or after', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.true();
+    (await this.monthAfter.exec(this.ctx)).should.be.true();
+    (await this.monthBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when day is same or after', function () {
-    this.sameDay.exec(this.ctx).should.be.true();
-    this.dayAfter.exec(this.ctx).should.be.true();
-    this.dayBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when day is same or after', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.true();
+    (await this.dayAfter.exec(this.ctx)).should.be.true();
+    (await this.dayBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when hour is same or after', function () {
-    this.sameHour.exec(this.ctx).should.be.true();
-    this.hourAfter.exec(this.ctx).should.be.true();
-    this.hourBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when hour is same or after', async function () {
+    (await this.sameHour.exec(this.ctx)).should.be.true();
+    (await this.hourAfter.exec(this.ctx)).should.be.true();
+    (await this.hourBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when minute is same or after', function () {
-    this.sameMinute.exec(this.ctx).should.be.true();
-    this.minuteAfter.exec(this.ctx).should.be.true();
-    this.minuteBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when minute is same or after', async function () {
+    (await this.sameMinute.exec(this.ctx)).should.be.true();
+    (await this.minuteAfter.exec(this.ctx)).should.be.true();
+    (await this.minuteBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when second is same or after', function () {
-    this.sameSecond.exec(this.ctx).should.be.true();
-    this.secondAfter.exec(this.ctx).should.be.true();
-    this.secondBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when second is same or after', async function () {
+    (await this.sameSecond.exec(this.ctx)).should.be.true();
+    (await this.secondAfter.exec(this.ctx)).should.be.true();
+    (await this.secondBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when millisecond is same or after', function () {
-    this.sameMillisecond.exec(this.ctx).should.be.true();
-    this.millisecondAfter.exec(this.ctx).should.be.true();
-    this.millisecondBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when millisecond is same or after', async function () {
+    (await this.sameMillisecond.exec(this.ctx)).should.be.true();
+    (await this.millisecondAfter.exec(this.ctx)).should.be.true();
+    (await this.millisecondBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine same or after using ms when no precision defined', function () {
-    this.same.exec(this.ctx).should.be.true();
-    this.after.exec(this.ctx).should.be.true();
-    this.before.exec(this.ctx).should.be.false();
+  it('should properly determine same or after using ms when no precision defined', async function () {
+    (await this.same.exec(this.ctx)).should.be.true();
+    (await this.after.exec(this.ctx)).should.be.true();
+    (await this.before.exec(this.ctx)).should.be.false();
   });
 
-  it('should consider precision units above the specified unit', function () {
-    this.sameDayMonthBefore.exec(this.ctx).should.be.false();
-    this.dayAfterMonthBefore.exec(this.ctx).should.be.false();
-    this.dayBeforeMonthAfter.exec(this.ctx).should.be.true();
+  it('should consider precision units above the specified unit', async function () {
+    (await this.sameDayMonthBefore.exec(this.ctx)).should.be.false();
+    (await this.dayAfterMonthBefore.exec(this.ctx)).should.be.false();
+    (await this.dayBeforeMonthAfter.exec(this.ctx)).should.be.true();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseDay.exec(this.ctx)).be.null();
-    this.impreciseDayMonthAfter.exec(this.ctx).should.be.true();
-    this.impreciseDayMonthBefore.exec(this.ctx).should.be.false();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseDay.exec(this.ctx)).be.null();
+    (await this.impreciseDayMonthAfter.exec(this.ctx)).should.be.true();
+    (await this.impreciseDayMonthBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should normalize timezones', function () {
-    this.sameHourNormalizeZones.exec(this.ctx).should.be.true();
-    this.hourAfterNormalizeZones.exec(this.ctx).should.be.true();
-    this.hourBeforeNormalizeZones.exec(this.ctx).should.be.false();
+  it('should normalize timezones', async function () {
+    (await this.sameHourNormalizeZones.exec(this.ctx)).should.be.true();
+    (await this.hourAfterNormalizeZones.exec(this.ctx)).should.be.true();
+    (await this.hourBeforeNormalizeZones.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 
-  it('should properly treat "on or after" the same as "same or after"', function () {
-    this.sameOOA.exec(this.ctx).should.be.true();
-    this.afterOOA.exec(this.ctx).should.be.true();
-    this.beforeOOA.exec(this.ctx).should.be.false();
-    should(this.nullLeftOOA.exec(this.ctx)).be.null();
-    should(this.nullRightOOA.exec(this.ctx)).be.null();
-    should(this.nullBothOOA.exec(this.ctx)).be.null();
+  it('should properly treat "on or after" the same as "same or after"', async function () {
+    (await this.sameOOA.exec(this.ctx)).should.be.true();
+    (await this.afterOOA.exec(this.ctx)).should.be.true();
+    (await this.beforeOOA.exec(this.ctx)).should.be.false();
+    should(await this.nullLeftOOA.exec(this.ctx)).be.null();
+    should(await this.nullRightOOA.exec(this.ctx)).be.null();
+    should(await this.nullBothOOA.exec(this.ctx)).be.null();
   });
 
-  it('should properly treat "after or on" the same as "same or after"', function () {
-    this.sameAOO.exec(this.ctx).should.be.true();
-    this.afterAOO.exec(this.ctx).should.be.true();
-    this.beforeAOO.exec(this.ctx).should.be.false();
-    should(this.nullLeftAOO.exec(this.ctx)).be.null();
-    should(this.nullRightAOO.exec(this.ctx)).be.null();
-    should(this.nullBothAOO.exec(this.ctx)).be.null();
+  it('should properly treat "after or on" the same as "same or after"', async function () {
+    (await this.sameAOO.exec(this.ctx)).should.be.true();
+    (await this.afterAOO.exec(this.ctx)).should.be.true();
+    (await this.beforeAOO.exec(this.ctx)).should.be.false();
+    should(await this.nullLeftAOO.exec(this.ctx)).be.null();
+    should(await this.nullRightAOO.exec(this.ctx)).be.null();
+    should(await this.nullBothAOO.exec(this.ctx)).be.null();
   });
 });
 
@@ -587,94 +589,94 @@ describe('SameOrBefore', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is same or after', function () {
-    this.sameYear.exec(this.ctx).should.be.true();
-    this.yearAfter.exec(this.ctx).should.be.false();
-    this.yearBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when year is same or after', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.true();
+    (await this.yearAfter.exec(this.ctx)).should.be.false();
+    (await this.yearBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when month is same or after', function () {
-    this.sameMonth.exec(this.ctx).should.be.true();
-    this.monthAfter.exec(this.ctx).should.be.false();
-    this.monthBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when month is same or after', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.true();
+    (await this.monthAfter.exec(this.ctx)).should.be.false();
+    (await this.monthBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when day is same or after', function () {
-    this.sameDay.exec(this.ctx).should.be.true();
-    this.dayAfter.exec(this.ctx).should.be.false();
-    this.dayBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when day is same or after', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.true();
+    (await this.dayAfter.exec(this.ctx)).should.be.false();
+    (await this.dayBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when hour is same or after', function () {
-    this.sameHour.exec(this.ctx).should.be.true();
-    this.hourAfter.exec(this.ctx).should.be.false();
-    this.hourBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when hour is same or after', async function () {
+    (await this.sameHour.exec(this.ctx)).should.be.true();
+    (await this.hourAfter.exec(this.ctx)).should.be.false();
+    (await this.hourBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when minute is same or after', function () {
-    this.sameMinute.exec(this.ctx).should.be.true();
-    this.minuteAfter.exec(this.ctx).should.be.false();
-    this.minuteBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when minute is same or after', async function () {
+    (await this.sameMinute.exec(this.ctx)).should.be.true();
+    (await this.minuteAfter.exec(this.ctx)).should.be.false();
+    (await this.minuteBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when second is same or after', function () {
-    this.sameSecond.exec(this.ctx).should.be.true();
-    this.secondAfter.exec(this.ctx).should.be.false();
-    this.secondBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when second is same or after', async function () {
+    (await this.sameSecond.exec(this.ctx)).should.be.true();
+    (await this.secondAfter.exec(this.ctx)).should.be.false();
+    (await this.secondBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when millisecond is same or after', function () {
-    this.sameMillisecond.exec(this.ctx).should.be.true();
-    this.millisecondAfter.exec(this.ctx).should.be.false();
-    this.millisecondBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when millisecond is same or after', async function () {
+    (await this.sameMillisecond.exec(this.ctx)).should.be.true();
+    (await this.millisecondAfter.exec(this.ctx)).should.be.false();
+    (await this.millisecondBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine same or after using ms when no precision defined', function () {
-    this.same.exec(this.ctx).should.be.true();
-    this.after.exec(this.ctx).should.be.false();
-    this.before.exec(this.ctx).should.be.true();
+  it('should properly determine same or after using ms when no precision defined', async function () {
+    (await this.same.exec(this.ctx)).should.be.true();
+    (await this.after.exec(this.ctx)).should.be.false();
+    (await this.before.exec(this.ctx)).should.be.true();
   });
 
-  it('should consider precision units above the specified unit', function () {
-    this.sameDayMonthBefore.exec(this.ctx).should.be.true();
-    this.dayAfterMonthBefore.exec(this.ctx).should.be.true();
-    this.dayBeforeMonthAfter.exec(this.ctx).should.be.false();
+  it('should consider precision units above the specified unit', async function () {
+    (await this.sameDayMonthBefore.exec(this.ctx)).should.be.true();
+    (await this.dayAfterMonthBefore.exec(this.ctx)).should.be.true();
+    (await this.dayBeforeMonthAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseDay.exec(this.ctx)).be.null();
-    this.impreciseDayMonthAfter.exec(this.ctx).should.be.false();
-    this.impreciseDayMonthBefore.exec(this.ctx).should.be.true();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseDay.exec(this.ctx)).be.null();
+    (await this.impreciseDayMonthAfter.exec(this.ctx)).should.be.false();
+    (await this.impreciseDayMonthBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should normalize timezones', function () {
-    this.sameHourNormalizeZones.exec(this.ctx).should.be.true();
-    this.hourAfterNormalizeZones.exec(this.ctx).should.be.false();
-    this.hourBeforeNormalizeZones.exec(this.ctx).should.be.true();
+  it('should normalize timezones', async function () {
+    (await this.sameHourNormalizeZones.exec(this.ctx)).should.be.true();
+    (await this.hourAfterNormalizeZones.exec(this.ctx)).should.be.false();
+    (await this.hourBeforeNormalizeZones.exec(this.ctx)).should.be.true();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 
-  it('should properly treat "on or before" the same as "same or before"', function () {
-    this.sameOOB.exec(this.ctx).should.be.true();
-    this.afterOOB.exec(this.ctx).should.be.false();
-    this.beforeOOB.exec(this.ctx).should.be.true();
-    should(this.nullLeftOOB.exec(this.ctx)).be.null();
-    should(this.nullRightOOB.exec(this.ctx)).be.null();
-    should(this.nullBothOOB.exec(this.ctx)).be.null();
+  it('should properly treat "on or before" the same as "same or before"', async function () {
+    (await this.sameOOB.exec(this.ctx)).should.be.true();
+    (await this.afterOOB.exec(this.ctx)).should.be.false();
+    (await this.beforeOOB.exec(this.ctx)).should.be.true();
+    should(await this.nullLeftOOB.exec(this.ctx)).be.null();
+    should(await this.nullRightOOB.exec(this.ctx)).be.null();
+    should(await this.nullBothOOB.exec(this.ctx)).be.null();
   });
 
-  it('should properly treat "before or on" the same as "same or before"', function () {
-    this.sameBOO.exec(this.ctx).should.be.true();
-    this.afterBOO.exec(this.ctx).should.be.false();
-    this.beforeBOO.exec(this.ctx).should.be.true();
-    should(this.nullLeftBOO.exec(this.ctx)).be.null();
-    should(this.nullRightBOO.exec(this.ctx)).be.null();
-    should(this.nullBothBOO.exec(this.ctx)).be.null();
+  it('should properly treat "before or on" the same as "same or before"', async function () {
+    (await this.sameBOO.exec(this.ctx)).should.be.true();
+    (await this.afterBOO.exec(this.ctx)).should.be.false();
+    (await this.beforeBOO.exec(this.ctx)).should.be.true();
+    should(await this.nullLeftBOO.exec(this.ctx)).be.null();
+    should(await this.nullRightBOO.exec(this.ctx)).be.null();
+    should(await this.nullBothBOO.exec(this.ctx)).be.null();
   });
 });
 
@@ -683,70 +685,70 @@ describe('After', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is same or after', function () {
-    this.sameYear.exec(this.ctx).should.be.false();
-    this.yearAfter.exec(this.ctx).should.be.true();
-    this.yearBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when year is same or after', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.false();
+    (await this.yearAfter.exec(this.ctx)).should.be.true();
+    (await this.yearBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when month is same or after', function () {
-    this.sameMonth.exec(this.ctx).should.be.false();
-    this.monthAfter.exec(this.ctx).should.be.true();
-    this.monthBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when month is same or after', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.false();
+    (await this.monthAfter.exec(this.ctx)).should.be.true();
+    (await this.monthBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when day is same or after', function () {
-    this.sameDay.exec(this.ctx).should.be.false();
-    this.dayAfter.exec(this.ctx).should.be.true();
-    this.dayBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when day is same or after', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.false();
+    (await this.dayAfter.exec(this.ctx)).should.be.true();
+    (await this.dayBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when hour is same or after', function () {
-    this.sameHour.exec(this.ctx).should.be.false();
-    this.hourAfter.exec(this.ctx).should.be.true();
-    this.hourBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when hour is same or after', async function () {
+    (await this.sameHour.exec(this.ctx)).should.be.false();
+    (await this.hourAfter.exec(this.ctx)).should.be.true();
+    (await this.hourBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when minute is same or after', function () {
-    this.sameMinute.exec(this.ctx).should.be.false();
-    this.minuteAfter.exec(this.ctx).should.be.true();
-    this.minuteBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when minute is same or after', async function () {
+    (await this.sameMinute.exec(this.ctx)).should.be.false();
+    (await this.minuteAfter.exec(this.ctx)).should.be.true();
+    (await this.minuteBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when second is same or after', function () {
-    this.sameSecond.exec(this.ctx).should.be.false();
-    this.secondAfter.exec(this.ctx).should.be.true();
-    this.secondBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when second is same or after', async function () {
+    (await this.sameSecond.exec(this.ctx)).should.be.false();
+    (await this.secondAfter.exec(this.ctx)).should.be.true();
+    (await this.secondBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine when millisecond is same or after', function () {
-    this.sameMillisecond.exec(this.ctx).should.be.false();
-    this.millisecondAfter.exec(this.ctx).should.be.true();
-    this.millisecondBefore.exec(this.ctx).should.be.false();
+  it('should properly determine when millisecond is same or after', async function () {
+    (await this.sameMillisecond.exec(this.ctx)).should.be.false();
+    (await this.millisecondAfter.exec(this.ctx)).should.be.true();
+    (await this.millisecondBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine same or after using ms when no precision defined', function () {
-    this.same.exec(this.ctx).should.be.false();
-    this.after.exec(this.ctx).should.be.true();
-    this.before.exec(this.ctx).should.be.false();
+  it('should properly determine same or after using ms when no precision defined', async function () {
+    (await this.same.exec(this.ctx)).should.be.false();
+    (await this.after.exec(this.ctx)).should.be.true();
+    (await this.before.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseDay.exec(this.ctx)).be.null();
-    this.impreciseDayMonthAfter.exec(this.ctx).should.be.true();
-    this.impreciseDayMonthBefore.exec(this.ctx).should.be.false();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseDay.exec(this.ctx)).be.null();
+    (await this.impreciseDayMonthAfter.exec(this.ctx)).should.be.true();
+    (await this.impreciseDayMonthBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should normalize timezones', function () {
-    this.sameHourNormalizeZones.exec(this.ctx).should.be.false();
-    this.hourAfterNormalizeZones.exec(this.ctx).should.be.true();
-    this.hourBeforeNormalizeZones.exec(this.ctx).should.be.false();
+  it('should normalize timezones', async function () {
+    (await this.sameHourNormalizeZones.exec(this.ctx)).should.be.false();
+    (await this.hourAfterNormalizeZones.exec(this.ctx)).should.be.true();
+    (await this.hourBeforeNormalizeZones.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 });
 
@@ -755,70 +757,70 @@ describe('Before', () => {
     setup(this, data);
   });
 
-  it('should properly determine when year is same or after', function () {
-    this.sameYear.exec(this.ctx).should.be.false();
-    this.yearAfter.exec(this.ctx).should.be.false();
-    this.yearBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when year is same or after', async function () {
+    (await this.sameYear.exec(this.ctx)).should.be.false();
+    (await this.yearAfter.exec(this.ctx)).should.be.false();
+    (await this.yearBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when month is same or after', function () {
-    this.sameMonth.exec(this.ctx).should.be.false();
-    this.monthAfter.exec(this.ctx).should.be.false();
-    this.monthBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when month is same or after', async function () {
+    (await this.sameMonth.exec(this.ctx)).should.be.false();
+    (await this.monthAfter.exec(this.ctx)).should.be.false();
+    (await this.monthBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when day is same or after', function () {
-    this.sameDay.exec(this.ctx).should.be.false();
-    this.dayAfter.exec(this.ctx).should.be.false();
-    this.dayBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when day is same or after', async function () {
+    (await this.sameDay.exec(this.ctx)).should.be.false();
+    (await this.dayAfter.exec(this.ctx)).should.be.false();
+    (await this.dayBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when hour is same or after', function () {
-    this.sameHour.exec(this.ctx).should.be.false();
-    this.hourAfter.exec(this.ctx).should.be.false();
-    this.hourBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when hour is same or after', async function () {
+    (await this.sameHour.exec(this.ctx)).should.be.false();
+    (await this.hourAfter.exec(this.ctx)).should.be.false();
+    (await this.hourBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when minute is same or after', function () {
-    this.sameMinute.exec(this.ctx).should.be.false();
-    this.minuteAfter.exec(this.ctx).should.be.false();
-    this.minuteBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when minute is same or after', async function () {
+    (await this.sameMinute.exec(this.ctx)).should.be.false();
+    (await this.minuteAfter.exec(this.ctx)).should.be.false();
+    (await this.minuteBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when second is same or after', function () {
-    this.sameSecond.exec(this.ctx).should.be.false();
-    this.secondAfter.exec(this.ctx).should.be.false();
-    this.secondBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when second is same or after', async function () {
+    (await this.sameSecond.exec(this.ctx)).should.be.false();
+    (await this.secondAfter.exec(this.ctx)).should.be.false();
+    (await this.secondBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine when millisecond is same or after', function () {
-    this.sameMillisecond.exec(this.ctx).should.be.false();
-    this.millisecondAfter.exec(this.ctx).should.be.false();
-    this.millisecondBefore.exec(this.ctx).should.be.true();
+  it('should properly determine when millisecond is same or after', async function () {
+    (await this.sameMillisecond.exec(this.ctx)).should.be.false();
+    (await this.millisecondAfter.exec(this.ctx)).should.be.false();
+    (await this.millisecondBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should properly determine same or after using ms when no precision defined', function () {
-    this.same.exec(this.ctx).should.be.false();
-    this.after.exec(this.ctx).should.be.false();
-    this.before.exec(this.ctx).should.be.true();
+  it('should properly determine same or after using ms when no precision defined', async function () {
+    (await this.same.exec(this.ctx)).should.be.false();
+    (await this.after.exec(this.ctx)).should.be.false();
+    (await this.before.exec(this.ctx)).should.be.true();
   });
 
-  it('should handle imprecision', function () {
-    should(this.impreciseDay.exec(this.ctx)).be.null();
-    this.impreciseDayMonthAfter.exec(this.ctx).should.be.false();
-    this.impreciseDayMonthBefore.exec(this.ctx).should.be.true();
+  it('should handle imprecision', async function () {
+    should(await this.impreciseDay.exec(this.ctx)).be.null();
+    (await this.impreciseDayMonthAfter.exec(this.ctx)).should.be.false();
+    (await this.impreciseDayMonthBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should normalize timezones', function () {
-    this.sameHourNormalizeZones.exec(this.ctx).should.be.false();
-    this.hourAfterNormalizeZones.exec(this.ctx).should.be.false();
-    this.hourBeforeNormalizeZones.exec(this.ctx).should.be.true();
+  it('should normalize timezones', async function () {
+    (await this.sameHourNormalizeZones.exec(this.ctx)).should.be.false();
+    (await this.hourAfterNormalizeZones.exec(this.ctx)).should.be.false();
+    (await this.hourBeforeNormalizeZones.exec(this.ctx)).should.be.true();
   });
 
-  it('should return null when either argument is null', function () {
-    should(this.nullLeft.exec(this.ctx)).be.null();
-    should(this.nullRight.exec(this.ctx)).be.null();
-    should(this.nullBoth.exec(this.ctx)).be.null();
+  it('should return null when either argument is null', async function () {
+    should(await this.nullLeft.exec(this.ctx)).be.null();
+    should(await this.nullRight.exec(this.ctx)).be.null();
+    should(await this.nullBoth.exec(this.ctx)).be.null();
   });
 });
 
@@ -827,86 +829,90 @@ describe('DifferenceBetween', () => {
     setup(this, data);
   });
 
-  it('should properly execute years between', function () {
-    this.yearsBetween.exec(this.ctx).should.equal(1);
+  it('should properly execute years between', async function () {
+    (await this.yearsBetween.exec(this.ctx)).should.equal(1);
   });
 
-  it('should properly execute months between', function () {
-    this.monthsBetween.exec(this.ctx).should.equal(12);
+  it('should properly execute months between', async function () {
+    (await this.monthsBetween.exec(this.ctx)).should.equal(12);
   });
 
-  it('should properly execute weeks between', function () {
-    this.weeksBetween.exec(this.ctx).should.equal(52);
+  it('should properly execute weeks between', async function () {
+    (await this.weeksBetween.exec(this.ctx)).should.equal(52);
   });
 
-  it('should properly execute days between', function () {
-    this.daysBetween.exec(this.ctx).should.equal(365);
+  it('should properly execute days between', async function () {
+    (await this.daysBetween.exec(this.ctx)).should.equal(365);
   });
 
-  it('should properly execute hours between', function () {
-    this.hoursBetween.exec(this.ctx).should.equal(24 * 365);
+  it('should properly execute hours between', async function () {
+    (await this.hoursBetween.exec(this.ctx)).should.equal(24 * 365);
   });
 
-  it('should properly execute minutes between', function () {
-    this.minutesBetween.exec(this.ctx).should.equal(60 * 24 * 365);
+  it('should properly execute minutes between', async function () {
+    (await this.minutesBetween.exec(this.ctx)).should.equal(60 * 24 * 365);
   });
 
-  it('should properly execute seconds between', function () {
-    this.secondsBetween.exec(this.ctx).should.equal(60 * 60 * 24 * 365);
+  it('should properly execute seconds between', async function () {
+    (await this.secondsBetween.exec(this.ctx)).should.equal(60 * 60 * 24 * 365);
   });
 
-  it('should properly execute milliseconds between', function () {
-    this.millisecondsBetween.exec(this.ctx).should.equal(1000 * 60 * 60 * 24 * 365);
+  it('should properly execute milliseconds between', async function () {
+    (await this.millisecondsBetween.exec(this.ctx)).should.equal(1000 * 60 * 60 * 24 * 365);
   });
 
-  it('should properly execute milliseconds between when date 1 is after date 2', function () {
-    this.millisecondsBetweenReversed.exec(this.ctx).should.equal(-1 * 1000 * 60 * 60 * 24 * 365);
+  it('should properly execute milliseconds between when date 1 is after date 2', async function () {
+    (await this.millisecondsBetweenReversed.exec(this.ctx)).should.equal(
+      -1 * 1000 * 60 * 60 * 24 * 365
+    );
   });
 
-  it('should properly execute years between with an uncertainty', function () {
-    this.yearsBetweenUncertainty.exec(this.ctx).should.equal(0);
+  it('should properly execute years between with an uncertainty', async function () {
+    (await this.yearsBetweenUncertainty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should properly execute months between with an uncertainty', function () {
-    this.monthsBetweenUncertainty.exec(this.ctx).should.equal(0);
+  it('should properly execute months between with an uncertainty', async function () {
+    (await this.monthsBetweenUncertainty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should properly execute weeks between with an uncertainty', function () {
-    this.weeksBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 4));
+  it('should properly execute weeks between with an uncertainty', async function () {
+    (await this.weeksBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 4));
   });
 
-  it('should properly execute days between with an uncertainty', function () {
-    this.daysBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 30));
+  it('should properly execute days between with an uncertainty', async function () {
+    (await this.daysBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 30));
   });
 
-  it('should properly execute hours between with an uncertainty', function () {
-    this.hoursBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 743));
+  it('should properly execute hours between with an uncertainty', async function () {
+    (await this.hoursBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 743));
   });
 
-  it('should properly execute minutes between with an uncertainty', function () {
-    this.minutesBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 44639));
+  it('should properly execute minutes between with an uncertainty', async function () {
+    (await this.minutesBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 44639));
   });
 
-  it('should properly execute seconds between with an uncertainty', function () {
-    this.secondsBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 2678399));
+  it('should properly execute seconds between with an uncertainty', async function () {
+    (await this.secondsBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 2678399));
   });
 
-  it('should properly execute milliseconds between with an uncertainty', function () {
-    this.millisecondsBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 2678399999));
+  it('should properly execute milliseconds between with an uncertainty', async function () {
+    (await this.millisecondsBetweenUncertainty.exec(this.ctx)).should.eql(
+      new Uncertainty(0, 2678399999)
+    );
   });
 
-  it('should properly execute seconds between when date 1 is after date 2 with an uncertainty', function () {
-    this.millisecondsBetweenReversedUncertainty
-      .exec(this.ctx)
-      .should.eql(new Uncertainty(-2678399999, 0));
+  it('should properly execute seconds between when date 1 is after date 2 with an uncertainty', async function () {
+    (await this.millisecondsBetweenReversedUncertainty.exec(this.ctx)).should.eql(
+      new Uncertainty(-2678399999, 0)
+    );
   });
 
-  it('should properly execute hours between when springing ahead for DST', function () {
-    this.hoursBetween1and3CrossingSpringDST.exec(this.ctx).should.equal(1);
+  it('should properly execute hours between when springing ahead for DST', async function () {
+    (await this.hoursBetween1and3CrossingSpringDST.exec(this.ctx)).should.equal(1);
   });
 
-  it('should properly execute hours between when falling back for DST', function () {
-    this.hoursBetween1and3CrossingFallDST.exec(this.ctx).should.equal(3);
+  it('should properly execute hours between when falling back for DST', async function () {
+    (await this.hoursBetween1and3CrossingFallDST.exec(this.ctx)).should.equal(3);
   });
 });
 
@@ -915,49 +921,49 @@ describe('DifferenceBetween Comparisons', () => {
     setup(this, data);
   });
 
-  it('should calculate days between > x', function () {
-    this.greaterThan25DaysAfter.exec(this.ctx).should.be.true();
-    should(this.greaterThan40DaysAfter.exec(this.ctx)).be.null();
-    this.greaterThan80DaysAfter.exec(this.ctx).should.be.false();
+  it('should calculate days between > x', async function () {
+    (await this.greaterThan25DaysAfter.exec(this.ctx)).should.be.true();
+    should(await this.greaterThan40DaysAfter.exec(this.ctx)).be.null();
+    (await this.greaterThan80DaysAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate days between >= x', function () {
-    this.greaterOrEqualTo25DaysAfter.exec(this.ctx).should.be.true();
-    should(this.greaterOrEqualTo40DaysAfter.exec(this.ctx)).be.null();
-    this.greaterOrEqualTo80DaysAfter.exec(this.ctx).should.be.false();
+  it('should calculate days between >= x', async function () {
+    (await this.greaterOrEqualTo25DaysAfter.exec(this.ctx)).should.be.true();
+    should(await this.greaterOrEqualTo40DaysAfter.exec(this.ctx)).be.null();
+    (await this.greaterOrEqualTo80DaysAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate days between = x', function () {
-    this.equalTo25DaysAfter.exec(this.ctx).should.be.false();
-    should(this.equalTo40DaysAfter.exec(this.ctx)).be.null();
-    this.equalTo80DaysAfter.exec(this.ctx).should.be.false();
+  it('should calculate days between = x', async function () {
+    (await this.equalTo25DaysAfter.exec(this.ctx)).should.be.false();
+    should(await this.equalTo40DaysAfter.exec(this.ctx)).be.null();
+    (await this.equalTo80DaysAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate days between <= x', function () {
-    this.lessOrEqualTo25DaysAfter.exec(this.ctx).should.be.false();
-    should(this.lessOrEqualTo40DaysAfter.exec(this.ctx)).be.null();
-    this.lessOrEqualTo80DaysAfter.exec(this.ctx).should.be.true();
+  it('should calculate days between <= x', async function () {
+    (await this.lessOrEqualTo25DaysAfter.exec(this.ctx)).should.be.false();
+    should(await this.lessOrEqualTo40DaysAfter.exec(this.ctx)).be.null();
+    (await this.lessOrEqualTo80DaysAfter.exec(this.ctx)).should.be.true();
   });
 
-  it('should calculate days between < x', function () {
-    this.lessThan25DaysAfter.exec(this.ctx).should.be.false();
-    should(this.lessThan40DaysAfter.exec(this.ctx)).be.null();
-    this.lessThan80DaysAfter.exec(this.ctx).should.be.true();
+  it('should calculate days between < x', async function () {
+    (await this.lessThan25DaysAfter.exec(this.ctx)).should.be.false();
+    should(await this.lessThan40DaysAfter.exec(this.ctx)).be.null();
+    (await this.lessThan80DaysAfter.exec(this.ctx)).should.be.true();
   });
 
-  it('should calculate other way too', function () {
-    this.twentyFiveDaysLessThanDaysBetween.exec(this.ctx).should.be.true();
-    should(this.fortyDaysEqualToDaysBetween.exec(this.ctx)).be.null();
-    this.twentyFiveDaysGreaterThanDaysBetween.exec(this.ctx).should.be.false();
+  it('should calculate other way too', async function () {
+    (await this.twentyFiveDaysLessThanDaysBetween.exec(this.ctx)).should.be.true();
+    should(await this.fortyDaysEqualToDaysBetween.exec(this.ctx)).be.null();
+    (await this.twentyFiveDaysGreaterThanDaysBetween.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine that Sep to Dec is NOT <= 2 months', function () {
-    this.bonnieTestCase.exec(this.ctx).should.be.false();
+  it('should properly determine that Sep to Dec is NOT <= 2 months', async function () {
+    (await this.bonnieTestCase.exec(this.ctx)).should.be.false();
   });
 
-  it('should properly determine that Sep to Dec is NOT <= 2 months with 0 timezone offset (Zulu)', function () {
+  it('should properly determine that Sep to Dec is NOT <= 2 months with 0 timezone offset (Zulu)', async function () {
     // THIS for some reason is BROKEN!
-    this.bonnieTestCaseZulu.exec(this.ctx).should.be.false();
+    (await this.bonnieTestCaseZulu.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -966,90 +972,94 @@ describe('DurationBetween', () => {
     setup(this, data);
   });
 
-  it('should properly execute years between', function () {
-    this.yearsBetween.exec(this.ctx).should.equal(1);
+  it('should properly execute years between', async function () {
+    (await this.yearsBetween.exec(this.ctx)).should.equal(1);
   });
 
-  it('should properly execute months between', function () {
-    this.monthsBetween.exec(this.ctx).should.equal(12);
+  it('should properly execute months between', async function () {
+    (await this.monthsBetween.exec(this.ctx)).should.equal(12);
   });
 
-  it('should properly execute days between', function () {
-    this.daysBetween.exec(this.ctx).should.equal(365 + 21);
+  it('should properly execute days between', async function () {
+    (await this.daysBetween.exec(this.ctx)).should.equal(365 + 21);
   });
 
-  it('should properly execute weeks between', function () {
-    this.weeksBetween.exec(this.ctx).should.equal(55);
+  it('should properly execute weeks between', async function () {
+    (await this.weeksBetween.exec(this.ctx)).should.equal(55);
   });
 
-  it('should properly execute hours between', function () {
-    this.hoursBetween.exec(this.ctx).should.equal(24 * (365 + 21) + 11);
+  it('should properly execute hours between', async function () {
+    (await this.hoursBetween.exec(this.ctx)).should.equal(24 * (365 + 21) + 11);
   });
 
-  it('should properly execute minutes between', function () {
-    this.minutesBetween.exec(this.ctx).should.equal(60 * (24 * (365 + 21) + 11) + 29);
+  it('should properly execute minutes between', async function () {
+    (await this.minutesBetween.exec(this.ctx)).should.equal(60 * (24 * (365 + 21) + 11) + 29);
   });
 
-  it('should properly execute seconds between', function () {
-    this.secondsBetween.exec(this.ctx).should.equal(60 * (60 * (24 * (365 + 21) + 11) + 29) + 29);
+  it('should properly execute seconds between', async function () {
+    (await this.secondsBetween.exec(this.ctx)).should.equal(
+      60 * (60 * (24 * (365 + 21) + 11) + 29) + 29
+    );
   });
 
-  it('should properly execute milliseconds between', function () {
-    this.millisecondsBetween
-      .exec(this.ctx)
-      .should.equal(1000 * (60 * (60 * (24 * (365 + 21) + 11) + 29) + 29) + 500);
+  it('should properly execute milliseconds between', async function () {
+    (await this.millisecondsBetween.exec(this.ctx)).should.equal(
+      1000 * (60 * (60 * (24 * (365 + 21) + 11) + 29) + 29) + 500
+    );
   });
 
-  it('should properly execute milliseconds between when date 1 is after date 2', function () {
-    this.millisecondsBetweenReversed
-      .exec(this.ctx)
-      .should.equal(-1 * 1000 * (60 * (60 * (24 * (365 + 21) + 11) + 29) + 29) - 500);
+  it('should properly execute milliseconds between when date 1 is after date 2', async function () {
+    (await this.millisecondsBetweenReversed.exec(this.ctx)).should.equal(
+      -1 * 1000 * (60 * (60 * (24 * (365 + 21) + 11) + 29) + 29) - 500
+    );
   });
 
-  it('should properly execute years between with an uncertainty', function () {
-    this.yearsBetweenUncertainty.exec(this.ctx).should.equal(0);
+  it('should properly execute years between with an uncertainty', async function () {
+    (await this.yearsBetweenUncertainty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should properly execute months between with an uncertainty', function () {
-    this.monthsBetweenUncertainty.exec(this.ctx).should.equal(0);
+  it('should properly execute months between with an uncertainty', async function () {
+    (await this.monthsBetweenUncertainty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should properly execute weeks between with an uncertainty', function () {
-    this.weeksBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 4));
+  it('should properly execute weeks between with an uncertainty', async function () {
+    (await this.weeksBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 4));
   });
 
-  it('should properly execute days between with an uncertainty', function () {
-    this.daysBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 30));
+  it('should properly execute days between with an uncertainty', async function () {
+    (await this.daysBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 30));
   });
 
-  it('should properly execute hours between with an uncertainty', function () {
-    this.hoursBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 743));
+  it('should properly execute hours between with an uncertainty', async function () {
+    (await this.hoursBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 743));
   });
 
-  it('should properly execute minutes between with an uncertainty', function () {
-    this.minutesBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 44639));
+  it('should properly execute minutes between with an uncertainty', async function () {
+    (await this.minutesBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 44639));
   });
 
-  it('should properly execute seconds between with an uncertainty', function () {
-    this.secondsBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 2678399));
+  it('should properly execute seconds between with an uncertainty', async function () {
+    (await this.secondsBetweenUncertainty.exec(this.ctx)).should.eql(new Uncertainty(0, 2678399));
   });
 
-  it('should properly execute milliseconds between with an uncertainty', function () {
-    this.millisecondsBetweenUncertainty.exec(this.ctx).should.eql(new Uncertainty(0, 2678399999));
+  it('should properly execute milliseconds between with an uncertainty', async function () {
+    (await this.millisecondsBetweenUncertainty.exec(this.ctx)).should.eql(
+      new Uncertainty(0, 2678399999)
+    );
   });
 
-  it('should properly execute seconds between when date 1 is after date 2 with an uncertainty', function () {
-    this.millisecondsBetweenReversedUncertainty
-      .exec(this.ctx)
-      .should.eql(new Uncertainty(-2678399999, 0));
+  it('should properly execute seconds between when date 1 is after date 2 with an uncertainty', async function () {
+    (await this.millisecondsBetweenReversedUncertainty.exec(this.ctx)).should.eql(
+      new Uncertainty(-2678399999, 0)
+    );
   });
 
-  it('should properly execute hours between when falling back for DST', function () {
-    this.hoursBetween1and3CrossingSpringDST.exec(this.ctx).should.equal(1);
+  it('should properly execute hours between when falling back for DST', async function () {
+    (await this.hoursBetween1and3CrossingSpringDST.exec(this.ctx)).should.equal(1);
   });
 
-  it('should properly execute hours between when springing ahead for DST', function () {
-    this.hoursBetween1and3CrossingFallDST.exec(this.ctx).should.equal(3);
+  it('should properly execute hours between when springing ahead for DST', async function () {
+    (await this.hoursBetween1and3CrossingFallDST.exec(this.ctx)).should.equal(3);
   });
 });
 
@@ -1058,59 +1068,59 @@ describe('DateMath', () => {
     setup(this, data);
   });
 
-  it('should properly add and subtract years', function () {
-    let d = this.plusThreeYears.exec(this.ctx);
+  it('should properly add and subtract years', async function () {
+    let d = await this.plusThreeYears.exec(this.ctx);
     dateCheck(d, 2016, 6, 15, 0, 0, 0, 0);
-    d = this.minusThreeYears.exec(this.ctx);
+    d = await this.minusThreeYears.exec(this.ctx);
     dateCheck(d, 2010, 6, 15, 0, 0, 0, 0);
   });
 
-  it('should properly add and subtract months', function () {
-    let d = this.plusEightMonths.exec(this.ctx);
+  it('should properly add and subtract months', async function () {
+    let d = await this.plusEightMonths.exec(this.ctx);
     dateCheck(d, 2014, 2, 15, 0, 0, 0, 0);
-    d = this.minusEightMonths.exec(this.ctx);
+    d = await this.minusEightMonths.exec(this.ctx);
     dateCheck(d, 2012, 10, 15, 0, 0, 0, 0);
   });
 
-  it('should properly add and subtract weeks', function () {
-    let d = this.plusThreeWeeks.exec(this.ctx);
+  it('should properly add and subtract weeks', async function () {
+    let d = await this.plusThreeWeeks.exec(this.ctx);
     dateCheck(d, 2013, 7, 6, 0, 0, 0, 0);
-    d = this.minusThreeWeeks.exec(this.ctx);
+    d = await this.minusThreeWeeks.exec(this.ctx);
     dateCheck(d, 2013, 5, 25, 0, 0, 0, 0);
   });
 
-  it('should properly add and subtract days', function () {
-    let d = this.plusTwentyDays.exec(this.ctx);
+  it('should properly add and subtract days', async function () {
+    let d = await this.plusTwentyDays.exec(this.ctx);
     dateCheck(d, 2013, 7, 5, 0, 0, 0, 0);
-    d = this.minusTwentyDays.exec(this.ctx);
+    d = await this.minusTwentyDays.exec(this.ctx);
     dateCheck(d, 2013, 5, 26, 0, 0, 0, 0);
   });
 
-  it('should properly add and subtract hours', function () {
-    let d = this.plusThreeHours.exec(this.ctx);
+  it('should properly add and subtract hours', async function () {
+    let d = await this.plusThreeHours.exec(this.ctx);
     dateCheck(d, 2013, 6, 15, 3, 0, 0, 0);
-    d = this.minusThreeHours.exec(this.ctx);
+    d = await this.minusThreeHours.exec(this.ctx);
     dateCheck(d, 2013, 6, 14, 21, 0, 0, 0);
   });
 
-  it('should properly add and subtract minutes', function () {
-    let d = this.plusThreeMinutes.exec(this.ctx);
+  it('should properly add and subtract minutes', async function () {
+    let d = await this.plusThreeMinutes.exec(this.ctx);
     dateCheck(d, 2013, 6, 15, 0, 3, 0, 0);
-    d = this.minusThreeMinutes.exec(this.ctx);
+    d = await this.minusThreeMinutes.exec(this.ctx);
     dateCheck(d, 2013, 6, 14, 23, 57, 0, 0);
   });
 
-  it('should properly add and subtract seconds', function () {
-    let d = this.plusThreeSeconds.exec(this.ctx);
+  it('should properly add and subtract seconds', async function () {
+    let d = await this.plusThreeSeconds.exec(this.ctx);
     dateCheck(d, 2013, 6, 15, 0, 0, 3, 0);
-    d = this.minusThreeSeconds.exec(this.ctx);
+    d = await this.minusThreeSeconds.exec(this.ctx);
     dateCheck(d, 2013, 6, 14, 23, 59, 57, 0);
   });
 
-  it('should properly add and subtract milliseconds', function () {
-    let d = this.plusThreeMilliseconds.exec(this.ctx);
+  it('should properly add and subtract milliseconds', async function () {
+    let d = await this.plusThreeMilliseconds.exec(this.ctx);
     dateCheck(d, 2013, 6, 15, 0, 0, 0, 3);
-    d = this.minusThreeMilliseconds.exec(this.ctx);
+    d = await this.minusThreeMilliseconds.exec(this.ctx);
     dateCheck(d, 2013, 6, 14, 23, 59, 59, 997);
   });
 });

--- a/test/elm/executor/executor-test.ts
+++ b/test/elm/executor/executor-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 
@@ -5,27 +6,27 @@ const { p1, p2 } = require('./patients');
 import { Patient } from '../../../src/cql-patient';
 
 describe('Age', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, data, [p1, p2]);
-    this.results = this.executor.withLibrary(this.lib).exec(this.patientSource);
+    this.results = await this.executor.withLibrary(this.lib).exec(this.patientSource);
   });
 
   it('should have correct patient results', function () {
-    this.results.patientResults['1'].Age.should.equal(32);
-    this.results.patientResults['2'].Age.should.equal(5);
+    should(this.results.patientResults['1'].Age).equal(32);
+    should(this.results.patientResults['2'].Age).equal(5);
   });
 
   it('should have correct patientEvaluatedRecords for each patient', function () {
-    this.results.patientEvaluatedRecords['1'].should.eql([new Patient(p1)]);
-    this.results.patientEvaluatedRecords['2'].should.eql([new Patient(p2)]);
+    should(this.results.patientEvaluatedRecords['1']).eql([new Patient(p1)]);
+    should(this.results.patientEvaluatedRecords['2']).eql([new Patient(p2)]);
   });
 
   it('should support older evaluatedRecords array field', function () {
-    this.results.evaluatedRecords.should.eql([new Patient(p1), new Patient(p2)]);
+    should(this.results.evaluatedRecords).eql([new Patient(p1), new Patient(p2)]);
   });
 
   it('should have the correct unfiltered results', function () {
-    this.results.unfilteredResults.AgeSum.should.equal(37);
+    should(this.results.unfilteredResults.AgeSum).equal(37);
   });
 
   it('should be able to reference other unfiltered context expressions', function () {

--- a/test/elm/external/external-test.ts
+++ b/test/elm/external/external-test.ts
@@ -9,8 +9,8 @@ describe('Retrieve', () => {
     setup(this, data, [p1], vsets, {}, new Repository(data));
   });
 
-  it('should find conditions', function () {
-    const c = this.conditions.exec(this.ctx);
+  it('should find conditions', async function () {
+    const c = await this.conditions.exec(this.ctx);
     c.should.have.length(2);
     c[0].id.should.equal('http://cqframework.org/3/2');
     c[1].id.should.equal('http://cqframework.org/3/4');
@@ -18,8 +18,8 @@ describe('Retrieve', () => {
     this.ctx.evaluatedRecords.should.containDeep(c);
   });
 
-  it('should find encounter performances', function () {
-    const e = this.encounters.exec(this.ctx);
+  it('should find encounter performances', async function () {
+    const e = await this.encounters.exec(this.ctx);
     e.should.have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
@@ -28,16 +28,16 @@ describe('Retrieve', () => {
     this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
-  it('should find observations with a value set from included library', function () {
-    const p = this.pharyngitisConditions.exec(this.ctx);
+  it('should find observations with a value set from included library', async function () {
+    const p = await this.pharyngitisConditions.exec(this.ctx);
     p.should.have.length(1);
     p[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(p);
   });
 
-  it('should find encounter performances with a value set', function () {
-    const a = this.ambulatoryEncounters.exec(this.ctx);
+  it('should find encounter performances with a value set', async function () {
+    const a = await this.ambulatoryEncounters.exec(this.ctx);
     a.should.have.length(3);
     a[0].id.should.equal('http://cqframework.org/3/1');
     a[1].id.should.equal('http://cqframework.org/3/3');
@@ -46,8 +46,8 @@ describe('Retrieve', () => {
     this.ctx.evaluatedRecords.should.containDeep(a);
   });
 
-  it('should find encounter performances by code', function () {
-    const e = this.encountersByCode.exec(this.ctx);
+  it('should find encounter performances by code', async function () {
+    const e = await this.encountersByCode.exec(this.ctx);
     e.should.have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
@@ -56,28 +56,28 @@ describe('Retrieve', () => {
     this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
-  it('should not find conditions with wrong valueset', function () {
-    const e = this.wrongValueSet.exec(this.ctx);
+  it('should not find conditions with wrong valueset', async function () {
+    const e = await this.wrongValueSet.exec(this.ctx);
     e.should.be.empty();
     this.ctx.evaluatedRecords.should.be.empty;
   });
 
-  it('should not find encounter performances using wrong codeProperty', function () {
-    const e = this.wrongCodeProperty.exec(this.ctx);
+  it('should not find encounter performances using wrong codeProperty', async function () {
+    const e = await this.wrongCodeProperty.exec(this.ctx);
     e.should.be.empty();
     this.ctx.evaluatedRecords.should.be.empty;
   });
 
-  it('should find conditions by specific pharyngitis code', function () {
-    const e = this.conditionsByCode.exec(this.ctx);
+  it('should find conditions by specific pharyngitis code', async function () {
+    const e = await this.conditionsByCode.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(e);
   });
 
-  it('should find conditions by specific pharyngitis concept', function () {
-    const e = this.conditionsByConcept.exec(this.ctx);
+  it('should find conditions by specific pharyngitis concept', async function () {
+    const e = await this.conditionsByConcept.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);

--- a/test/elm/external/external-test.ts
+++ b/test/elm/external/external-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 const vsets = require('./valuesets');
@@ -11,7 +12,7 @@ describe('Retrieve', () => {
 
   it('should find conditions', async function () {
     const c = await this.conditions.exec(this.ctx);
-    c.should.have.length(2);
+    should(c).have.length(2);
     c[0].id.should.equal('http://cqframework.org/3/2');
     c[1].id.should.equal('http://cqframework.org/3/4');
     this.ctx.evaluatedRecords.should.have.length(2);
@@ -20,7 +21,7 @@ describe('Retrieve', () => {
 
   it('should find encounter performances', async function () {
     const e = await this.encounters.exec(this.ctx);
-    e.should.have.length(3);
+    should(e).have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[2].id.should.equal('http://cqframework.org/3/5');
@@ -30,7 +31,7 @@ describe('Retrieve', () => {
 
   it('should find observations with a value set from included library', async function () {
     const p = await this.pharyngitisConditions.exec(this.ctx);
-    p.should.have.length(1);
+    should(p).have.length(1);
     p[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(p);
@@ -38,7 +39,7 @@ describe('Retrieve', () => {
 
   it('should find encounter performances with a value set', async function () {
     const a = await this.ambulatoryEncounters.exec(this.ctx);
-    a.should.have.length(3);
+    should(a).have.length(3);
     a[0].id.should.equal('http://cqframework.org/3/1');
     a[1].id.should.equal('http://cqframework.org/3/3');
     a[2].id.should.equal('http://cqframework.org/3/5');
@@ -48,7 +49,7 @@ describe('Retrieve', () => {
 
   it('should find encounter performances by code', async function () {
     const e = await this.encountersByCode.exec(this.ctx);
-    e.should.have.length(3);
+    should(e).have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[2].id.should.equal('http://cqframework.org/3/5');
@@ -58,19 +59,19 @@ describe('Retrieve', () => {
 
   it('should not find conditions with wrong valueset', async function () {
     const e = await this.wrongValueSet.exec(this.ctx);
-    e.should.be.empty();
+    should(e).be.empty();
     this.ctx.evaluatedRecords.should.be.empty;
   });
 
   it('should not find encounter performances using wrong codeProperty', async function () {
     const e = await this.wrongCodeProperty.exec(this.ctx);
-    e.should.be.empty();
+    should(e).be.empty();
     this.ctx.evaluatedRecords.should.be.empty;
   });
 
   it('should find conditions by specific pharyngitis code', async function () {
     const e = await this.conditionsByCode.exec(this.ctx);
-    e.should.have.length(1);
+    should(e).have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(e);
@@ -78,7 +79,7 @@ describe('Retrieve', () => {
 
   it('should find conditions by specific pharyngitis concept', async function () {
     const e = await this.conditionsByConcept.exec(this.ctx);
-    e.should.have.length(1);
+    should(e).have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/2');
     this.ctx.evaluatedRecords.should.have.length(1);
     this.ctx.evaluatedRecords.should.containDeep(e);

--- a/test/elm/instance/instance-test.ts
+++ b/test/elm/instance/instance-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 import { Code, Concept } from '../../../src/datatypes/clinical';
@@ -8,27 +9,27 @@ describe('Instance', () => {
     setup(this, data);
   });
 
-  it('should be able to construct a Quantity', function () {
-    const q = this.quantityA.exec(this.ctx);
-    q.should.be.instanceof(Quantity);
+  it('should be able to construct a Quantity', async function () {
+    const q = await this.quantityA.exec(this.ctx);
+    should(q).be.instanceof(Quantity);
     q.unit.should.eql('a');
     q.value.should.eql(12);
     q.toString().should.equal("12 'a'");
-    this.val.exec(this.ctx).should.eql(12);
+    (await this.val.exec(this.ctx)).should.eql(12);
   });
 
-  it('should be able to construct a Code', function () {
-    const c = this.codeA.exec(this.ctx);
-    c.should.be.instanceof(Code);
+  it('should be able to construct a Code', async function () {
+    const c = await this.codeA.exec(this.ctx);
+    should(c).be.instanceof(Code);
     c.code.should.equal('12345');
     c.system.should.equal('http://loinc.org');
     c.version.should.equal('1');
     c.display.should.equal('Test Code');
   });
 
-  it('should be able to construct a Concept', function () {
-    const c = this.conceptA.exec(this.ctx);
-    c.should.be.instanceof(Concept);
+  it('should be able to construct a Concept', async function () {
+    const c = await this.conceptA.exec(this.ctx);
+    should(c).be.instanceof(Concept);
     c.codes.should.have.length(1);
     c.codes[0].code.should.equal('12345');
     c.codes[0].system.should.equal('http://loinc.org');
@@ -37,8 +38,8 @@ describe('Instance', () => {
     c.display.should.equal('Test Concept');
   });
 
-  it('should create generic json objects with the correct key values', function () {
-    this.pharyngitis.exec(this.ctx).status.code.should.eql('active');
-    this.pharyngitis.exec(this.ctx).code.display.should.eql('Viral pharyngitis (disorder)');
+  it('should create generic json objects with the correct key values', async function () {
+    (await this.pharyngitis.exec(this.ctx)).status.code.should.eql('active');
+    (await this.pharyngitis.exec(this.ctx)).code.display.should.eql('Viral pharyngitis (disorder)');
   });
 });

--- a/test/elm/interval/interval-test.ts
+++ b/test/elm/interval/interval-test.ts
@@ -18,36 +18,36 @@ describe('Interval', () => {
     setup(this, data);
   });
 
-  it('should properly represent an open interval', function () {
+  it('should properly represent an open interval', async function () {
     this.open.lowClosed.should.be.false();
     this.open.highClosed.should.be.false();
-    this.open.low.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
-    this.open.high.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+    (await this.open.low.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
+    (await this.open.high.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should properly represent a left-open interval', function () {
+  it('should properly represent a left-open interval', async function () {
     this.leftOpen.lowClosed.should.be.false();
     this.leftOpen.highClosed.should.be.true();
-    this.leftOpen.low.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
-    this.leftOpen.high.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+    (await this.leftOpen.low.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
+    (await this.leftOpen.high.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should properly represent a right-open interval', function () {
+  it('should properly represent a right-open interval', async function () {
     this.rightOpen.lowClosed.should.be.true();
     this.rightOpen.highClosed.should.be.false();
-    this.rightOpen.low.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
-    this.rightOpen.high.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+    (await this.rightOpen.low.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
+    (await this.rightOpen.high.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should properly represent a closed interval', function () {
+  it('should properly represent a closed interval', async function () {
     this.closed.lowClosed.should.be.true();
     this.closed.highClosed.should.be.true();
-    this.closed.low.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
-    this.closed.high.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+    (await this.closed.low.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
+    (await this.closed.high.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should exec to native Interval datatype', function () {
-    const ivl = this.open.exec(this.ctx);
+  it('should exec to native Interval datatype', async function () {
+    const ivl = await this.open.exec(this.ctx);
     ivl.should.be.instanceOf(Interval);
     ivl.lowClosed.should.equal(this.open.lowClosed);
     ivl.highClosed.should.equal(this.open.highClosed);
@@ -61,39 +61,39 @@ describe('Equal', () => {
     setup(this, data);
   });
 
-  it('should determine equal integer intervals', function () {
-    this.equalClosed.exec(this.ctx).should.be.true();
-    this.equalOpen.exec(this.ctx).should.be.true();
-    this.equalOpenClosed.exec(this.ctx).should.be.true();
+  it('should determine equal integer intervals', async function () {
+    (await this.equalClosed.exec(this.ctx)).should.be.true();
+    (await this.equalOpen.exec(this.ctx)).should.be.true();
+    (await this.equalOpenClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('should determine unequal integer intervals', function () {
-    this.unequalClosed.exec(this.ctx).should.be.false();
-    this.unequalOpen.exec(this.ctx).should.be.false();
-    this.unequalClosedOpen.exec(this.ctx).should.be.false();
+  it('should determine unequal integer intervals', async function () {
+    (await this.unequalClosed.exec(this.ctx)).should.be.false();
+    (await this.unequalOpen.exec(this.ctx)).should.be.false();
+    (await this.unequalClosedOpen.exec(this.ctx)).should.be.false();
   });
 
-  it('should determine equal quantity intervals', function () {
-    this.equalQuantityClosed.exec(this.ctx).should.be.true();
-    this.equalQuantityOpen.exec(this.ctx).should.be.true();
-    this.equalQuantityOpenClosed.exec(this.ctx).should.be.true();
+  it('should determine equal quantity intervals', async function () {
+    (await this.equalQuantityClosed.exec(this.ctx)).should.be.true();
+    (await this.equalQuantityOpen.exec(this.ctx)).should.be.true();
+    (await this.equalQuantityOpenClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('should determine unequal quantity intervals', function () {
-    this.unequalQuantityClosed.exec(this.ctx).should.be.false();
-    this.unequalQuantityOpen.exec(this.ctx).should.be.false();
-    this.unequalQuantityClosedOpen.exec(this.ctx).should.be.false();
+  it('should determine unequal quantity intervals', async function () {
+    (await this.unequalQuantityClosed.exec(this.ctx)).should.be.false();
+    (await this.unequalQuantityOpen.exec(this.ctx)).should.be.false();
+    (await this.unequalQuantityClosedOpen.exec(this.ctx)).should.be.false();
   });
 
-  it('should determine equal datetime intervals', function () {
-    this.equalDates.exec(this.ctx).should.be.true();
-    this.equalDatesOpenClosed.exec(this.ctx).should.be.true();
+  it('should determine equal datetime intervals', async function () {
+    (await this.equalDates.exec(this.ctx)).should.be.true();
+    (await this.equalDatesOpenClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('should operate correctly with imprecision', function () {
-    this.sameDays.exec(this.ctx).should.be.true();
-    this.differentDays.exec(this.ctx).should.be.false();
-    should(this.differingPrecision.exec(this.ctx)).be.null();
+  it('should operate correctly with imprecision', async function () {
+    (await this.sameDays.exec(this.ctx)).should.be.true();
+    (await this.differentDays.exec(this.ctx)).should.be.false();
+    should(await this.differingPrecision.exec(this.ctx)).be.null();
   });
 });
 
@@ -102,39 +102,39 @@ describe('NotEqual', () => {
     setup(this, data);
   });
 
-  it('should determine equal integer intervals', function () {
-    this.equalClosed.exec(this.ctx).should.be.false();
-    this.equalOpen.exec(this.ctx).should.be.false();
-    this.equalOpenClosed.exec(this.ctx).should.be.false();
+  it('should determine equal integer intervals', async function () {
+    (await this.equalClosed.exec(this.ctx)).should.be.false();
+    (await this.equalOpen.exec(this.ctx)).should.be.false();
+    (await this.equalOpenClosed.exec(this.ctx)).should.be.false();
   });
 
-  it('should determine unequal integer intervals', function () {
-    this.unequalClosed.exec(this.ctx).should.be.true();
-    this.unequalOpen.exec(this.ctx).should.be.true();
-    this.unequalClosedOpen.exec(this.ctx).should.be.true();
+  it('should determine unequal integer intervals', async function () {
+    (await this.unequalClosed.exec(this.ctx)).should.be.true();
+    (await this.unequalOpen.exec(this.ctx)).should.be.true();
+    (await this.unequalClosedOpen.exec(this.ctx)).should.be.true();
   });
 
-  it('should determine equal quantity intervals', function () {
-    this.equalQuantityClosed.exec(this.ctx).should.be.false();
-    this.equalQuantityOpen.exec(this.ctx).should.be.false();
-    this.equalQuantityOpenClosed.exec(this.ctx).should.be.false();
+  it('should determine equal quantity intervals', async function () {
+    (await this.equalQuantityClosed.exec(this.ctx)).should.be.false();
+    (await this.equalQuantityOpen.exec(this.ctx)).should.be.false();
+    (await this.equalQuantityOpenClosed.exec(this.ctx)).should.be.false();
   });
 
-  it('should determine unequal quantity intervals', function () {
-    this.unequalQuantityClosed.exec(this.ctx).should.be.true();
-    this.unequalQuantityOpen.exec(this.ctx).should.be.true();
-    this.unequalQuantityClosedOpen.exec(this.ctx).should.be.true();
+  it('should determine unequal quantity intervals', async function () {
+    (await this.unequalQuantityClosed.exec(this.ctx)).should.be.true();
+    (await this.unequalQuantityOpen.exec(this.ctx)).should.be.true();
+    (await this.unequalQuantityClosedOpen.exec(this.ctx)).should.be.true();
   });
 
-  it('should determine equal datetime intervals', function () {
-    this.equalDates.exec(this.ctx).should.be.false();
-    this.equalDatesOpenClosed.exec(this.ctx).should.be.false();
+  it('should determine equal datetime intervals', async function () {
+    (await this.equalDates.exec(this.ctx)).should.be.false();
+    (await this.equalDatesOpenClosed.exec(this.ctx)).should.be.false();
   });
 
-  it('should operate correctly with imprecision', function () {
-    this.sameDays.exec(this.ctx).should.be.false();
-    this.differentDays.exec(this.ctx).should.be.true();
-    should(this.differingPrecision.exec(this.ctx)).be.null();
+  it('should operate correctly with imprecision', async function () {
+    (await this.sameDays.exec(this.ctx)).should.be.false();
+    (await this.differentDays.exec(this.ctx)).should.be.true();
+    should(await this.differingPrecision.exec(this.ctx)).be.null();
   });
 });
 
@@ -143,76 +143,76 @@ describe('Contains', () => {
     setup(this, data);
   });
 
-  it('should accept contained items', function () {
-    this.containsInt.exec(this.ctx).should.be.true();
-    this.containsReal.exec(this.ctx).should.be.true();
-    this.containsQuantity.exec(this.ctx).should.be.true();
-    this.containsQuantityInclusiveEdge.exec(this.ctx).should.be.true();
-    this.containsDate.exec(this.ctx).should.be.true();
+  it('should accept contained items', async function () {
+    (await this.containsInt.exec(this.ctx)).should.be.true();
+    (await this.containsReal.exec(this.ctx)).should.be.true();
+    (await this.containsQuantity.exec(this.ctx)).should.be.true();
+    (await this.containsQuantityInclusiveEdge.exec(this.ctx)).should.be.true();
+    (await this.containsDate.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject uncontained items', function () {
-    this.notContainsInt.exec(this.ctx).should.be.false();
-    this.notContainsReal.exec(this.ctx).should.be.false();
-    this.notContainsQuantity.exec(this.ctx).should.be.false();
-    this.notContainsQuantityExclusiveEdge.exec(this.ctx).should.be.false();
-    this.notContainsDate.exec(this.ctx).should.be.false();
+  it('should reject uncontained items', async function () {
+    (await this.notContainsInt.exec(this.ctx)).should.be.false();
+    (await this.notContainsReal.exec(this.ctx)).should.be.false();
+    (await this.notContainsQuantity.exec(this.ctx)).should.be.false();
+    (await this.notContainsQuantityExclusiveEdge.exec(this.ctx)).should.be.false();
+    (await this.notContainsDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegContainsInt.exec(this.ctx).should.be.true();
-    this.negInfBegNotContainsInt.exec(this.ctx).should.be.false();
-    this.unknownOpenBegContainsInt.exec(this.ctx).should.be.true();
-    this.unknownClosedBegContainsInt.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayContainInt.exec(this.ctx)).be.null();
-    this.unknownBegNotContainsInt.exec(this.ctx).should.be.false();
-    this.posInfEndContainsInt.exec(this.ctx).should.be.true();
-    this.posInfEndNotContainsInt.exec(this.ctx).should.be.false();
-    this.unknownOpenEndContainsInt.exec(this.ctx).should.be.true();
-    this.unknownClosedEndContainsInt.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayContainInt.exec(this.ctx)).be.null();
-    this.unknownEndNotContainsInt.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegContainsInt.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenBegContainsInt.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedBegContainsInt.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayContainInt.exec(this.ctx)).be.null();
+    (await this.unknownBegNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.posInfEndContainsInt.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenEndContainsInt.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedEndContainsInt.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayContainInt.exec(this.ctx)).be.null();
+    (await this.unknownEndNotContainsInt.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegContainsDate.exec(this.ctx).should.be.true();
-    this.negInfBegNotContainsDate.exec(this.ctx).should.be.false();
-    should(this.unknownOpenBegMayContainDate.exec(this.ctx)).be.null();
-    this.unknownClosedBegContainsDate.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayContainDate.exec(this.ctx)).be.null();
-    this.unknownBegNotContainsDate.exec(this.ctx).should.be.false();
-    this.posInfEndContainsDate.exec(this.ctx).should.be.true();
-    this.posInfEndNotContainsDate.exec(this.ctx).should.be.false();
-    this.unknownOpenEndContainsDate.exec(this.ctx).should.be.true();
-    this.unknownClosedEndContainsDate.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayContainDate.exec(this.ctx)).be.null();
-    this.unknownEndNotContainsDate.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegContainsDate.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotContainsDate.exec(this.ctx)).should.be.false();
+    should(await this.unknownOpenBegMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownClosedBegContainsDate.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownBegNotContainsDate.exec(this.ctx)).should.be.false();
+    (await this.posInfEndContainsDate.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotContainsDate.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenEndContainsDate.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedEndContainsDate.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownEndNotContainsDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.containsImpreciseDate.exec(this.ctx).should.be.true();
-    this.notContainsImpreciseDate.exec(this.ctx).should.be.false();
-    should(this.mayContainImpreciseDate.exec(this.ctx)).be.null();
-    this.impreciseContainsDate.exec(this.ctx).should.be.true();
-    this.impreciseNotContainsDate.exec(this.ctx).should.be.false();
-    should(this.impreciseMayContainDate.exec(this.ctx)).be.null();
+  it('should correctly handle imprecision', async function () {
+    (await this.containsImpreciseDate.exec(this.ctx)).should.be.true();
+    (await this.notContainsImpreciseDate.exec(this.ctx)).should.be.false();
+    should(await this.mayContainImpreciseDate.exec(this.ctx)).be.null();
+    (await this.impreciseContainsDate.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotContainsDate.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayContainDate.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.containsDayOfDateLowEdge.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx).should.be.false();
-    this.containsDayOfDateHighEdgeClosed.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateLowEdge.exec(this.ctx).should.be.false();
-    this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx).should.be.false();
-    this.containsDayOfDateImpreciseLowEdge.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx).should.be.false();
-    this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx).should.be.true();
-    this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx).should.be.false();
-    this.notContainsDayOfDateVeryImpreciseHighEdgeOpen.exec(this.ctx).should.be.false();
-    should(this.mayContainDayOfDateVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayContainDayOfDateVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayContainDayOfDateVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.containsDayOfDateLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateHighEdgeClosed.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx)).should.be.true();
+    (await this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx)).should.be.false();
+    (await this.notContainsDayOfDateVeryImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    should(await this.mayContainDayOfDateVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayContainDayOfDateVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayContainDayOfDateVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 });
 
@@ -221,76 +221,76 @@ describe('In', () => {
     setup(this, data);
   });
 
-  it('should accept contained items', function () {
-    this.containsInt.exec(this.ctx).should.be.true();
-    this.containsReal.exec(this.ctx).should.be.true();
-    this.containsQuantity.exec(this.ctx).should.be.true();
-    this.containsQuantityInclusiveEdge.exec(this.ctx).should.be.true();
-    this.containsDate.exec(this.ctx).should.be.true();
+  it('should accept contained items', async function () {
+    (await this.containsInt.exec(this.ctx)).should.be.true();
+    (await this.containsReal.exec(this.ctx)).should.be.true();
+    (await this.containsQuantity.exec(this.ctx)).should.be.true();
+    (await this.containsQuantityInclusiveEdge.exec(this.ctx)).should.be.true();
+    (await this.containsDate.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject uncontained items', function () {
-    this.notContainsInt.exec(this.ctx).should.be.false();
-    this.notContainsReal.exec(this.ctx).should.be.false();
-    this.notContainsQuantity.exec(this.ctx).should.be.false();
-    this.notContainsQuantityExclusiveEdge.exec(this.ctx).should.be.false();
-    this.notContainsDate.exec(this.ctx).should.be.false();
+  it('should reject uncontained items', async function () {
+    (await this.notContainsInt.exec(this.ctx)).should.be.false();
+    (await this.notContainsReal.exec(this.ctx)).should.be.false();
+    (await this.notContainsQuantity.exec(this.ctx)).should.be.false();
+    (await this.notContainsQuantityExclusiveEdge.exec(this.ctx)).should.be.false();
+    (await this.notContainsDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegContainsInt.exec(this.ctx).should.be.true();
-    this.negInfBegNotContainsInt.exec(this.ctx).should.be.false();
-    this.unknownOpenBegContainsInt.exec(this.ctx).should.be.true();
-    this.unknownClosedBegContainsInt.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayContainInt.exec(this.ctx)).be.null();
-    this.unknownBegNotContainsInt.exec(this.ctx).should.be.false();
-    this.posInfEndContainsInt.exec(this.ctx).should.be.true();
-    this.posInfEndNotContainsInt.exec(this.ctx).should.be.false();
-    this.unknownOpenEndContainsInt.exec(this.ctx).should.be.true();
-    this.unknownClosedEndContainsInt.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayContainInt.exec(this.ctx)).be.null();
-    this.unknownEndNotContainsInt.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegContainsInt.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenBegContainsInt.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedBegContainsInt.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayContainInt.exec(this.ctx)).be.null();
+    (await this.unknownBegNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.posInfEndContainsInt.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotContainsInt.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenEndContainsInt.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedEndContainsInt.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayContainInt.exec(this.ctx)).be.null();
+    (await this.unknownEndNotContainsInt.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegContainsDate.exec(this.ctx).should.be.true();
-    this.negInfBegNotContainsDate.exec(this.ctx).should.be.false();
-    should(this.unknownOpenBegMayContainDate.exec(this.ctx)).be.null();
-    this.unknownClosedBegContainsDate.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayContainDate.exec(this.ctx)).be.null();
-    this.unknownBegNotContainsDate.exec(this.ctx).should.be.false();
-    this.posInfEndContainsDate.exec(this.ctx).should.be.true();
-    this.posInfEndNotContainsDate.exec(this.ctx).should.be.false();
-    this.unknownOpenEndContainsDate.exec(this.ctx).should.be.true();
-    this.unknownClosedEndContainsDate.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayContainDate.exec(this.ctx)).be.null();
-    this.unknownEndNotContainsDate.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegContainsDate.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotContainsDate.exec(this.ctx)).should.be.false();
+    should(await this.unknownOpenBegMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownClosedBegContainsDate.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownBegNotContainsDate.exec(this.ctx)).should.be.false();
+    (await this.posInfEndContainsDate.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotContainsDate.exec(this.ctx)).should.be.false();
+    (await this.unknownOpenEndContainsDate.exec(this.ctx)).should.be.true();
+    (await this.unknownClosedEndContainsDate.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayContainDate.exec(this.ctx)).be.null();
+    (await this.unknownEndNotContainsDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.containsImpreciseDate.exec(this.ctx).should.be.true();
-    this.notContainsImpreciseDate.exec(this.ctx).should.be.false();
-    should(this.mayContainImpreciseDate.exec(this.ctx)).be.null();
-    this.impreciseContainsDate.exec(this.ctx).should.be.true();
-    this.impreciseNotContainsDate.exec(this.ctx).should.be.false();
-    should(this.impreciseMayContainDate.exec(this.ctx)).be.null();
+  it('should correctly handle imprecision', async function () {
+    (await this.containsImpreciseDate.exec(this.ctx)).should.be.true();
+    (await this.notContainsImpreciseDate.exec(this.ctx)).should.be.false();
+    should(await this.mayContainImpreciseDate.exec(this.ctx)).be.null();
+    (await this.impreciseContainsDate.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotContainsDate.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayContainDate.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.containsDayOfDateLowEdge.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx).should.be.false();
-    this.containsDayOfDateHighEdgeClosed.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateLowEdge.exec(this.ctx).should.be.false();
-    this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx).should.be.false();
-    this.containsDayOfDateImpreciseLowEdge.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx).should.be.false();
-    this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx).should.be.true();
-    this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx).should.be.true();
-    this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx).should.be.false();
-    this.notContainsDayOfDateVeryImpreciseHighEdgeOpen.exec(this.ctx).should.be.false();
-    should(this.mayContainDayOfDateVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayContainDayOfDateVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayContainDayOfDateVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.containsDayOfDateLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateHighEdgeClosed.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notContainsDayOfDateBeyondHighEdge.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseLowEdge.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    (await this.containsDayOfDateImpreciseHighEdgeClosed.exec(this.ctx)).should.be.true();
+    (await this.containsDayOfDateVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
+    (await this.notContainsDayOfDateVeryImpreciseLow.exec(this.ctx)).should.be.false();
+    (await this.notContainsDayOfDateVeryImpreciseHighEdgeOpen.exec(this.ctx)).should.be.false();
+    should(await this.mayContainDayOfDateVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayContainDayOfDateVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayContainDayOfDateVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 });
 
@@ -299,73 +299,73 @@ describe('Includes', () => {
     setup(this, data);
   });
 
-  it('should accept included items', function () {
-    this.includesIntIvl.exec(this.ctx).should.be.true();
-    this.includesRealIvl.exec(this.ctx).should.be.true();
-    this.includesDateIvl.exec(this.ctx).should.be.true();
+  it('should accept included items', async function () {
+    (await this.includesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.includesRealIvl.exec(this.ctx)).should.be.true();
+    (await this.includesDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject unincluded items', function () {
-    this.notIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.notIncludesRealIvl.exec(this.ctx).should.be.false();
-    this.notIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should reject unincluded items', async function () {
+    (await this.notIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notIncludesRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.unknownBegIncludesIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayIncludeIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.unknownEndIncludesIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayIncludeIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotIncludesIntIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegIncludesIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayIncludeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndIncludesIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayIncludeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotIncludesIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegIncludesDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    this.unknownBegIncludesDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayIncludeDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndIncludesDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    this.unknownEndIncludesDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayIncludeDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegIncludesDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegIncludesDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayIncludeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndIncludesDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndIncludesDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayIncludeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.includesImpreciseDateIvl.exec(this.ctx).should.be.true();
-    this.notIncludesImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.mayIncludeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.impreciseIncludesDateIvl.exec(this.ctx).should.be.true();
-    this.impreciseNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayIncludeDateIvl.exec(this.ctx)).be.null();
+  it('should correctly handle imprecision', async function () {
+    (await this.includesImpreciseDateIvl.exec(this.ctx)).should.be.true();
+    (await this.notIncludesImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayIncludeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseIncludesDateIvl.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayIncludeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.includesDayOfIvlLowEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlHighEdge.exec(this.ctx).should.be.true();
-    this.notIncludesDayOfIvlLowEdge.exec(this.ctx).should.be.false();
-    this.notIncludesDayOfIvlHighEdge.exec(this.ctx).should.be.false();
-    this.includesDayOfIvlImpreciseLowEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlImpreciseHighEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlVeryImpreciseMiddle.exec(this.ctx).should.be.true();
-    this.notIncludesDayOfIvlVeryImpreciseLow.exec(this.ctx).should.be.false();
-    this.notIncludesDayOfIvlVeryImpreciseHigh.exec(this.ctx).should.be.false();
-    should(this.mayIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.includesDayOfIvlLowEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlHighEdge.exec(this.ctx)).should.be.true();
+    (await this.notIncludesDayOfIvlLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDayOfIvlHighEdge.exec(this.ctx)).should.be.false();
+    (await this.includesDayOfIvlImpreciseLowEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlImpreciseHighEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
+    (await this.notIncludesDayOfIvlVeryImpreciseLow.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDayOfIvlVeryImpreciseHigh.exec(this.ctx)).should.be.false();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle point inclusion', function () {
-    this.impreciseIncludesDate.exec(this.ctx).should.be.true();
-    this.impreciseDoesntIncludeDate.exec(this.ctx).should.be.false();
-    this.intervalIncludesQuantity.exec(this.ctx).should.be.true();
-    this.intervalDoesntIncludeQuantity.exec(this.ctx).should.be.false();
+  it('should correctly handle point inclusion', async function () {
+    (await this.impreciseIncludesDate.exec(this.ctx)).should.be.true();
+    (await this.impreciseDoesntIncludeDate.exec(this.ctx)).should.be.false();
+    (await this.intervalIncludesQuantity.exec(this.ctx)).should.be.true();
+    (await this.intervalDoesntIncludeQuantity.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -374,35 +374,35 @@ describe('ProperlyIncludes', () => {
     setup(this, data);
   });
 
-  it('should accept properly included intervals', function () {
-    this.properlyIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesIntBeginsIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesIntEndsIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesRealIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesDateIvl.exec(this.ctx).should.be.true();
+  it('should accept properly included intervals', async function () {
+    (await this.properlyIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesIntBeginsIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesIntEndsIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesRealIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals not properly included', function () {
-    this.notProperlyIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.notProperlyIncludesRealIvl.exec(this.ctx).should.be.false();
-    this.notProperlyIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not properly included', async function () {
+    (await this.notProperlyIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notProperlyIncludesRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notProperlyIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.posInfEndProperlyIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotProperlyIncludesIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayProperlyIncludeIntIvl.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.posInfEndProperlyIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotProperlyIncludesIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayProperlyIncludeIntIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.properlyIncludesDayOfIvlLowEdge.exec(this.ctx).should.be.true();
-    this.properlyIncludesDayOfIvlHighEdge.exec(this.ctx).should.be.true();
-    this.properlyIncludesDayOfIvlNearEdges.exec(this.ctx).should.be.true();
-    this.notProperlyIncludesDayOfIvlSameEdges.exec(this.ctx).should.be.false();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.properlyIncludesDayOfIvlLowEdge.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDayOfIvlHighEdge.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDayOfIvlNearEdges.exec(this.ctx)).should.be.true();
+    (await this.notProperlyIncludesDayOfIvlSameEdges.exec(this.ctx)).should.be.false();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 });
 
@@ -411,73 +411,73 @@ describe('IncludedIn', () => {
     setup(this, data);
   });
 
-  it('should accept included items', function () {
-    this.includesIntIvl.exec(this.ctx).should.be.true();
-    this.includesRealIvl.exec(this.ctx).should.be.true();
-    this.includesDateIvl.exec(this.ctx).should.be.true();
+  it('should accept included items', async function () {
+    (await this.includesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.includesRealIvl.exec(this.ctx)).should.be.true();
+    (await this.includesDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject unincluded items', function () {
-    this.notIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.notIncludesRealIvl.exec(this.ctx).should.be.false();
-    this.notIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should reject unincluded items', async function () {
+    (await this.notIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notIncludesRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegIncludedInIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotIncludedInIntIvl.exec(this.ctx).should.be.false();
-    this.unknownBegIncludedInIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayBeIncludedInIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotIncludedInIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndIncludedInIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotIncludedInIntIvl.exec(this.ctx).should.be.false();
-    this.unknownEndIncludedInIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayBeIncludedInIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotIncludedInIntIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegIncludedInIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotIncludedInIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegIncludedInIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayBeIncludedInIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotIncludedInIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndIncludedInIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotIncludedInIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndIncludedInIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayBeIncludedInIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotIncludedInIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegIncludedInDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotIncludedInDateIvl.exec(this.ctx).should.be.false();
-    this.unknownBegIncludedInDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayBeIncludedInDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotIncludedInDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndIncludedInDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotIncludedInDateIvl.exec(this.ctx).should.be.false();
-    this.unknownEndIncludedInDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayBeIncludedInDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotIncludedInDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotIncludedInDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayBeIncludedInDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotIncludedInDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotIncludedInDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayBeIncludedInDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotIncludedInDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.includesImpreciseDateIvl.exec(this.ctx).should.be.true();
-    this.notIncludesImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.mayIncludeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.impreciseIncludesDateIvl.exec(this.ctx).should.be.true();
-    this.impreciseNotIncludesDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayIncludeDateIvl.exec(this.ctx)).be.null();
+  it('should correctly handle imprecision', async function () {
+    (await this.includesImpreciseDateIvl.exec(this.ctx)).should.be.true();
+    (await this.notIncludesImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayIncludeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseIncludesDateIvl.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotIncludesDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayIncludeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.includesDayOfIvlLowEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlHighEdge.exec(this.ctx).should.be.true();
-    this.notIncludesDayOfIvlLowEdge.exec(this.ctx).should.be.false();
-    this.notIncludesDayOfIvlHighEdge.exec(this.ctx).should.be.false();
-    this.includesDayOfIvlImpreciseLowEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlImpreciseHighEdge.exec(this.ctx).should.be.true();
-    this.includesDayOfIvlVeryImpreciseMiddle.exec(this.ctx).should.be.true();
-    this.notIncludesDayOfIvlVeryImpreciseLow.exec(this.ctx).should.be.false();
-    this.notIncludesDayOfIvlVeryImpreciseHigh.exec(this.ctx).should.be.false();
-    should(this.mayIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.includesDayOfIvlLowEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlHighEdge.exec(this.ctx)).should.be.true();
+    (await this.notIncludesDayOfIvlLowEdge.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDayOfIvlHighEdge.exec(this.ctx)).should.be.false();
+    (await this.includesDayOfIvlImpreciseLowEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlImpreciseHighEdge.exec(this.ctx)).should.be.true();
+    (await this.includesDayOfIvlVeryImpreciseMiddle.exec(this.ctx)).should.be.true();
+    (await this.notIncludesDayOfIvlVeryImpreciseLow.exec(this.ctx)).should.be.false();
+    (await this.notIncludesDayOfIvlVeryImpreciseHigh.exec(this.ctx)).should.be.false();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle point comparisons', function () {
-    this.includesDayInInterval.exec(this.ctx).should.be.true();
-    this.doesNotIncludeDayInInterval.exec(this.ctx).should.be.false();
-    this.quantityIncludedInterval.exec(this.ctx).should.be.true();
-    this.quantityNotIncludedInterval.exec(this.ctx).should.be.false();
+  it('should correctly handle point comparisons', async function () {
+    (await this.includesDayInInterval.exec(this.ctx)).should.be.true();
+    (await this.doesNotIncludeDayInInterval.exec(this.ctx)).should.be.false();
+    (await this.quantityIncludedInterval.exec(this.ctx)).should.be.true();
+    (await this.quantityNotIncludedInterval.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -486,35 +486,35 @@ describe('ProperlyIncludedIn', () => {
     setup(this, data);
   });
 
-  it('should accept properly included intervals', function () {
-    this.properlyIncludesIntIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesIntBeginsIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesIntEndsIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesRealIvl.exec(this.ctx).should.be.true();
-    this.properlyIncludesDateIvl.exec(this.ctx).should.be.true();
+  it('should accept properly included intervals', async function () {
+    (await this.properlyIncludesIntIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesIntBeginsIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesIntEndsIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesRealIvl.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals not properly included', function () {
-    this.notProperlyIncludesIntIvl.exec(this.ctx).should.be.false();
-    this.notProperlyIncludesRealIvl.exec(this.ctx).should.be.false();
-    this.notProperlyIncludesDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not properly included', async function () {
+    (await this.notProperlyIncludesIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notProperlyIncludesRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notProperlyIncludesDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.posInfEndProperlyIncludedInDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotProperlyIncludedInDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayBeProperlyIncludedInDateIvl.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.posInfEndProperlyIncludedInDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotProperlyIncludedInDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayBeProperlyIncludedInDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.properlyIncludesDayOfIvlLowEdge.exec(this.ctx).should.be.true();
-    this.properlyIncludesDayOfIvlHighEdge.exec(this.ctx).should.be.true();
-    this.properlyIncludesDayOfIvlNearEdges.exec(this.ctx).should.be.true();
-    this.notProperlyIncludesDayOfIvlSameEdges.exec(this.ctx).should.be.false();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh.exec(this.ctx)).be.null();
-    should(this.mayProperlyIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.properlyIncludesDayOfIvlLowEdge.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDayOfIvlHighEdge.exec(this.ctx)).should.be.true();
+    (await this.properlyIncludesDayOfIvlNearEdges.exec(this.ctx)).should.be.true();
+    (await this.notProperlyIncludesDayOfIvlSameEdges.exec(this.ctx)).should.be.false();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseLow.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseHigh.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseLowAndHigh.exec(this.ctx)).be.null();
+    should(await this.mayProperlyIncludeDayOfIvlVeryImpreciseSurrounding.exec(this.ctx)).be.null();
   });
 });
 
@@ -523,55 +523,55 @@ describe('After', () => {
     setup(this, data);
   });
 
-  it('should accept intervals before it', function () {
-    this.afterIntIvl.exec(this.ctx).should.be.true();
-    this.afterRealIvl.exec(this.ctx).should.be.true();
-    this.afterDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals before it', async function () {
+    (await this.afterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.afterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.afterDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals on or after it', function () {
-    this.notAfterIntIvl.exec(this.ctx).should.be.false();
-    this.notAfterRealIvl.exec(this.ctx).should.be.false();
-    this.notAfterDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals on or after it', async function () {
+    (await this.notAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notAfterRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notAfterDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegNotAfterIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownBegMayBeAfterIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotAfterIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndAfterIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotAfterIntIvl.exec(this.ctx).should.be.false();
-    this.unknownEndAfterIntIvl.exec(this.ctx).should.be.true();
-    this.unknownEndNotAfterIntIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegNotAfterIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownBegMayBeAfterIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownEndNotAfterIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegNotAfterDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownBegMayBeAfterDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotAfterDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndAfterDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotAfterDateIvl.exec(this.ctx).should.be.false();
-    this.unknownEndAfterDateIvl.exec(this.ctx).should.be.true();
-    this.unknownEndNotAfterDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegNotAfterDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownBegMayBeAfterDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownEndNotAfterDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.afterImpreciseDateIvl.exec(this.ctx).should.be.true();
-    should(this.notAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    should(this.mayBeAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.impreciseAfterDateIvl.exec(this.ctx).should.be.true();
+  it('should correctly handle imprecision', async function () {
+    (await this.afterImpreciseDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.notAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    should(await this.mayBeAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseAfterDateIvl.exec(this.ctx)).should.be.true();
     // meets with uncertainty due to toClose
-    should(this.impreciseNotAfterDateIvl.exec(this.ctx)).be.null();
-    should(this.impreciseMayBeAfterDateIvl.exec(this.ctx)).be.null();
+    should(await this.impreciseNotAfterDateIvl.exec(this.ctx)).be.null();
+    should(await this.impreciseMayBeAfterDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.afterDayOfIvl.exec(this.ctx).should.be.true();
-    this.beforeDayOfIvl.exec(this.ctx).should.be.false();
-    this.startsSameDayOfIvlEnd.exec(this.ctx).should.be.false();
-    this.endsSameDayOfIvlStart.exec(this.ctx).should.be.false();
-    should(this.mayBeAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    this.mayBeBeforeDayOfImpreciseIvl.exec(this.ctx).should.be.false();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.afterDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.beforeDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.startsSameDayOfIvlEnd.exec(this.ctx)).should.be.false();
+    (await this.endsSameDayOfIvlStart.exec(this.ctx)).should.be.false();
+    should(await this.mayBeAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    (await this.mayBeBeforeDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -580,55 +580,55 @@ describe('Before', () => {
     setup(this, data);
   });
 
-  it('should accept intervals before it', function () {
-    this.beforeIntIvl.exec(this.ctx).should.be.true();
-    this.beforeRealIvl.exec(this.ctx).should.be.true();
-    this.beforeDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals before it', async function () {
+    (await this.beforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.beforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.beforeDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals on or after it', function () {
-    this.notBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.notBeforeRealIvl.exec(this.ctx).should.be.false();
-    this.notBeforeDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals on or after it', async function () {
+    (await this.notBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notBeforeRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notBeforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.unknownBegBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.unknownBegNotBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndNotBeforeIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayBeBeforeIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotBeforeIntIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownBegNotBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndNotBeforeIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayBeBeforeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotBeforeIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.unknownBegBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.unknownBegNotBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndNotBeforeDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayBeBeforeDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotBeforeDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownBegNotBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndNotBeforeDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayBeBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotBeforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.beforeImpreciseDateIvl.exec(this.ctx).should.be.true();
+  it('should correctly handle imprecision', async function () {
+    (await this.beforeImpreciseDateIvl.exec(this.ctx)).should.be.true();
     // meets with uncertaintity due to toClose
-    should(this.notBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    should(this.mayBeBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.impreciseBeforeDateIvl.exec(this.ctx).should.be.true();
-    should(this.impreciseNotBeforeDateIvl.exec(this.ctx)).be.null();
-    should(this.impreciseMayBeBeforeDateIvl.exec(this.ctx)).be.null();
+    should(await this.notBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    should(await this.mayBeBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseBeforeDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.impreciseNotBeforeDateIvl.exec(this.ctx)).be.null();
+    should(await this.impreciseMayBeBeforeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.afterDayOfIvl.exec(this.ctx).should.be.false();
-    this.beforeDayOfIvl.exec(this.ctx).should.be.true();
-    this.startsSameDayOfIvlEnd.exec(this.ctx).should.be.false();
-    this.endsSameDayOfIvlStart.exec(this.ctx).should.be.false();
-    this.mayBeAfterDayOfImpreciseIvl.exec(this.ctx).should.be.false();
-    should(this.mayBeBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.afterDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.beforeDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.startsSameDayOfIvlEnd.exec(this.ctx)).should.be.false();
+    (await this.endsSameDayOfIvlStart.exec(this.ctx)).should.be.false();
+    (await this.mayBeAfterDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayBeBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -640,61 +640,61 @@ describe('BeforeOrOn', () => {
     setup(this, data);
   });
 
-  it('should handle nominal datetime interval situations', function () {
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.afterDateIvl.exec(this.ctx).should.be.false();
-    this.beforeDateIvl.exec(this.ctx).should.be.true();
+  it('should handle nominal datetime interval situations', async function () {
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.afterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.beforeDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.mayMeetAfterImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseMayMeetAfterDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseMayMeetBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    (await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.true();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.false();
-    this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx).should.be.false();
-    should(this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.false();
+    (await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle intervals with null end', function () {
-    this.beforeNullEndIvl.exec(this.ctx).should.be.true();
-    this.afterStartNullEndIvl.exec(this.ctx).should.be.false();
-    should(this.nullEndStartBeforeIvl.exec(this.ctx)).be.null();
-    should(this.nullEndStartAfterIvl.exec(this.ctx)).be.null();
+  it('should handle intervals with null end', async function () {
+    (await this.beforeNullEndIvl.exec(this.ctx)).should.be.true();
+    (await this.afterStartNullEndIvl.exec(this.ctx)).should.be.false();
+    should(await this.nullEndStartBeforeIvl.exec(this.ctx)).be.null();
+    should(await this.nullEndStartAfterIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle intervals with null start', function () {
-    should(this.endsBeforeNullStartIvlEnds.exec(this.ctx)).be.null();
-    should(this.afterEndOfNullStartIvl.exec(this.ctx)).be.null();
-    this.nullStartStartBeforeIvl.exec(this.ctx).should.be.true();
-    this.nullStartStartAfterIvl.exec(this.ctx).should.be.false();
+  it('should handle intervals with null start', async function () {
+    should(await this.endsBeforeNullStartIvlEnds.exec(this.ctx)).be.null();
+    should(await this.afterEndOfNullStartIvl.exec(this.ctx)).be.null();
+    (await this.nullStartStartBeforeIvl.exec(this.ctx)).should.be.true();
+    (await this.nullStartStartAfterIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle null on either side', function () {
-    should(this.dateIvlBeforeNull.exec(this.ctx)).be.null();
-    should(this.nullBeforeDateIvl.exec(this.ctx)).be.null();
+  it('should handle null on either side', async function () {
+    should(await this.dateIvlBeforeNull.exec(this.ctx)).be.null();
+    should(await this.nullBeforeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle Date and DateTime on either side', function () {
-    this.dateTimeBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.dateBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.dateIvlBeforeDateTime.exec(this.ctx).should.be.true();
-    this.dateIvlBeforeDate.exec(this.ctx).should.be.true();
+  it('should handle Date and DateTime on either side', async function () {
+    (await this.dateTimeBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.dateBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.dateIvlBeforeDateTime.exec(this.ctx)).should.be.true();
+    (await this.dateIvlBeforeDate.exec(this.ctx)).should.be.true();
   });
 
-  it('should handle Interval<Date> and Interval<DateTime> on either side', function () {
-    this.dateOnlyIvlBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.dateIvlAfterDateOnlyIvl.exec(this.ctx).should.be.false();
-    this.dateOnlyMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
+  it('should handle Interval<Date> and Interval<DateTime> on either side', async function () {
+    (await this.dateOnlyIvlBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.dateIvlAfterDateOnlyIvl.exec(this.ctx)).should.be.false();
+    (await this.dateOnlyMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
   });
 });
 
@@ -706,61 +706,61 @@ describe('AfterOrOn', () => {
     setup(this, data);
   });
 
-  it('should handle nominal datetime interval situations', function () {
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.afterDateIvl.exec(this.ctx).should.be.true();
-    this.beforeDateIvl.exec(this.ctx).should.be.false();
+  it('should handle nominal datetime interval situations', async function () {
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.afterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.beforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    should(this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseMayMeetAfterDateIvl.exec(this.ctx).should.be.true();
-    this.impreciseMayMeetBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    should(await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.true();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.true();
-    should(this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx).should.be.false();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.true();
+    should(await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    (await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle intervals with null end', function () {
-    should(this.beforeNullEndIvl.exec(this.ctx)).be.null();
-    should(this.afterStartNullEndIvl.exec(this.ctx)).be.null();
-    this.nullEndStartBeforeIvl.exec(this.ctx).should.be.false();
-    this.nullEndStartAfterIvl.exec(this.ctx).should.be.true();
+  it('should handle intervals with null end', async function () {
+    should(await this.beforeNullEndIvl.exec(this.ctx)).be.null();
+    should(await this.afterStartNullEndIvl.exec(this.ctx)).be.null();
+    (await this.nullEndStartBeforeIvl.exec(this.ctx)).should.be.false();
+    (await this.nullEndStartAfterIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should handle intervals with null start', function () {
-    this.endsBeforeNullStartIvlEnds.exec(this.ctx).should.be.false();
-    this.afterEndOfNullStartIvl.exec(this.ctx).should.be.true();
-    should(this.nullStartStartBeforeIvl.exec(this.ctx)).be.null();
-    should(this.nullStartStartAfterIvl.exec(this.ctx)).be.null();
+  it('should handle intervals with null start', async function () {
+    (await this.endsBeforeNullStartIvlEnds.exec(this.ctx)).should.be.false();
+    (await this.afterEndOfNullStartIvl.exec(this.ctx)).should.be.true();
+    should(await this.nullStartStartBeforeIvl.exec(this.ctx)).be.null();
+    should(await this.nullStartStartAfterIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle null on either side', function () {
-    should(this.dateIvlBeforeNull.exec(this.ctx)).be.null();
-    should(this.nullBeforeDateIvl.exec(this.ctx)).be.null();
+  it('should handle null on either side', async function () {
+    should(await this.dateIvlBeforeNull.exec(this.ctx)).be.null();
+    should(await this.nullBeforeDateIvl.exec(this.ctx)).be.null();
   });
 
-  it('should handle Date and DateTime on either side', function () {
-    this.dateTimeBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.dateBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlBeforeDateTime.exec(this.ctx).should.be.false();
-    this.dateIvlBeforeDate.exec(this.ctx).should.be.false();
+  it('should handle Date and DateTime on either side', async function () {
+    (await this.dateTimeBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlBeforeDateTime.exec(this.ctx)).should.be.false();
+    (await this.dateIvlBeforeDate.exec(this.ctx)).should.be.false();
   });
 
-  it('should handle Interval<Date> and Interval<DateTime> on either side', function () {
-    this.dateOnlyIvlBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlAfterDateOnlyIvl.exec(this.ctx).should.be.true();
-    this.dateOnlyMeetsAfterDateIvl.exec(this.ctx).should.be.true();
+  it('should handle Interval<Date> and Interval<DateTime> on either side', async function () {
+    (await this.dateOnlyIvlBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlAfterDateOnlyIvl.exec(this.ctx)).should.be.true();
+    (await this.dateOnlyMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
   });
 });
 
@@ -769,74 +769,74 @@ describe('Meets', () => {
     setup(this, data);
   });
 
-  it('should accept intervals meeting after it', function () {
-    this.meetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeRealIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals meeting after it', async function () {
+    (await this.meetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept intervals meeting before it', function () {
-    this.meetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.meetsAfterRealIvl.exec(this.ctx).should.be.true();
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals meeting before it', async function () {
+    (await this.meetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsAfterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals not meeting it', function () {
-    this.notMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.notMeetsRealIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not meeting it', async function () {
+    (await this.notMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegMeetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    should(this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
-    this.posInfEndMeetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterIntIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    should(this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
+    (await this.posInfEndMeetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    should(this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
-    this.posInfEndMeetsAfterDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterDateIvl.exec(this.ctx).should.be.true();
-    should(this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    should(this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
+    (await this.posInfEndMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    should(await this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle imprecision', function () {
-    should(this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    should(this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).be.null();
-    should(this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    should(await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    should(await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).be.null();
+    should(await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.true();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.false();
-    should(this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    should(this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    should(await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -845,74 +845,74 @@ describe('MeetsAfter', () => {
     setup(this, data);
   });
 
-  it('should accept intervals meeting before it', function () {
-    this.meetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.meetsAfterRealIvl.exec(this.ctx).should.be.true();
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals meeting before it', async function () {
+    (await this.meetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsAfterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals meeting after it', function () {
-    this.meetsBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeRealIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals meeting after it', async function () {
+    (await this.meetsBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeRealIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject intervals not meeting it', function () {
-    this.notMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.notMeetsRealIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not meeting it', async function () {
+    (await this.notMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegMeetsBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.negInfBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx).should.be.false();
-    this.posInfEndMeetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx).should.be.false();
-    this.unknownEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    should(this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.negInfBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).should.be.false();
+    (await this.posInfEndMeetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegMeetsBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.negInfBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).be.null();
-    this.unknownBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx).should.be.false();
-    this.posInfEndMeetsAfterDateIvl.exec(this.ctx).should.be.true();
-    this.posInfEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterDateIvl.exec(this.ctx).should.be.true();
-    this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.unknownEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    should(this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.negInfBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).should.be.false();
+    (await this.posInfEndMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.posInfEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterDateIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).be.null();
   });
 
-  it('should correctly handle imprecision', function () {
-    should(this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).be.null();
-    this.impreciseMayMeetBeforeDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    should(await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.false();
-    should(this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx).should.be.false();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    (await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -921,74 +921,74 @@ describe('MeetsBefore', () => {
     setup(this, data);
   });
 
-  it('should accept intervals meeting after it', function () {
-    this.meetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeRealIvl.exec(this.ctx).should.be.true();
-    this.meetsBeforeDateIvl.exec(this.ctx).should.be.true();
+  it('should accept intervals meeting after it', async function () {
+    (await this.meetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.meetsBeforeDateIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject intervals meeting before it', function () {
-    this.meetsAfterIntIvl.exec(this.ctx).should.be.false();
-    this.meetsAfterRealIvl.exec(this.ctx).should.be.false();
-    this.meetsAfterDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals meeting before it', async function () {
+    (await this.meetsAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsAfterRealIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsAfterDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject intervals not meeting it', function () {
-    this.notMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.notMeetsRealIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should reject intervals not meeting it', async function () {
+    (await this.notMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsRealIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (int)', function () {
-    this.negInfBegMeetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.unknownBegMayMeetAfterIntIvl.exec(this.ctx).should.be.false();
-    this.unknownBegNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    should(this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
-    this.posInfEndMeetsAfterIntIvl.exec(this.ctx).should.be.false();
-    this.posInfEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterIntIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotMeetsIntIvl.exec(this.ctx).should.be.false();
-    this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (int)', async function () {
+    (await this.negInfBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownBegMayMeetAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.intIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
+    (await this.posInfEndMeetsAfterIntIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterIntIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayMeetBeforeIntIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotMeetsIntIvl.exec(this.ctx)).should.be.false();
+    (await this.intIvlMayMeetAfterUnknownEnd.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle null endpoints (date)', function () {
-    this.negInfBegMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.negInfBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsNegInfBeg.exec(this.ctx).should.be.false();
-    this.unknownBegMeetsBeforeDateIvl.exec(this.ctx).should.be.true();
-    this.unknownBegMayMeetAfterDateIvl.exec(this.ctx).should.be.false();
-    this.unknownBegNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    should(this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
-    this.posInfEndMeetsAfterDateIvl.exec(this.ctx).should.be.false();
-    this.posInfEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlNotMeetsPosInfEnd.exec(this.ctx).should.be.false();
-    this.unknownEndMeetsAfterDateIvl.exec(this.ctx).should.be.false();
-    should(this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
-    this.unknownEndNotMeetsDateIvl.exec(this.ctx).should.be.false();
-    this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx).should.be.false();
+  it('should correctly handle null endpoints (date)', async function () {
+    (await this.negInfBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.negInfBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsNegInfBeg.exec(this.ctx)).should.be.false();
+    (await this.unknownBegMeetsBeforeDateIvl.exec(this.ctx)).should.be.true();
+    (await this.unknownBegMayMeetAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.unknownBegNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.dateIvlMayMeetBeforeUnknownBeg.exec(this.ctx)).be.null();
+    (await this.posInfEndMeetsAfterDateIvl.exec(this.ctx)).should.be.false();
+    (await this.posInfEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlNotMeetsPosInfEnd.exec(this.ctx)).should.be.false();
+    (await this.unknownEndMeetsAfterDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.unknownEndMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.unknownEndNotMeetsDateIvl.exec(this.ctx)).should.be.false();
+    (await this.dateIvlMayMeetAfterUnknownEnd.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly handle imprecision', function () {
-    this.mayMeetAfterImpreciseDateIvl.exec(this.ctx).should.be.false();
-    should(this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
-    this.notMeetsImpreciseDateIvl.exec(this.ctx).should.be.false();
-    this.impreciseMayMeetAfterDateIvl.exec(this.ctx).should.be.false();
-    should(this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
-    this.impreciseNotMeetsDateIvl.exec(this.ctx).should.be.false();
+  it('should correctly handle imprecision', async function () {
+    (await this.mayMeetAfterImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetBeforeImpreciseDateIvl.exec(this.ctx)).be.null();
+    (await this.notMeetsImpreciseDateIvl.exec(this.ctx)).should.be.false();
+    (await this.impreciseMayMeetAfterDateIvl.exec(this.ctx)).should.be.false();
+    should(await this.impreciseMayMeetBeforeDateIvl.exec(this.ctx)).be.null();
+    (await this.impreciseNotMeetsDateIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.meetsAfterDayOfIvl.exec(this.ctx).should.be.false();
-    this.meetsBeforeDayOfIvl.exec(this.ctx).should.be.true();
-    this.notMeetsDayOfIvl.exec(this.ctx).should.be.false();
-    this.notMeetsDayOfImpreciseIVL.exec(this.ctx).should.be.false();
-    this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx).should.be.false();
-    should(this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.meetsAfterDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.meetsBeforeDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notMeetsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notMeetsDayOfImpreciseIVL.exec(this.ctx)).should.be.false();
+    (await this.mayMeetAfterDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayMeetBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -997,28 +997,28 @@ describe('Overlaps', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps (integer)', function () {
-    this.overlapsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.overlapsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryIntIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps (integer)', async function () {
+    (await this.overlapsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryIntIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept overlaps (real)', function () {
-    this.overlapsBeforeRealIvl.exec(this.ctx).should.be.true();
-    this.overlapsAfterRealIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryRealIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps (real)', async function () {
+    (await this.overlapsBeforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryRealIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject non-overlaps (integer)', function () {
-    this.noOverlapsIntIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (integer)', async function () {
+    (await this.noOverlapsIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (real)', function () {
-    this.noOverlapsRealIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (real)', async function () {
+    (await this.noOverlapsRealIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null for null value', function () {
-    should(this.overlapsIsNull.exec(this.ctx)).be.null();
+  it('should return null for null value', async function () {
+    should(await this.overlapsIsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -1027,42 +1027,42 @@ describe('OverlapsDateTime', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps', function () {
-    this.overlapsBefore.exec(this.ctx).should.be.true();
-    this.overlapsAfter.exec(this.ctx).should.be.true();
-    this.overlapsContained.exec(this.ctx).should.be.true();
-    this.overlapsContains.exec(this.ctx).should.be.true();
+  it('should accept overlaps', async function () {
+    (await this.overlapsBefore.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfter.exec(this.ctx)).should.be.true();
+    (await this.overlapsContained.exec(this.ctx)).should.be.true();
+    (await this.overlapsContains.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept imprecise overlaps', function () {
-    this.impreciseOverlap.exec(this.ctx).should.be.true();
+  it('should accept imprecise overlaps', async function () {
+    (await this.impreciseOverlap.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject non-overlaps', function () {
-    this.noOverlap.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps', async function () {
+    (await this.noOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise non-overlaps', function () {
-    this.noImpreciseOverlap.exec(this.ctx).should.be.false();
+  it('should reject imprecise non-overlaps', async function () {
+    (await this.noImpreciseOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null for imprecise overlaps with differing precision', function () {
-    should(this.unknownOverlap.exec(this.ctx)).be.null();
+  it('should return null for imprecise overlaps with differing precision', async function () {
+    should(await this.unknownOverlap.exec(this.ctx)).be.null();
   });
 
-  it('should return true for imprecise overlaps with matching precision', function () {
-    this.matchingPrecisionOverlap.exec(this.ctx).should.be.true();
+  it('should return true for imprecise overlaps with matching precision', async function () {
+    (await this.matchingPrecisionOverlap.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.overlapsBeforeDayOfIvlEdge.exec(this.ctx).should.be.true();
-    this.overlapsAfterDayOfIvlEdge.exec(this.ctx).should.be.true();
-    this.overlapsContainsDayOfIvl.exec(this.ctx).should.be.true();
-    this.overlapsContainedByDayOfIvl.exec(this.ctx).should.be.true();
-    this.notOverlapsDayOfIvl.exec(this.ctx).should.be.false();
-    this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx).should.be.true();
-    should(this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    should(this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.overlapsBeforeDayOfIvlEdge.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfterDayOfIvlEdge.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainsDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainedByDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.notOverlapsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx)).should.be.true();
+    should(await this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    should(await this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -1071,30 +1071,30 @@ describe('OverlapsAfter', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps that are after (integer)', function () {
-    this.overlapsAfterIntIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryIntIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are after (integer)', async function () {
+    (await this.overlapsAfterIntIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryIntIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept overlaps that are after (real)', function () {
-    this.overlapsAfterRealIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryRealIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are after (real)', async function () {
+    (await this.overlapsAfterRealIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryRealIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject overlaps that are before (integer)', function () {
-    this.overlapsBeforeIntIvl.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are before (integer)', async function () {
+    (await this.overlapsBeforeIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject overlaps that are before (real)', function () {
-    this.overlapsBeforeRealIvl.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are before (real)', async function () {
+    (await this.overlapsBeforeRealIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (integer)', function () {
-    this.noOverlapsIntIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (integer)', async function () {
+    (await this.noOverlapsIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (real)', function () {
-    this.noOverlapsRealIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (real)', async function () {
+    (await this.noOverlapsRealIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1103,49 +1103,49 @@ describe('OverlapsAfterDateTime', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps that are after', function () {
-    this.overlapsAfter.exec(this.ctx).should.be.true();
-    this.overlapsContains.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are after', async function () {
+    (await this.overlapsAfter.exec(this.ctx)).should.be.true();
+    (await this.overlapsContains.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept imprecise overlaps that are after', function () {
-    this.impreciseOverlapAfter.exec(this.ctx).should.be.true();
+  it('should accept imprecise overlaps that are after', async function () {
+    (await this.impreciseOverlapAfter.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject overlaps that are not before', function () {
-    this.overlapsBefore.exec(this.ctx).should.be.false();
-    this.overlapsContained.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are not before', async function () {
+    (await this.overlapsBefore.exec(this.ctx)).should.be.false();
+    (await this.overlapsContained.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise overlaps that are not before', function () {
-    this.impreciseOverlapBefore.exec(this.ctx).should.be.false();
+  it('should reject imprecise overlaps that are not before', async function () {
+    (await this.impreciseOverlapBefore.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps', function () {
-    this.noOverlap.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps', async function () {
+    (await this.noOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise non-overlaps', function () {
-    this.noImpreciseOverlap.exec(this.ctx).should.be.false();
+  it('should reject imprecise non-overlaps', async function () {
+    (await this.noImpreciseOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true for imprecise overlaps with matching precision', function () {
-    this.matchingPrecisionOverlap.exec(this.ctx).should.be.true();
+  it('should return true for imprecise overlaps with matching precision', async function () {
+    (await this.matchingPrecisionOverlap.exec(this.ctx)).should.be.true();
   });
 
-  it('should return null for imprecise overlaps that are unknown', function () {
-    should(this.unknownOverlap.exec(this.ctx)).be.null();
+  it('should return null for imprecise overlaps that are unknown', async function () {
+    should(await this.unknownOverlap.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.overlapsBeforeDayOfIvlEdge.exec(this.ctx).should.be.false();
-    this.overlapsAfterDayOfIvlEdge.exec(this.ctx).should.be.true();
-    this.overlapsContainsDayOfIvl.exec(this.ctx).should.be.true();
-    this.overlapsContainedByDayOfIvl.exec(this.ctx).should.be.false();
-    this.notOverlapsDayOfIvl.exec(this.ctx).should.be.false();
-    this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx).should.be.true();
-    this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx).should.be.false();
-    should(this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.overlapsBeforeDayOfIvlEdge.exec(this.ctx)).should.be.false();
+    (await this.overlapsAfterDayOfIvlEdge.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainsDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainedByDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notOverlapsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx)).should.be.true();
+    (await this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
+    should(await this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).be.null();
   });
 });
 
@@ -1154,30 +1154,30 @@ describe('OverlapsBefore', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps that are before (integer)', function () {
-    this.overlapsBeforeIntIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryIntIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are before (integer)', async function () {
+    (await this.overlapsBeforeIntIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryIntIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept overlaps that are before (real)', function () {
-    this.overlapsBeforeRealIvl.exec(this.ctx).should.be.true();
-    this.overlapsBoundaryRealIvl.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are before (real)', async function () {
+    (await this.overlapsBeforeRealIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsBoundaryRealIvl.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject overlaps that are after (integer)', function () {
-    this.overlapsAfterIntIvl.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are after (integer)', async function () {
+    (await this.overlapsAfterIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject overlaps that are after (real)', function () {
-    this.overlapsAfterRealIvl.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are after (real)', async function () {
+    (await this.overlapsAfterRealIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (integer)', function () {
-    this.noOverlapsIntIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (integer)', async function () {
+    (await this.noOverlapsIntIvl.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps (real)', function () {
-    this.noOverlapsRealIvl.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps (real)', async function () {
+    (await this.noOverlapsRealIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1186,49 +1186,49 @@ describe('OverlapsBeforeDateTime', () => {
     setup(this, data);
   });
 
-  it('should accept overlaps that are before', function () {
-    this.overlapsBefore.exec(this.ctx).should.be.true();
-    this.overlapsContains.exec(this.ctx).should.be.true();
+  it('should accept overlaps that are before', async function () {
+    (await this.overlapsBefore.exec(this.ctx)).should.be.true();
+    (await this.overlapsContains.exec(this.ctx)).should.be.true();
   });
 
-  it('should accept imprecise overlaps that are before', function () {
-    this.impreciseOverlapBefore.exec(this.ctx).should.be.true();
+  it('should accept imprecise overlaps that are before', async function () {
+    (await this.impreciseOverlapBefore.exec(this.ctx)).should.be.true();
   });
 
-  it('should reject overlaps that are not before', function () {
-    this.overlapsAfter.exec(this.ctx).should.be.false();
-    this.overlapsContained.exec(this.ctx).should.be.false();
+  it('should reject overlaps that are not before', async function () {
+    (await this.overlapsAfter.exec(this.ctx)).should.be.false();
+    (await this.overlapsContained.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise overlaps that are not before', function () {
-    this.impreciseOverlapAfter.exec(this.ctx).should.be.false();
+  it('should reject imprecise overlaps that are not before', async function () {
+    (await this.impreciseOverlapAfter.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject non-overlaps', function () {
-    this.noOverlap.exec(this.ctx).should.be.false();
+  it('should reject non-overlaps', async function () {
+    (await this.noOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should reject imprecise non-overlaps', function () {
-    this.noImpreciseOverlap.exec(this.ctx).should.be.false();
+  it('should reject imprecise non-overlaps', async function () {
+    (await this.noImpreciseOverlap.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true for imprecise overlaps with matching precision', function () {
-    this.matchingPrecisionOverlap.exec(this.ctx).should.be.true();
+  it('should return true for imprecise overlaps with matching precision', async function () {
+    (await this.matchingPrecisionOverlap.exec(this.ctx)).should.be.true();
   });
 
-  it('should return null for imprecise overlaps that are unknown', function () {
-    should(this.unknownOverlap.exec(this.ctx)).be.null();
+  it('should return null for imprecise overlaps that are unknown', async function () {
+    should(await this.unknownOverlap.exec(this.ctx)).be.null();
   });
 
-  it('should correctly compare using the requested precision', function () {
-    this.overlapsBeforeDayOfIvlEdge.exec(this.ctx).should.be.true();
-    this.overlapsAfterDayOfIvlEdge.exec(this.ctx).should.be.false();
-    this.overlapsContainsDayOfIvl.exec(this.ctx).should.be.true();
-    this.overlapsContainedByDayOfIvl.exec(this.ctx).should.be.false();
-    this.notOverlapsDayOfIvl.exec(this.ctx).should.be.false();
-    this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx).should.be.false();
-    should(this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
-    this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx).should.be.false();
+  it('should correctly compare using the requested precision', async function () {
+    (await this.overlapsBeforeDayOfIvlEdge.exec(this.ctx)).should.be.true();
+    (await this.overlapsAfterDayOfIvlEdge.exec(this.ctx)).should.be.false();
+    (await this.overlapsContainsDayOfIvl.exec(this.ctx)).should.be.true();
+    (await this.overlapsContainedByDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.notOverlapsDayOfIvl.exec(this.ctx)).should.be.false();
+    (await this.overlapsAfterDayOfImpreciseInterval.exec(this.ctx)).should.be.false();
+    should(await this.mayOverlapBeforeDayOfImpreciseIvl.exec(this.ctx)).be.null();
+    (await this.mayOverlapAfterDayOfImpreciseIvl.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1237,54 +1237,54 @@ describe('Width', () => {
     setup(this, data);
   });
 
-  it('should calculate the width of integer intervals', function () {
+  it('should calculate the width of integer intervals', async function () {
     // define IntWidth: width of Interval[-2, 5]
-    this.intWidth.exec(this.ctx).should.equal(7);
+    (await this.intWidth.exec(this.ctx)).should.equal(7);
     // define IntOpenWidth: width of Interval(-2, 5)
-    this.intOpenWidth.exec(this.ctx).should.equal(5);
+    (await this.intOpenWidth.exec(this.ctx)).should.equal(5);
   });
 
-  it('should calculate the width of real intervals', function () {
+  it('should calculate the width of real intervals', async function () {
     // define RealWidth: width of Interval[1.23, 4.56]
-    this.realWidth.exec(this.ctx).should.equal(3.33);
+    (await this.realWidth.exec(this.ctx)).should.equal(3.33);
     // define RealOpenWidth: width of Interval(1.23, 4.56)
-    this.realOpenWidth.exec(this.ctx).should.equal(3.32999998);
+    (await this.realOpenWidth.exec(this.ctx)).should.equal(3.32999998);
   });
 
-  it('should calculate the width of infinite intervals', function () {
+  it('should calculate the width of infinite intervals', async function () {
     // define IntWidthThreeToMax: width of Interval[3, null]
-    this.intWidthThreeToMax.exec(this.ctx).should.equal(Math.pow(2, 31) - 4);
+    (await this.intWidthThreeToMax.exec(this.ctx)).should.equal(Math.pow(2, 31) - 4);
     // define IntWidthMinToThree: width of Interval[null, 3]
-    this.intWidthMinToThree.exec(this.ctx).should.equal(Math.pow(2, 31) + 3);
+    (await this.intWidthMinToThree.exec(this.ctx)).should.equal(Math.pow(2, 31) + 3);
   });
 
-  it('should calculate the width of infinite intervals that result in null', function () {
+  it('should calculate the width of infinite intervals that result in null', async function () {
     // define IntWidthThreeToUnknown: width of Interval[3, null)
-    should(this.intWidthThreeToUnknown.exec(this.ctx)).be.null();
+    should(await this.intWidthThreeToUnknown.exec(this.ctx)).be.null();
     // define IntWidthUnknownToThree: width of Interval(null, 3]
-    should(this.intWidthUnknownToThree.exec(this.ctx)).be.null();
+    should(await this.intWidthUnknownToThree.exec(this.ctx)).be.null();
   });
 
-  it('should calculate the width of interval of quantities', function () {
+  it('should calculate the width of interval of quantities', async function () {
     // define WidthOfQuantityInterval: width of Interval[Quantity{value: 1, unit: 'mm'}, Quantity{value: 10, unit: 'mm'}]
-    const width = this.widthOfQuantityInterval.exec(this.ctx);
+    const width = await this.widthOfQuantityInterval.exec(this.ctx);
     width.value.should.equal(9);
     width.unit.should.equal('mm');
   });
 
   it('should throw for DateTime Intervals', function () {
     // define WidthOfDateTimeInterval: width of Interval[DateTime(2012,01,01), DateTime(2012,01,03)]
-    should(() => this.widthOfDateTimeInterval.exec(this.ctx)).throw();
+    return this.widthOfDateTimeInterval.exec(this.ctx).should.be.rejected();
   });
 
   it('should throw for Date Intervals', function () {
     // define WidthOfDateInterval: width of Interval[Date(2012,01,01), Date(2012,01,03)]
-    should(() => this.widthOfDateInterval.exec(this.ctx)).throw();
+    return this.widthOfDateInterval.exec(this.ctx).should.be.rejected();
   });
 
   it('should throw for Time Intervals', function () {
     // define WidthOfTimeInterval: width of Interval[Time(12,00,00), Time(12,30,02)]
-    should(() => this.widthOfTimeInterval.exec(this.ctx)).throw();
+    return this.widthOfTimeInterval.exec(this.ctx).should.be.rejected();
   });
 });
 
@@ -1293,64 +1293,64 @@ describe('Size', () => {
     setup(this, data);
   });
 
-  it('should calculate the size of integer intervals', function () {
+  it('should calculate the size of integer intervals', async function () {
     // define IntSize: Size(Interval[-2, 5])
-    this.intSize.exec(this.ctx).should.equal(8);
+    (await this.intSize.exec(this.ctx)).should.equal(8);
     // define IntOpenSize: Size(Interval(-2, 5))
-    this.intOpenSize.exec(this.ctx).should.equal(6);
+    (await this.intOpenSize.exec(this.ctx)).should.equal(6);
   });
 
-  it('should calculate the size of real intervals', function () {
+  it('should calculate the size of real intervals', async function () {
     // define RealSize: Size(Interval[1.23, 4.56])
-    this.realSize.exec(this.ctx).should.equal(3.33 + MIN_FLOAT_PRECISION_VALUE);
+    (await this.realSize.exec(this.ctx)).should.equal(3.33 + MIN_FLOAT_PRECISION_VALUE);
     // define RealOpenSize: Size(Interval(1.23, 4.56))
-    this.realOpenSize.exec(this.ctx).should.equal(3.32999998 + MIN_FLOAT_PRECISION_VALUE);
+    (await this.realOpenSize.exec(this.ctx)).should.equal(3.32999998 + MIN_FLOAT_PRECISION_VALUE);
   });
 
-  it('should calculate the size of infinite intervals', function () {
+  it('should calculate the size of infinite intervals', async function () {
     // define IntSizeThreeToMax: Size(Interval[3, null])
-    this.intSizeThreeToMax.exec(this.ctx).should.equal(Math.pow(2, 31) - 4 + 1);
+    (await this.intSizeThreeToMax.exec(this.ctx)).should.equal(Math.pow(2, 31) - 4 + 1);
     // define IntSizeMinToThree: Size(Interval[null, 3])
-    this.intSizeMinToThree.exec(this.ctx).should.equal(Math.pow(2, 31) + 3 + 1);
+    (await this.intSizeMinToThree.exec(this.ctx)).should.equal(Math.pow(2, 31) + 3 + 1);
   });
 
-  it('should calculate the size of infinite intervals that result in null', function () {
+  it('should calculate the size of infinite intervals that result in null', async function () {
     // define IntSizeThreeToUnknown: Size(Interval[3, null))
-    should(this.intSizeThreeToUnknown.exec(this.ctx)).be.null();
+    should(await this.intSizeThreeToUnknown.exec(this.ctx)).be.null();
     // define IntSizeUnknownToThree: Size(Interval(null, 3])
-    should(this.intSizeUnknownToThree.exec(this.ctx)).be.null();
+    should(await this.intSizeUnknownToThree.exec(this.ctx)).be.null();
   });
 
-  it('should return null if integer is null', function () {
+  it('should return null if integer is null', async function () {
     // define SizeIsNull: Size(null as Interval<Integer>)
-    should(this.sizeIsNull.exec(this.ctx)).be.null();
+    should(await this.sizeIsNull.exec(this.ctx)).be.null();
   });
 
-  it('should return null if integer is null', function () {
+  it('should return null if integer is null', async function () {
     // define SizeIsNull: Size(null as Interval<Integer>)
-    should(this.sizeIsNull.exec(this.ctx)).be.null();
+    should(await this.sizeIsNull.exec(this.ctx)).be.null();
   });
 
-  it('should calculate size of interval of quantities', function () {
+  it('should calculate size of interval of quantities', async function () {
     // define SizeOfQuantityInterval: Size(Interval[Quantity{value: 1, unit: 'mm'}, Quantity{value: 10, unit: 'mm'}])
-    const size = this.sizeOfQuantityInterval.exec(this.ctx);
+    const size = await this.sizeOfQuantityInterval.exec(this.ctx);
     size.value.should.equal(10);
     size.unit.should.equal('mm');
   });
 
-  it('should throw for Date Interval', function () {
+  it('should throw for Date Interval', async function () {
     // define SizeOfDateTimeInterval: Size(Interval[DateTime(2012,01,01), DateTime(2012,01,03)])
-    should(() => this.sizeOfDateTimeInterval.exec(this.ctx)).throw();
+    return this.sizeOfDateTimeInterval.exec(this.ctx).should.be.rejected();
   });
 
-  it('should throw for DateTime Interval', function () {
+  it('should throw for DateTime Interval', async function () {
     // define SizeOfDateInterval: Size(Interval[Date(2012,01,01), Date(2012,01,03)])
-    should(() => this.sizeOfDateInterval.exec(this.ctx)).throw();
+    return this.sizeOfDateInterval.exec(this.ctx).should.be.rejected();
   });
 
-  it('should throw for Time Interval', function () {
+  it('should throw for Time Interval', async function () {
     // define SizeOfTimeInterval: Size(Interval[Time(12,00,00), Time(12,30,02)])
-    should(() => this.sizeOfTimeInterval.exec(this.ctx)).throw();
+    return await this.sizeOfTimeInterval.exec(this.ctx).should.be.rejected();
   });
 });
 
@@ -1359,38 +1359,38 @@ describe('Start', () => {
     setup(this, data);
   });
 
-  it('should return the low of the interval', function () {
-    this.closedNotNull.exec(this.ctx).should.eql(new DateTime(2012, 1, 1));
+  it('should return the low of the interval', async function () {
+    (await this.closedNotNull.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1));
   });
 
-  it('should return the minimum possible DateTime', function () {
-    this.closedNullDateTime.exec(this.ctx).should.eql(MIN_DATETIME_VALUE);
+  it('should return the minimum possible DateTime', async function () {
+    (await this.closedNullDateTime.exec(this.ctx)).should.eql(MIN_DATETIME_VALUE);
   });
 
-  it('should return the minimum possible DateTime in timzoneOffset of context', function () {
+  it('should return the minimum possible DateTime in timzoneOffset of context', async function () {
     // set execution timestamp to be +5
     this.ctx.executionDateTime = new DateTime(2019, 10, 1, 12, 31, 31, 2, 5);
-    this.closedNullDateTime.exec(this.ctx).timezoneOffset.should.eql(5);
+    (await this.closedNullDateTime.exec(this.ctx)).timezoneOffset.should.eql(5);
   });
 
-  it('should return the minimum possible Integer', function () {
-    this.closedNullInteger.exec(this.ctx).should.eql(MIN_INT_VALUE);
+  it('should return the minimum possible Integer', async function () {
+    (await this.closedNullInteger.exec(this.ctx)).should.eql(MIN_INT_VALUE);
   });
 
-  it('should return the minimum possible Decimal', function () {
-    this.closedNullDecimal.exec(this.ctx).should.eql(MIN_FLOAT_VALUE);
+  it('should return the minimum possible Decimal', async function () {
+    (await this.closedNullDecimal.exec(this.ctx)).should.eql(MIN_FLOAT_VALUE);
   });
 
-  it('should return null when the interval is null', function () {
-    should(this.nullInterval.exec(this.ctx)).be.null();
+  it('should return null when the interval is null', async function () {
+    should(await this.nullInterval.exec(this.ctx)).be.null();
   });
 
-  it('should return successor of low when the interval is open', function () {
-    this.openNotNull.exec(this.ctx).should.eql(new DateTime(2012, 1, 1).successor());
+  it('should return successor of low when the interval is open', async function () {
+    (await this.openNotNull.exec(this.ctx)).should.eql(new DateTime(2012, 1, 1).successor());
   });
 
-  it('should return null for open interval with null high value', function () {
-    should(this.openNull.exec(this.ctx)).be.null();
+  it('should return null for open interval with null high value', async function () {
+    should(await this.openNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -1399,38 +1399,38 @@ describe('End', () => {
     setup(this, data);
   });
 
-  it('should return the high of the interval', function () {
-    this.closedNotNull.exec(this.ctx).should.eql(new DateTime(2013, 1, 1));
+  it('should return the high of the interval', async function () {
+    (await this.closedNotNull.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1));
   });
 
-  it('should return the maximum possible DateTime', function () {
-    this.closedNullDateTime.exec(this.ctx).should.eql(MAX_DATETIME_VALUE);
+  it('should return the maximum possible DateTime', async function () {
+    (await this.closedNullDateTime.exec(this.ctx)).should.eql(MAX_DATETIME_VALUE);
   });
 
-  it('should return the maximum possible DateTime in timzoneOffset of context', function () {
+  it('should return the maximum possible DateTime in timzoneOffset of context', async function () {
     // set execution timestamp to be +5
     this.ctx.executionDateTime = new DateTime(2019, 10, 1, 12, 31, 31, 2, 5);
-    this.closedNullDateTime.exec(this.ctx).timezoneOffset.should.eql(5);
+    (await this.closedNullDateTime.exec(this.ctx)).timezoneOffset.should.eql(5);
   });
 
-  it('should return the maximum possible Integer', function () {
-    this.closedNullInteger.exec(this.ctx).should.eql(MAX_INT_VALUE);
+  it('should return the maximum possible Integer', async function () {
+    (await this.closedNullInteger.exec(this.ctx)).should.eql(MAX_INT_VALUE);
   });
 
-  it('should return the maximum possible Decimal', function () {
-    this.closedNullDecimal.exec(this.ctx).should.eql(MAX_FLOAT_VALUE);
+  it('should return the maximum possible Decimal', async function () {
+    (await this.closedNullDecimal.exec(this.ctx)).should.eql(MAX_FLOAT_VALUE);
   });
 
-  it('should return null when the interval is null', function () {
-    should(this.nullInterval.exec(this.ctx)).be.null();
+  it('should return null when the interval is null', async function () {
+    should(await this.nullInterval.exec(this.ctx)).be.null();
   });
 
-  it('should return predecessor of high when the interval is open', function () {
-    this.openNotNull.exec(this.ctx).should.eql(new DateTime(2013, 1, 1).predecessor());
+  it('should return predecessor of high when the interval is open', async function () {
+    (await this.openNotNull.exec(this.ctx)).should.eql(new DateTime(2013, 1, 1).predecessor());
   });
 
-  it('should return null for open interval with null low value', function () {
-    should(this.openNull.exec(this.ctx)).be.null();
+  it('should return null for open interval with null low value', async function () {
+    should(await this.openNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -1439,33 +1439,33 @@ describe('Starts', () => {
     setup(this, data);
   });
 
-  it('should calculate to null', function () {
-    should(this.testStartsNull.exec(this.ctx)).be.null();
+  it('should calculate to null', async function () {
+    should(await this.testStartsNull.exec(this.ctx)).be.null();
   });
 
-  it('should calculate integer intervals properly', function () {
-    this.integerIntervalStartsTrue.exec(this.ctx).should.be.true();
-    this.integerIntervalStartsFalse.exec(this.ctx).should.be.false();
-    this.integerIntervalStartEndsFalse.exec(this.ctx).should.be.false();
+  it('should calculate integer intervals properly', async function () {
+    (await this.integerIntervalStartsTrue.exec(this.ctx)).should.be.true();
+    (await this.integerIntervalStartsFalse.exec(this.ctx)).should.be.false();
+    (await this.integerIntervalStartEndsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate decimal intervals properly', function () {
-    this.decimalIntervalStartsTrue.exec(this.ctx).should.be.true();
-    this.decimalIntervalStartsFalse.exec(this.ctx).should.be.false();
-    this.decimalIntervalStartsEndsFalse.exec(this.ctx).should.be.false();
+  it('should calculate decimal intervals properly', async function () {
+    (await this.decimalIntervalStartsTrue.exec(this.ctx)).should.be.true();
+    (await this.decimalIntervalStartsFalse.exec(this.ctx)).should.be.false();
+    (await this.decimalIntervalStartsEndsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate quantity intervals properly', function () {
-    this.quantityIntervalStartsTrue.exec(this.ctx).should.be.true();
-    this.quantityIntervalStartsFalse.exec(this.ctx).should.be.false();
-    this.quantityIntervalStartsEndsFalse.exec(this.ctx).should.be.false();
+  it('should calculate quantity intervals properly', async function () {
+    (await this.quantityIntervalStartsTrue.exec(this.ctx)).should.be.true();
+    (await this.quantityIntervalStartsFalse.exec(this.ctx)).should.be.false();
+    (await this.quantityIntervalStartsEndsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate datetime intervals properly', function () {
-    this.dateTimeIntervalStartsTrue.exec(this.ctx).should.be.true();
-    this.dateTimeIntervalStartsFalse.exec(this.ctx).should.be.false();
-    this.dateTimeIntervalStartsDayOfTrue.exec(this.ctx).should.be.true();
-    this.dateTimeIntervalStartsEndsFalse.exec(this.ctx).should.be.false();
+  it('should calculate datetime intervals properly', async function () {
+    (await this.dateTimeIntervalStartsTrue.exec(this.ctx)).should.be.true();
+    (await this.dateTimeIntervalStartsFalse.exec(this.ctx)).should.be.false();
+    (await this.dateTimeIntervalStartsDayOfTrue.exec(this.ctx)).should.be.true();
+    (await this.dateTimeIntervalStartsEndsFalse.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1474,33 +1474,33 @@ describe('Ends', () => {
     setup(this, data);
   });
 
-  it('should calculate to null', function () {
-    should(this.testEndsNull.exec(this.ctx)).be.null();
+  it('should calculate to null', async function () {
+    should(await this.testEndsNull.exec(this.ctx)).be.null();
   });
 
-  it('should calculate integer intervals properly', function () {
-    this.integerIntervalEndsTrue.exec(this.ctx).should.be.true();
-    this.integerIntervalEndsFalse.exec(this.ctx).should.be.false();
-    this.integerIntervalEndsStartsFalse.exec(this.ctx).should.be.false();
+  it('should calculate integer intervals properly', async function () {
+    (await this.integerIntervalEndsTrue.exec(this.ctx)).should.be.true();
+    (await this.integerIntervalEndsFalse.exec(this.ctx)).should.be.false();
+    (await this.integerIntervalEndsStartsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate decimal intervals properly', function () {
-    this.decimalIntervalEndsTrue.exec(this.ctx).should.be.true();
-    this.decimalIntervalEndsFalse.exec(this.ctx).should.be.false();
-    this.decimalIntervalEndsStartsFalse.exec(this.ctx).should.be.false();
+  it('should calculate decimal intervals properly', async function () {
+    (await this.decimalIntervalEndsTrue.exec(this.ctx)).should.be.true();
+    (await this.decimalIntervalEndsFalse.exec(this.ctx)).should.be.false();
+    (await this.decimalIntervalEndsStartsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate quantity intervals properly', function () {
-    this.quantityIntervalEndsTrue.exec(this.ctx).should.be.true();
-    this.quantityIntervalEndsFalse.exec(this.ctx).should.be.false();
-    this.quantityIntervalEndsStartsFalse.exec(this.ctx).should.be.false();
+  it('should calculate quantity intervals properly', async function () {
+    (await this.quantityIntervalEndsTrue.exec(this.ctx)).should.be.true();
+    (await this.quantityIntervalEndsFalse.exec(this.ctx)).should.be.false();
+    (await this.quantityIntervalEndsStartsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should calculate datetime intervals properly', function () {
-    this.dateTimeIntervalEndsTrue.exec(this.ctx).should.be.true();
-    this.dateTimeIntervalEndsFalse.exec(this.ctx).should.be.false();
-    this.dateTimeIntervalEndsDayOfTrue.exec(this.ctx).should.be.true();
-    this.dateTimeIntervalEndsStartsFalse.exec(this.ctx).should.be.false();
+  it('should calculate datetime intervals properly', async function () {
+    (await this.dateTimeIntervalEndsTrue.exec(this.ctx)).should.be.true();
+    (await this.dateTimeIntervalEndsFalse.exec(this.ctx)).should.be.false();
+    (await this.dateTimeIntervalEndsDayOfTrue.exec(this.ctx)).should.be.true();
+    (await this.dateTimeIntervalEndsStartsFalse.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -1509,67 +1509,67 @@ describe('IntegerIntervalUnion', () => {
     setup(this, data);
   });
 
-  it('should properly calculate open and closed unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    let y = this.intClosedUnionClosed.exec(this.ctx);
+  it('should properly calculate open and closed unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    let y = await this.intClosedUnionClosed.exec(this.ctx);
     y.equals(x).should.be.true();
 
-    y = this.intClosedUnionOpen.exec(this.ctx);
+    y = await this.intClosedUnionOpen.exec(this.ctx);
     y.contains(0).should.be.true();
     y.contains(10).should.be.false();
 
-    y = this.intOpenUnionOpen.exec(this.ctx);
+    y = await this.intOpenUnionOpen.exec(this.ctx);
     y.contains(0).should.be.false();
     y.contains(10).should.be.false();
 
-    y = this.intOpenUnionClosed.exec(this.ctx);
+    y = await this.intOpenUnionClosed.exec(this.ctx);
     y.contains(0).should.be.false();
     y.contains(10).should.be.true();
   });
 
-  it('should properly calculate sameAs unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intSameAsUnion.exec(this.ctx);
+  it('should properly calculate sameAs unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intSameAsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate before/after unions', function () {
-    should(this.intBeforeUnion.exec(this.ctx)).be.null();
+  it('should properly calculate before/after unions', async function () {
+    should(await this.intBeforeUnion.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate meets unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intMeetsUnion.exec(this.ctx);
+  it('should properly calculate meets unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intMeetsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intOverlapsUnion.exec(this.ctx);
+  it('should properly calculate left/right overlapping unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intOverlapsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intBeginsUnion.exec(this.ctx);
+  it('should properly calculate begins/begun by unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intBeginsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate includes/included by unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intDuringUnion.exec(this.ctx);
+  it('should properly calculate includes/included by unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intDuringUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate ends/ended by unions', function () {
-    const x = this.intFullInterval.exec(this.ctx);
-    const y = this.intEndsUnion.exec(this.ctx);
+  it('should properly calculate ends/ended by unions', async function () {
+    const x = await this.intFullInterval.exec(this.ctx);
+    const y = await this.intEndsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly handle null unions', function () {
-    should(this.nullUnion.exec(this.ctx)).be.null();
-    should(this.unionNull.exec(this.ctx)).be.null();
+  it('should properly handle null unions', async function () {
+    should(await this.nullUnion.exec(this.ctx)).be.null();
+    should(await this.unionNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -1581,64 +1581,64 @@ describe('DateTimeIntervalUnion', () => {
     setup(this, data);
   });
 
-  it('should properly calculate open and closed unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    let y = this.dateTimeClosedUnionClosed.exec(this.ctx);
+  it('should properly calculate open and closed unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    let y = await this.dateTimeClosedUnionClosed.exec(this.ctx);
     y.equals(x).should.be.true();
 
     const a = new DateTime(2012, 1, 1, 0, 0, 0, 0);
     const b = new DateTime(2013, 1, 1, 0, 0, 0, 0);
 
-    y = this.dateTimeClosedUnionOpen.exec(this.ctx);
+    y = await this.dateTimeClosedUnionOpen.exec(this.ctx);
     y.contains(a).should.be.true();
     y.contains(b).should.be.false();
 
-    y = this.dateTimeOpenUnionOpen.exec(this.ctx);
+    y = await this.dateTimeOpenUnionOpen.exec(this.ctx);
     y.contains(a).should.be.false();
     y.contains(b).should.be.false();
 
-    y = this.dateTimeOpenUnionClosed.exec(this.ctx);
+    y = await this.dateTimeOpenUnionClosed.exec(this.ctx);
     y.contains(a).should.be.false();
     y.contains(b).should.be.true();
   });
 
-  it('should properly calculate sameAs unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeSameAsUnion.exec(this.ctx);
+  it('should properly calculate sameAs unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeSameAsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate before/after unions', function () {
-    should(this.dateTimeBeforeUnion.exec(this.ctx)).be.null();
+  it('should properly calculate before/after unions', async function () {
+    should(await this.dateTimeBeforeUnion.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate meets unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeMeetsUnion.exec(this.ctx);
+  it('should properly calculate meets unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeMeetsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeOverlapsUnion.exec(this.ctx);
+  it('should properly calculate left/right overlapping unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeOverlapsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeBeginsUnion.exec(this.ctx);
+  it('should properly calculate begins/begun by unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeBeginsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate includes/included by unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeDuringUnion.exec(this.ctx);
+  it('should properly calculate includes/included by unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeDuringUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate ends/ended by unions', function () {
-    const x = this.dateTimeFullInterval.exec(this.ctx);
-    const y = this.dateTimeEndsUnion.exec(this.ctx);
+  it('should properly calculate ends/ended by unions', async function () {
+    const x = await this.dateTimeFullInterval.exec(this.ctx);
+    const y = await this.dateTimeEndsUnion.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 });
@@ -1651,36 +1651,36 @@ describe('IntegerIntervalExcept', () => {
     setup(this, data);
   });
 
-  it('should properly calculate sameAs except', function () {
-    should(this.intSameAsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate sameAs except', async function () {
+    should(await this.intSameAsExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate before/after except', function () {
-    this.intBeforeExcept.exec(this.ctx).should.eql(new Interval(0, 4));
+  it('should properly calculate before/after except', async function () {
+    (await this.intBeforeExcept.exec(this.ctx)).should.eql(new Interval(0, 4));
   });
 
-  it('should properly calculate meets except', function () {
-    const x = this.intHalfInterval.exec(this.ctx);
-    const y = this.intMeetsExcept.exec(this.ctx);
+  it('should properly calculate meets except', async function () {
+    const x = await this.intHalfInterval.exec(this.ctx);
+    const y = await this.intMeetsExcept.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping except', function () {
-    const x = this.intHalfInterval.exec(this.ctx);
-    const y = this.intOverlapsExcept.exec(this.ctx);
+  it('should properly calculate left/right overlapping except', async function () {
+    const x = await this.intHalfInterval.exec(this.ctx);
+    const y = await this.intOverlapsExcept.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by except', function () {
-    should(this.intBeginsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate begins/begun by except', async function () {
+    should(await this.intBeginsExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate includes/included by except', function () {
-    should(this.intDuringExcept.exec(this.ctx)).be.null();
+  it('should properly calculate includes/included by except', async function () {
+    should(await this.intDuringExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate ends/ended by except', function () {
-    should(this.intEndsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate ends/ended by except', async function () {
+    should(await this.intEndsExcept.exec(this.ctx)).be.null();
   });
 });
 
@@ -1692,40 +1692,38 @@ describe('DateTimeIntervalExcept', () => {
     setup(this, data);
   });
 
-  it('should properly calculate sameAs except', function () {
-    should(this.dateTimeSameAsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate sameAs except', async function () {
+    should(await this.dateTimeSameAsExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate before/after except', function () {
-    this.dateTimeBeforeExcept
-      .exec(this.ctx)
-      .should.eql(
-        new Interval(new DateTime(2012, 1, 1, 0, 0, 0, 0), new DateTime(2012, 4, 1, 0, 0, 0, 0))
-      );
+  it('should properly calculate before/after except', async function () {
+    (await this.dateTimeBeforeExcept.exec(this.ctx)).should.eql(
+      new Interval(new DateTime(2012, 1, 1, 0, 0, 0, 0), new DateTime(2012, 4, 1, 0, 0, 0, 0))
+    );
   });
 
-  it('should properly calculate meets except', function () {
-    const x = this.dateTimeHalfInterval.exec(this.ctx);
-    const y = this.dateTimeMeetsExcept.exec(this.ctx);
+  it('should properly calculate meets except', async function () {
+    const x = await this.dateTimeHalfInterval.exec(this.ctx);
+    const y = await this.dateTimeMeetsExcept.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping except', function () {
-    const x = this.dateTimeHalfInterval.exec(this.ctx);
-    const y = this.dateTimeOverlapsExcept.exec(this.ctx);
+  it('should properly calculate left/right overlapping except', async function () {
+    const x = await this.dateTimeHalfInterval.exec(this.ctx);
+    const y = await this.dateTimeOverlapsExcept.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by except', function () {
-    should(this.dateTimeBeginsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate begins/begun by except', async function () {
+    should(await this.dateTimeBeginsExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate includes/included by except', function () {
-    should(this.dateTimeDuringExcept.exec(this.ctx)).be.null();
+  it('should properly calculate includes/included by except', async function () {
+    should(await this.dateTimeDuringExcept.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate ends/ended by except', function () {
-    should(this.dateTimeEndsExcept.exec(this.ctx)).be.null();
+  it('should properly calculate ends/ended by except', async function () {
+    should(await this.dateTimeEndsExcept.exec(this.ctx)).be.null();
   });
 });
 
@@ -1737,43 +1735,43 @@ describe('IntegerIntervalIntersect', () => {
     setup(this, data);
   });
 
-  it('should properly calculate sameAs intersect', function () {
-    const x = this.intSameAsIntersect.exec(this.ctx);
-    const y = this.intFullInterval.exec(this.ctx);
+  it('should properly calculate sameAs intersect', async function () {
+    const x = await this.intSameAsIntersect.exec(this.ctx);
+    const y = await this.intFullInterval.exec(this.ctx);
     x.equals(y).should.be.true();
   });
 
-  it('should properly calculate before/after intersect', function () {
-    should(this.intBeforeIntersect.exec(this.ctx)).be.null();
+  it('should properly calculate before/after intersect', async function () {
+    should(await this.intBeforeIntersect.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate meets intersect', function () {
-    const x = this.intMeetsInterval.exec(this.ctx);
-    const y = this.intMeetsIntersect.exec(this.ctx);
+  it('should properly calculate meets intersect', async function () {
+    const x = await this.intMeetsInterval.exec(this.ctx);
+    const y = await this.intMeetsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping intersect', function () {
-    const x = this.intOverlapsInterval.exec(this.ctx);
-    const y = this.intOverlapsIntersect.exec(this.ctx);
+  it('should properly calculate left/right overlapping intersect', async function () {
+    const x = await this.intOverlapsInterval.exec(this.ctx);
+    const y = await this.intOverlapsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by intersect', function () {
-    const x = this.intBeginsInterval.exec(this.ctx);
-    const y = this.intBeginsIntersect.exec(this.ctx);
+  it('should properly calculate begins/begun by intersect', async function () {
+    const x = await this.intBeginsInterval.exec(this.ctx);
+    const y = await this.intBeginsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate includes/included by intersect', function () {
-    const x = this.intDuringInterval.exec(this.ctx);
-    const y = this.intDuringIntersect.exec(this.ctx);
+  it('should properly calculate includes/included by intersect', async function () {
+    const x = await this.intDuringInterval.exec(this.ctx);
+    const y = await this.intDuringIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate ends/ended by intersect', function () {
-    const x = this.intEndsInterval.exec(this.ctx);
-    const y = this.intEndsIntersect.exec(this.ctx);
+  it('should properly calculate ends/ended by intersect', async function () {
+    const x = await this.intEndsInterval.exec(this.ctx);
+    const y = await this.intEndsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 });
@@ -1783,43 +1781,43 @@ describe('DateTimeIntervalIntersect', () => {
     setup(this, data);
   });
 
-  it('should properly calculate sameAs intersect', function () {
-    const x = this.dateTimeSameAsIntersect.exec(this.ctx);
-    const y = this.dateTimeFullInterval.exec(this.ctx);
+  it('should properly calculate sameAs intersect', async function () {
+    const x = await this.dateTimeSameAsIntersect.exec(this.ctx);
+    const y = await this.dateTimeFullInterval.exec(this.ctx);
     x.equals(y).should.be.true();
   });
 
-  it('should properly calculate before/after intersect', function () {
-    should(this.dateTimeBeforeIntersect.exec(this.ctx)).be.null();
+  it('should properly calculate before/after intersect', async function () {
+    should(await this.dateTimeBeforeIntersect.exec(this.ctx)).be.null();
   });
 
-  it('should properly calculate meets intersect', function () {
-    const x = this.dateTimeMeetsInterval.exec(this.ctx);
-    const y = this.dateTimeMeetsIntersect.exec(this.ctx);
+  it('should properly calculate meets intersect', async function () {
+    const x = await this.dateTimeMeetsInterval.exec(this.ctx);
+    const y = await this.dateTimeMeetsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate left/right overlapping intersect', function () {
-    const x = this.dateTimeOverlapsInterval.exec(this.ctx);
-    const y = this.dateTimeOverlapsIntersect.exec(this.ctx);
+  it('should properly calculate left/right overlapping intersect', async function () {
+    const x = await this.dateTimeOverlapsInterval.exec(this.ctx);
+    const y = await this.dateTimeOverlapsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate begins/begun by intersect', function () {
-    const x = this.dateTimeBeginsInterval.exec(this.ctx);
-    const y = this.dateTimeBeginsIntersect.exec(this.ctx);
+  it('should properly calculate begins/begun by intersect', async function () {
+    const x = await this.dateTimeBeginsInterval.exec(this.ctx);
+    const y = await this.dateTimeBeginsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate includes/included by intersect', function () {
-    const x = this.dateTimeDuringInterval.exec(this.ctx);
-    const y = this.dateTimeDuringIntersect.exec(this.ctx);
+  it('should properly calculate includes/included by intersect', async function () {
+    const x = await this.dateTimeDuringInterval.exec(this.ctx);
+    const y = await this.dateTimeDuringIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 
-  it('should properly calculate ends/ended by intersect', function () {
-    const x = this.dateTimeEndsInterval.exec(this.ctx);
-    const y = this.dateTimeEndsIntersect.exec(this.ctx);
+  it('should properly calculate ends/ended by intersect', async function () {
+    const x = await this.dateTimeEndsInterval.exec(this.ctx);
+    const y = await this.dateTimeEndsIntersect.exec(this.ctx);
     y.equals(x).should.be.true();
   });
 });
@@ -1832,41 +1830,49 @@ describe('IntegerIntervalCollapse', () => {
     setup(this, data);
   });
 
-  it('empty interval collapses to empty', function () {
-    this.intCollapseEmpty.exec(this.ctx).should.eql(this.intEmptyIntervalList.exec(this.ctx));
+  it('empty interval collapses to empty', async function () {
+    (await this.intCollapseEmpty.exec(this.ctx)).should.eql(
+      await this.intEmptyIntervalList.exec(this.ctx)
+    );
   });
 
-  it('single interval list collapse to self', function () {
-    this.intCollapseSingleInterval
-      .exec(this.ctx)
-      .should.eql(this.int1_10IntervalList.exec(this.ctx));
+  it('single interval list collapse to self', async function () {
+    (await this.intCollapseSingleInterval.exec(this.ctx)).should.eql(
+      await this.int1_10IntervalList.exec(this.ctx)
+    );
   });
 
-  it('disjoint intervals list collapses to ordered self', function () {
-    this.intCollapseDisjoint.exec(this.ctx).should.eql(this.intTwoItemDisjointList.exec(this.ctx));
-    this.intCollapseDisjointReversed
-      .exec(this.ctx)
-      .should.eql(this.intTwoItemDisjointList.exec(this.ctx));
+  it('disjoint intervals list collapses to ordered self', async function () {
+    (await this.intCollapseDisjoint.exec(this.ctx)).should.eql(
+      await this.intTwoItemDisjointList.exec(this.ctx)
+    );
+    (await this.intCollapseDisjointReversed.exec(this.ctx)).should.eql(
+      await this.intTwoItemDisjointList.exec(this.ctx)
+    );
   });
 
-  it('adjacent intervals list combines', function () {
-    this.intCollapseAdjacent.exec(this.ctx).should.eql(this.int1_15IntervalList.exec(this.ctx));
+  it('adjacent intervals list combines', async function () {
+    (await this.intCollapseAdjacent.exec(this.ctx)).should.eql(
+      await this.int1_15IntervalList.exec(this.ctx)
+    );
   });
 
-  it('overlapping intervals list combine', function () {
-    this.intCollapseOverlap.exec(this.ctx).should.eql(this.int1_12IntervalList.exec(this.ctx));
-    this.intCollapseOverlapContained
-      .exec(this.ctx)
-      .should.eql(this.int1_15IntervalList.exec(this.ctx));
-    this.intCollapseOverlapContainedEdge
-      .exec(this.ctx)
-      .should.eql(this.int1_10IntervalList.exec(this.ctx));
-    this.intCollapseOverlapContainedEdge2
-      .exec(this.ctx)
-      .should.eql(this.int1_15IntervalList.exec(this.ctx));
-    this.intCollapseOverlapMultipleCombine
-      .exec(this.ctx)
-      .should.eql(this.int1_15IntervalList.exec(this.ctx));
+  it('overlapping intervals list combine', async function () {
+    (await this.intCollapseOverlap.exec(this.ctx)).should.eql(
+      await this.int1_12IntervalList.exec(this.ctx)
+    );
+    (await this.intCollapseOverlapContained.exec(this.ctx)).should.eql(
+      await this.int1_15IntervalList.exec(this.ctx)
+    );
+    (await this.intCollapseOverlapContainedEdge.exec(this.ctx)).should.eql(
+      await this.int1_10IntervalList.exec(this.ctx)
+    );
+    (await this.intCollapseOverlapContainedEdge2.exec(this.ctx)).should.eql(
+      await this.int1_15IntervalList.exec(this.ctx)
+    );
+    (await this.intCollapseOverlapMultipleCombine.exec(this.ctx)).should.eql(
+      await this.int1_15IntervalList.exec(this.ctx)
+    );
   });
 });
 
@@ -1875,65 +1881,65 @@ describe('DateTimeIntervalCollapse', () => {
     setup(this, data);
   });
 
-  it('empty interval collapses to empty', function () {
-    this.dateTimeCollapseEmpty
-      .exec(this.ctx)
-      .should.eql(this.dateTimeEmptyIntervalList.exec(this.ctx));
+  it('empty interval collapses to empty', async function () {
+    (await this.dateTimeCollapseEmpty.exec(this.ctx)).should.eql(
+      await this.dateTimeEmptyIntervalList.exec(this.ctx)
+    );
   });
 
-  it('single interval list collapse to self', function () {
-    this.dateTimeCollapseSingleInterval
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_10IntervalList.exec(this.ctx));
+  it('single interval list collapse to self', async function () {
+    (await this.dateTimeCollapseSingleInterval.exec(this.ctx)).should.eql(
+      await this.dateTime1_10IntervalList.exec(this.ctx)
+    );
   });
 
-  it('disjoint intervals list collapses to ordered self', function () {
-    this.dateTimeCollapseDisjoint
-      .exec(this.ctx)
-      .should.eql(this.dateTimeTwoItemDisjointList.exec(this.ctx));
+  it('disjoint intervals list collapses to ordered self', async function () {
+    (await this.dateTimeCollapseDisjoint.exec(this.ctx)).should.eql(
+      await this.dateTimeTwoItemDisjointList.exec(this.ctx)
+    );
   });
 
-  it('reversed disjoint intervals list collapses to ordered self', function () {
-    this.dateTimeCollapseDisjointReversed
-      .exec(this.ctx)
-      .should.eql(this.dateTimeTwoItemDisjointList.exec(this.ctx));
+  it('reversed disjoint intervals list collapses to ordered self', async function () {
+    (await this.dateTimeCollapseDisjointReversed.exec(this.ctx)).should.eql(
+      await this.dateTimeTwoItemDisjointList.exec(this.ctx)
+    );
   });
 
-  it('adjacent intervals list combines', function () {
-    this.dateTimeCollapseAdjacent
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
+  it('adjacent intervals list combines', async function () {
+    (await this.dateTimeCollapseAdjacent.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
   });
 
-  it('overlapping intervals list combine', function () {
-    this.dateTimeCollapseOverlap
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_12IntervalList.exec(this.ctx));
-    this.dateTimeCollapseOverlapContained
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
-    this.dateTimeCollapseOverlapContainedEdge
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_10IntervalList.exec(this.ctx));
-    this.dateTimeCollapseOverlapContainedEdge2
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
-    this.dateTimeCollapseOverlapMultipleCombine
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
+  it('overlapping intervals list combine', async function () {
+    (await this.dateTimeCollapseOverlap.exec(this.ctx)).should.eql(
+      await this.dateTime1_12IntervalList.exec(this.ctx)
+    );
+    (await this.dateTimeCollapseOverlapContained.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
+    (await this.dateTimeCollapseOverlapContainedEdge.exec(this.ctx)).should.eql(
+      await this.dateTime1_10IntervalList.exec(this.ctx)
+    );
+    (await this.dateTimeCollapseOverlapContainedEdge2.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
+    (await this.dateTimeCollapseOverlapMultipleCombine.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
   });
 
-  it('throws collapsing imprecise interval', function () {
-    this.dateTimeCollapseImpreciseBoundary
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_10IntervalList.exec(this.ctx));
+  it('throws collapsing imprecise interval', async function () {
+    (await this.dateTimeCollapseImpreciseBoundary.exec(this.ctx)).should.eql(
+      await this.dateTime1_10IntervalList.exec(this.ctx)
+    );
   });
 
-  it('should not modify collapse parameters', function () {
+  it('should not modify collapse parameters', async function () {
     const interval1CopyString = this.dateTime1_6Interval.toString();
     const interval2CopyString = this.dateTime5_12Interval.toString();
     const interval3CopyString = this.dateTime10_15Interval.toString();
-    this.dateTimeCollapseOverlapMultipleCombine.exec(this.ctx);
+    await this.dateTimeCollapseOverlapMultipleCombine.exec(this.ctx);
     this.dateTime1_6Interval.toString().should.eql(interval1CopyString);
     this.dateTime5_12Interval.toString().should.eql(interval2CopyString);
     this.dateTime10_15Interval.toString().should.eql(interval3CopyString);
@@ -1945,203 +1951,219 @@ describe('Collapse', () => {
     setup(this, data);
   });
 
-  it('numeric collapse uses "1" as default per unit', function () {
-    this.intCollapseNoPer.exec(this.ctx).should.eql(this.intCollapsePerUnit1.exec(this.ctx));
+  it('numeric collapse uses "1" as default per unit', async function () {
+    (await this.intCollapseNoPer.exec(this.ctx)).should.eql(
+      await this.intCollapsePerUnit1.exec(this.ctx)
+    );
   });
 
-  it('combines intervals separated by less than per unit', function () {
-    this.intCollapseSeparatedListPer3
-      .exec(this.ctx)
-      .should.eql(this.expectedIntervalList.exec(this.ctx));
+  it('combines intervals separated by less than per unit', async function () {
+    (await this.intCollapseSeparatedListPer3.exec(this.ctx)).should.eql(
+      await this.expectedIntervalList.exec(this.ctx)
+    );
   });
 
-  it('DateTime collapse uses 1 ms as default per unit', function () {
+  it('DateTime collapse uses 1 ms as default per unit', async function () {
     // TODO: spec says to determine this based on width of successor, but Bonnie
     // will only ever have fully-defined dates. Implement successor way if time.
-    this.dateTimeCollapseNoPer.exec(this.ctx).should.eql(this.dateTimeCollapsePerMs.exec(this.ctx));
+    (await this.dateTimeCollapseNoPer.exec(this.ctx)).should.eql(
+      await this.dateTimeCollapsePerMs.exec(this.ctx)
+    );
   });
 
-  it('DateTime with null end collapse with no overlap', function () {
-    this.dateTimeNullEndCollapseNoOverlap
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullEndCollapseNoOverlapExpected.exec(this.ctx));
+  it('DateTime with null end collapse with no overlap', async function () {
+    (await this.dateTimeNullEndCollapseNoOverlap.exec(this.ctx)).should.eql(
+      await this.dateTimeNullEndCollapseNoOverlapExpected.exec(this.ctx)
+    );
   });
 
-  it('DateTime with null start collapse with no overlap', function () {
-    this.dateTimeNullStartCollapseNoOverlap
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullStartCollapseNoOverlapExpected.exec(this.ctx));
+  it('DateTime with null start collapse with no overlap', async function () {
+    (await this.dateTimeNullStartCollapseNoOverlap.exec(this.ctx)).should.eql(
+      await this.dateTimeNullStartCollapseNoOverlapExpected.exec(this.ctx)
+    );
   });
 
-  it('combines DateTime intervals separated by less than per unit', function () {
-    this.dateTimeCollapsePerDay
-      .exec(this.ctx)
-      .should.eql(this.dateTime1_15IntervalList.exec(this.ctx));
+  it('combines DateTime intervals separated by less than per unit', async function () {
+    (await this.dateTimeCollapsePerDay.exec(this.ctx)).should.eql(
+      await this.dateTime1_15IntervalList.exec(this.ctx)
+    );
   });
 
-  it('Date collapse overlapping intervals with no per', function () {
-    this.overlappingDateCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.date1_15Interval.exec(this.ctx)]);
+  it('Date collapse overlapping intervals with no per', async function () {
+    (await this.overlappingDateCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.date1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Date collapse adjacent intervals with no per', function () {
-    this.adjacentDateCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.date1_15Interval.exec(this.ctx)]);
+  it('Date collapse adjacent intervals with no per', async function () {
+    (await this.adjacentDateCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.date1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Date collapse disjoint intervals with no per', function () {
-    this.disjointDateCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.date1_2Interval.exec(this.ctx), this.date4_15Interval.exec(this.ctx)]);
+  it('Date collapse disjoint intervals with no per', async function () {
+    (await this.disjointDateCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.date1_2Interval.exec(this.ctx),
+      await this.date4_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Date collapse per day', function () {
-    this.dateCollapsePerDay
-      .exec(this.ctx)
-      .should.eql([this.date1_2Interval.exec(this.ctx), this.date4_15Interval.exec(this.ctx)]);
+  it('Date collapse per day', async function () {
+    (await this.dateCollapsePerDay.exec(this.ctx)).should.eql([
+      await this.date1_2Interval.exec(this.ctx),
+      await this.date4_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Date collapse per month', function () {
-    this.dateCollapsePerMonth.exec(this.ctx).should.eql([this.date1_15Interval.exec(this.ctx)]);
+  it('Date collapse per month', async function () {
+    (await this.dateCollapsePerMonth.exec(this.ctx)).should.eql([
+      await this.date1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse overlapping intervals with no per', function () {
-    this.overlappingTimeCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.time1_15Interval.exec(this.ctx)]);
+  it('Time collapse overlapping intervals with no per', async function () {
+    (await this.overlappingTimeCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.time1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse adjacent intervals with no per', function () {
-    this.adjacentTimeCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.time1_15Interval.exec(this.ctx)]);
+  it('Time collapse adjacent intervals with no per', async function () {
+    (await this.adjacentTimeCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.time1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse disjoint intervals with no per', function () {
-    this.disjointTimeCollapseNoPer
-      .exec(this.ctx)
-      .should.eql([this.time1_2Interval.exec(this.ctx), this.time4_15Interval.exec(this.ctx)]);
+  it('Time collapse disjoint intervals with no per', async function () {
+    (await this.disjointTimeCollapseNoPer.exec(this.ctx)).should.eql([
+      await this.time1_2Interval.exec(this.ctx),
+      await this.time4_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse per second', function () {
-    this.timeCollapsePerSecond
-      .exec(this.ctx)
-      .should.eql([this.time1_2Interval.exec(this.ctx), this.time4_15Interval.exec(this.ctx)]);
+  it('Time collapse per second', async function () {
+    (await this.timeCollapsePerSecond.exec(this.ctx)).should.eql([
+      await this.time1_2Interval.exec(this.ctx),
+      await this.time4_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Time collapse per minute', function () {
-    this.timeCollapsePerMinute.exec(this.ctx).should.eql([this.time1_15Interval.exec(this.ctx)]);
+  it('Time collapse per minute', async function () {
+    (await this.timeCollapsePerMinute.exec(this.ctx)).should.eql([
+      await this.time1_15Interval.exec(this.ctx)
+    ]);
   });
 
-  it('Quantity uses default per unit', function () {
-    const quantity_collapse = this.quantityIntervalCollapseNoPer.exec(this.ctx);
-    quantity_collapse.should.eql(this.expectedQuantityList.exec(this.ctx));
-    quantity_collapse.should.eql(this.quantityIntervalCollapsePerUnit1.exec(this.ctx));
+  it('Quantity uses default per unit', async function () {
+    const quantity_collapse = await this.quantityIntervalCollapseNoPer.exec(this.ctx);
+    quantity_collapse.should.eql(await this.expectedQuantityList.exec(this.ctx));
+    quantity_collapse.should.eql(await this.quantityIntervalCollapsePerUnit1.exec(this.ctx));
   });
 
-  it('Quantity with separated intervals', function () {
-    this.collapseSeparatedQuantity
-      .exec(this.ctx)
-      .should.eql(this.quantitySeparatedBy3.exec(this.ctx));
+  it('Quantity with separated intervals', async function () {
+    (await this.collapseSeparatedQuantity.exec(this.ctx)).should.eql(
+      await this.quantitySeparatedBy3.exec(this.ctx)
+    );
   });
 
-  it('Quantity combines disjoint intervals that are within per width', function () {
-    this.collapseSeparatedQuantityPer3
-      .exec(this.ctx)
-      .should.eql(this.expectedSeparatedQuantity.exec(this.ctx));
+  it('Quantity combines disjoint intervals that are within per width', async function () {
+    (await this.collapseSeparatedQuantityPer3.exec(this.ctx)).should.eql(
+      await this.expectedSeparatedQuantity.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units uses point type as default per value', function () {
-    this.collapseDisjointQuantityUnits
-      .exec(this.ctx)
-      .should.eql(this.expectedQuantityUnitsCollapse.exec(this.ctx));
+  it('Quantity with units uses point type as default per value', async function () {
+    (await this.collapseDisjointQuantityUnits.exec(this.ctx)).should.eql(
+      await this.expectedQuantityUnitsCollapse.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units disjoint but within per', function () {
-    this.collapseQuantityUnitsWithinPer
-      .exec(this.ctx)
-      .should.eql(this.expectedQuantityUnitsCollapse.exec(this.ctx));
+  it('Quantity with units disjoint but within per', async function () {
+    (await this.collapseQuantityUnitsWithinPer.exec(this.ctx)).should.eql(
+      await this.expectedQuantityUnitsCollapse.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units disjoint and not within per', function () {
-    this.collapseQuantityUnitsNotWithinPer
-      .exec(this.ctx)
-      .should.eql(this.quantityMeterIntervalList.exec(this.ctx));
+  it('Quantity with units disjoint and not within per', async function () {
+    (await this.collapseQuantityUnitsNotWithinPer.exec(this.ctx)).should.eql(
+      await this.quantityMeterIntervalList.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units with null low value', function () {
-    this.collapseQuantityNullLowUnitsWithinPer
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityNullLowUnitsWithinPerExpected.exec(this.ctx));
+  it('Quantity with units with null low value', async function () {
+    (await this.collapseQuantityNullLowUnitsWithinPer.exec(this.ctx)).should.eql(
+      await this.collapseQuantityNullLowUnitsWithinPerExpected.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units with null low and high values', function () {
-    this.collapseQuantityIntervalListWithNulls
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityIntervalListWithNullsExpected.exec(this.ctx));
+  it('Quantity with units with null low and high values', async function () {
+    (await this.collapseQuantityIntervalListWithNulls.exec(this.ctx)).should.eql(
+      await this.collapseQuantityIntervalListWithNullsExpected.exec(this.ctx)
+    );
   });
 
-  it('Quantity with units with null high value', function () {
-    this.collapseQuantityNullHighUnitsWithinPer
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityNullHighUnitsWithinPerExpected.exec(this.ctx));
+  it('Quantity with units with null high value', async function () {
+    (await this.collapseQuantityNullHighUnitsWithinPer.exec(this.ctx)).should.eql(
+      await this.collapseQuantityNullHighUnitsWithinPerExpected.exec(this.ctx)
+    );
   });
 
-  it('Quantity Intervals no overlap with null low', function () {
-    this.collapseQuantityIntervalListWithNullLowNoOverlap
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityIntervalListWithNullLowNoOverlapExpected.exec(this.ctx));
+  it('Quantity Intervals no overlap with null low', async function () {
+    (await this.collapseQuantityIntervalListWithNullLowNoOverlap.exec(this.ctx)).should.eql(
+      await this.collapseQuantityIntervalListWithNullLowNoOverlapExpected.exec(this.ctx)
+    );
   });
 
-  it('Quantity Intervals no overlap with null high', function () {
-    this.collapseQuantityIntervalListWithNullHighNoOverlap
-      .exec(this.ctx)
-      .should.eql(this.collapseQuantityIntervalListWithNullHighNoOverlapExpected.exec(this.ctx));
+  it('Quantity Intervals no overlap with null high', async function () {
+    (await this.collapseQuantityIntervalListWithNullHighNoOverlap.exec(this.ctx)).should.eql(
+      await this.collapseQuantityIntervalListWithNullHighNoOverlapExpected.exec(this.ctx)
+    );
   });
 
-  it('with Interval that has null low values', function () {
-    this.collapseNullLowIntervalList
-      .exec(this.ctx)
-      .should.eql(this.expectedNullLowIntervalCollapse.exec(this.ctx));
+  it('with Interval that has null low values', async function () {
+    (await this.collapseNullLowIntervalList.exec(this.ctx)).should.eql(
+      await this.expectedNullLowIntervalCollapse.exec(this.ctx)
+    );
   });
 
-  it('with Interval that has null high values', function () {
-    this.collapseNullHighIntervalList
-      .exec(this.ctx)
-      .should.eql(this.expectedNullHighIntervalCollapse.exec(this.ctx));
+  it('with Interval that has null high values', async function () {
+    (await this.collapseNullHighIntervalList.exec(this.ctx)).should.eql(
+      await this.expectedNullHighIntervalCollapse.exec(this.ctx)
+    );
   });
 
-  it('with Date Interval that has null start values', function () {
-    this.dateTimeNullStartCollapse
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullStartCollapseExpected.exec(this.ctx));
+  it('with Date Interval that has null start values', async function () {
+    (await this.dateTimeNullStartCollapse.exec(this.ctx)).should.eql(
+      await this.dateTimeNullStartCollapseExpected.exec(this.ctx)
+    );
   });
 
-  it('with Date Interval that has null high values', function () {
-    this.dateTimeNullEndCollapse
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullEndCollapseExpected.exec(this.ctx));
+  it('with Date Interval that has null high values', async function () {
+    (await this.dateTimeNullEndCollapse.exec(this.ctx)).should.eql(
+      await this.dateTimeNullEndCollapseExpected.exec(this.ctx)
+    );
   });
 
-  it('with Date Interval that has null high and low values', function () {
-    this.dateTimeNullStartEndCollapse
-      .exec(this.ctx)
-      .should.eql(this.dateTimeNullStartEndCollapseExpected.exec(this.ctx));
+  it('with Date Interval that has null high and low values', async function () {
+    (await this.dateTimeNullStartEndCollapse.exec(this.ctx)).should.eql(
+      await this.dateTimeNullStartEndCollapseExpected.exec(this.ctx)
+    );
   });
 
-  it('should ignore nulls in list of Intervals', function () {
-    this.nullInCollapse.exec(this.ctx).should.eql(this.expectedResultWithNull.exec(this.ctx));
+  it('should ignore nulls in list of Intervals', async function () {
+    (await this.nullInCollapse.exec(this.ctx)).should.eql(
+      await this.expectedResultWithNull.exec(this.ctx)
+    );
   });
 
-  it.skip('should return null if list is null', function () {
+  it.skip('should return null if list is null', async function () {
     // TODO: Translation Error
-    should.not.exist(this.nullCollapse.exec(this.ctx));
+    should.not.exist(await this.nullCollapse.exec(this.ctx));
   });
 
-  it('should use default per unit if per is expicitly null', function () {
-    this.nullPerCollapse.exec(this.ctx).should.eql(this.expectedResultNullPer.exec(this.ctx));
+  it('should use default per unit if per is expicitly null', async function () {
+    (await this.nullPerCollapse.exec(this.ctx)).should.eql(
+      await this.expectedResultNullPer.exec(this.ctx)
+    );
   });
 });
 
@@ -2157,163 +2179,163 @@ describe('DateIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands a closed interval per day', function () {
+  it('expands a closed interval per day', async function () {
     // define ClosedSinglePerDay: expand { Interval[@2018-01-01, @2018-01-03] } per day
-    const a = this.closedSinglePerDay.exec(this.ctx);
+    const a = await this.closedSinglePerDay.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
   });
 
-  it('expands a closed interval per week', function () {
+  it('expands a closed interval per week', async function () {
     // define ClosedSinglePerWeek: expand { Interval[@2018-01-01, @2018-01-21] } per week
-    const a = this.closedSinglePerWeek.exec(this.ctx);
+    const a = await this.closedSinglePerWeek.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }'
     );
   });
 
-  it('expands a closed interval per month', function () {
+  it('expands a closed interval per month', async function () {
     // define ClosedSinglePerMonth: expand { Interval[@2018-01-01, @2018-03-31] } per month
     // define ClosedSinglePerMonthTrunc: expand { Interval[@2018-01-01, @2018-04-29] } per month
-    const a = this.closedSinglePerMonth.exec(this.ctx);
-    const b = this.closedSinglePerMonthTrunc.exec(this.ctx);
+    const a = await this.closedSinglePerMonth.exec(this.ctx);
+    const b = await this.closedSinglePerMonthTrunc.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }');
     prettyList(b).should.equal(
       '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03], [2018-04, 2018-04] }'
     );
   });
 
-  it('expands a closed interval per year', function () {
+  it('expands a closed interval per year', async function () {
     // define ClosedSinglePerYear: expand { Interval[@2016-01-01, @2018-12-32] } per year
     // define ClosedSinglePerYearTrunc: expand { Interval[@2016-01-01, @2019-12-30] } per year
-    const a = this.closedSinglePerYear.exec(this.ctx);
-    const b = this.closedSinglePerYearTrunc.exec(this.ctx);
+    const a = await this.closedSinglePerYear.exec(this.ctx);
+    const b = await this.closedSinglePerYearTrunc.exec(this.ctx);
     prettyList(a).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018] }');
     prettyList(b).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018], [2019, 2019] }');
   });
 
-  it('ignores null item in list', function () {
+  it('ignores null item in list', async function () {
     // define NullInList: expand { Interval[@2018-01-01, @2018-01-03], null } per day
-    const a = this.nullInList.exec(this.ctx);
+    const a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
   });
 
-  it('expands two overlapping intervals', function () {
+  it('expands two overlapping intervals', async function () {
     // define Overlapping: expand { Interval[@2018-01-01, @2018-01-03], Interval[@2018-01-02, @2018-01-04] } per day
-    const a = this.overlapping.exec(this.ctx);
+    const a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03], [2018-01-04, 2018-01-04] }'
     );
   });
 
-  it('expands two non overlapping intervals', function () {
+  it('expands two non overlapping intervals', async function () {
     // define NonOverlapping: expand { Interval[@2018-01-01, @2018-01-03], Interval[@2018-01-08, @2018-01-08] } per day
-    const a = this.nonOverlapping.exec(this.ctx);
+    const a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03], [2018-01-08, 2018-01-08] }'
     );
   });
 
-  it('expands an interval with mid boundaries per day', function () {
+  it('expands an interval with mid boundaries per day', async function () {
     // define MidBoundariesPerDay: expand { Interval[@2017-12-30, @2018-01-01] } per day
-    const a = this.midBoundariesPerDay.exec(this.ctx);
+    const a = await this.midBoundariesPerDay.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2017-12-30, 2017-12-30], [2017-12-31, 2017-12-31], [2018-01-01, 2018-01-01] }'
     );
   });
 
-  it('expands an interval with mid boundaries per month', function () {
+  it('expands an interval with mid boundaries per month', async function () {
     // define MidBoundariesPerMonth: expand { Interval[@2017-11-14, @2018-01-18] } per month
-    const a = this.midBoundariesPerMonth.exec(this.ctx);
+    const a = await this.midBoundariesPerMonth.exec(this.ctx);
     prettyList(a).should.equal('{ [2017-11, 2017-11], [2017-12, 2017-12], [2018-01, 2018-01] }');
   });
 
-  it('expands an interval with mid boundaries per year', function () {
+  it('expands an interval with mid boundaries per year', async function () {
     // define MidBoundariesPerYear: expand { Interval[@2016-04-06, @2018-04-06] } per year
-    const a = this.midBoundariesPerYear.exec(this.ctx);
+    const a = await this.midBoundariesPerYear.exec(this.ctx);
     prettyList(a).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018] }');
   });
 
-  it('expands an interval with default per', function () {
+  it('expands an interval with default per', async function () {
     // define NoPerDefaultDay: expand { Interval[@2018-01-01, @2018-01-03] }
-    let a = this.noPerDefaultDay.exec(this.ctx);
+    let a = await this.noPerDefaultDay.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
 
     // define NoPerDefaultMonth: expand { Interval[@2018-01, @2018-03] }
-    a = this.noPerDefaultMonth.exec(this.ctx);
+    a = await this.noPerDefaultMonth.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }');
 
     // define NoPerDefaultYear: expand { Interval[@2016, @2018] }
-    a = this.noPerDefaultYear.exec(this.ctx);
+    a = await this.noPerDefaultYear.exec(this.ctx);
     prettyList(a).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018] }');
 
     // define NoPerDefaultMonthWithMismatch: expand { Interval[@2016, @2018-03] }
-    a = this.noPerDefaultMonthWithMismatch.exec(this.ctx);
+    a = await this.noPerDefaultMonthWithMismatch.exec(this.ctx);
     prettyList(a).should.equal('{ [2016, 2016], [2017, 2017], [2018, 2018] }');
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(@2018-01-01, @2018-01-03] } per day
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }');
 
     // define OpenEnd: expand { Interval[@2018-01-01, @2018-01-03) } per day
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02] }');
 
     // define OpenBoth: expand { Interval(@2018-01-01, @2018-01-03) } per day
-    a = this.openBoth.exec(this.ctx);
+    a = await this.openBoth.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-02, 2018-01-02] }');
   });
 
-  it('handles ends with mismatched precision', function () {
+  it('handles ends with mismatched precision', async function () {
     // define MismatchPrecision: expand { Interval[@2018-01-01, @2018-03] } per month
     let e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.mismatchPrecision.exec(this.ctx)).should.equal(e);
+    prettyList(await this.mismatchPrecision.exec(this.ctx)).should.equal(e);
 
     // define MismatchPrecisionResultLongerThanInput: expand { Interval[@2018-01, @2018-02-28] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02] }';
-    prettyList(this.mismatchPrecisionResultLongerThanInput.exec(this.ctx)).should.equal(e);
+    prettyList(await this.mismatchPrecisionResultLongerThanInput.exec(this.ctx)).should.equal(e);
   });
 
-  it('returns an empty list if we get an empty list', function () {
+  it('returns an empty list if we get an empty list', async function () {
     // define EmptyList: List<Interval<Date>>{}
-    const a = this.emptyList.exec(this.ctx);
+    const a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullOpen: expand { Interval[null, @2018-01-03] } per day
-    let a = this.nullOpen.exec(this.ctx);
+    let a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
 
     // define NullClose: expand { Interval[@2018-01-01, null] } per day
-    a = this.nullClose.exec(this.ctx);
+    a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
 
     // define NullBoth: expand { Interval[null, null] } per day
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns empty list when per is more precise than the interval ends', function () {
+  it('returns empty list when per is more precise than the interval ends', async function () {
     // define MonthDayPer: expand { Interval[@2018-01, @2018-03] } per day
-    this.monthDayPer.exec(this.ctx).should.be.empty();
+    (await this.monthDayPer.exec(this.ctx)).should.be.empty();
   });
 
-  it('returns null when per not applicable', function () {
+  it('returns null when per not applicable', async function () {
     // define BadPerMinute: expand { Interval[@2018-01-01, @2018-01-04] } per minute
-    let a = this.badPerMinute.exec(this.ctx);
+    let a = await this.badPerMinute.exec(this.ctx);
     should.not.exist(a);
 
     // define BadPerGram: expand { Interval[@2018-01-01, @2018-01-04] } per 1 'g'
-    a = this.badPerGram.exec(this.ctx);
+    a = await this.badPerGram.exec(this.ctx);
     should.not.exist(a);
   });
 });
@@ -2323,303 +2345,303 @@ describe('DateTimeIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands a millisecond precision datetime', function () {
+  it('expands a millisecond precision datetime', async function () {
     // define MsPrecPerYear: expand { Interval[@2016-01-01T00:00:00.000+00:00, @2018-01-01T00:00:00.000+00:00] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.msPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMonth: expand { Interval[@2018-01-01T00:00:00.000+00:00, @2018-03-01T00:00:00.000+00:00] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.msPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerWeek: expand { Interval[@2018-01-01T00:00:00.000+00:00, @2018-01-21T00:00:00.000+00:00] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }';
-    prettyList(this.msPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerDay: expand { Interval[@2018-01-01T00:00:00.000+00:00, @2018-01-03T00:00:00.000+00:00] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }';
-    prettyList(this.msPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerDay.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerHour: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T03:00:00.000+00:00] } per hour
     e =
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T03+00:00, 2018-01-01T03+00:00] }';
-    prettyList(this.msPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMinute: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T01:02:00.000+00:00] } per minute
     e =
       '{ [2018-01-01T01:00+00:00, 2018-01-01T01:00+00:00], [2018-01-01T01:01+00:00, 2018-01-01T01:01+00:00], [2018-01-01T01:02+00:00, 2018-01-01T01:02+00:00] }';
-    prettyList(this.msPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMinute.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerSecond: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T01:00:02.000+00:00] } per second
     e =
       '{ [2018-01-01T01:00:00+00:00, 2018-01-01T01:00:00+00:00], [2018-01-01T01:00:01+00:00, 2018-01-01T01:00:01+00:00], [2018-01-01T01:00:02+00:00, 2018-01-01T01:00:02+00:00] }';
-    prettyList(this.msPrecPerSecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerSecond.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMillisecond: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T01:00:00.001+00:00] } per millisecond
     e =
       '{ [2018-01-01T01:00:00.000+00:00, 2018-01-01T01:00:00.000+00:00], [2018-01-01T01:00:00.001+00:00, 2018-01-01T01:00:00.001+00:00] }';
-    prettyList(this.msPrecPerMillisecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMillisecond.exec(this.ctx)).should.equal(e);
   });
 
-  it('expands a second precision datetime', function () {
+  it('expands a second precision datetime', async function () {
     // define SecPrecPerYear: expand { Interval[@2016-01-01T00:00:00+00:00, @2018-01-01T00:00:00+00:00] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.secPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerMonth: expand { Interval[@2018-01-01T00:00:00+00:00, @2018-03-01T00:00:00+00:00] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.secPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerWeek: expand { Interval[@2018-01-01T00:00:00+00:00, @2018-01-21T00:00:00+00:00] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }';
-    prettyList(this.secPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerDay: expand { Interval[@2018-01-01T00:00:00+00:00, @2018-01-03T00:00:00+00:00] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }';
-    prettyList(this.secPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerDay.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerHour: expand { Interval[@2018-01-01T01:00:00+00:00, @2018-01-01T03:00:00+00:00] } per hour
     e =
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T03+00:00, 2018-01-01T03+00:00] }';
-    prettyList(this.secPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerMinute: expand { Interval[@2018-01-01T01:00:00+00:00, @2018-01-01T01:02:00+00:00] } per minute
     e =
       '{ [2018-01-01T01:00+00:00, 2018-01-01T01:00+00:00], [2018-01-01T01:01+00:00, 2018-01-01T01:01+00:00], [2018-01-01T01:02+00:00, 2018-01-01T01:02+00:00] }';
-    prettyList(this.secPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerMinute.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerSecond: expand { Interval[@2018-01-01T01:00:00+00:00, @2018-01-01T01:00:01+00:00] } per second
     e =
       '{ [2018-01-01T01:00:00+00:00, 2018-01-01T01:00:00+00:00], [2018-01-01T01:00:01+00:00, 2018-01-01T01:00:01+00:00] }';
-    prettyList(this.secPrecPerSecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerSecond.exec(this.ctx)).should.equal(e);
 
-    this.secPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.secPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a minute precision datetime', function () {
+  it('expands a minute precision datetime', async function () {
     // define MinPrecPerYear: expand { Interval[@2016-01-01T00:00+00:00, @2018-01-01T00:00+00:00] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.minPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerMonth: expand { Interval[@2018-01-01T00:00+00:00, @2018-03-01T00:00+00:00] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.minPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerWeek: expand { Interval[@2018-01-01T00:00+00:00, @2018-01-21T00:00+00:00] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }';
-    prettyList(this.minPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerDay: expand { Interval[@2018-01-01T00:00+00:00, @2018-01-03T00:00+00:00] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }';
-    prettyList(this.minPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerDay.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerHour: expand { Interval[@2018-01-01T01:00+00:00, @2018-01-01T03:00+00:00] } per hour
     e =
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T03+00:00, 2018-01-01T03+00:00] }';
-    prettyList(this.minPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerMinute: expand { Interval[@2018-01-01T01:00+00:00, @2018-01-01T01:01+00:00] } per minute
     e =
       '{ [2018-01-01T01:00+00:00, 2018-01-01T01:00+00:00], [2018-01-01T01:01+00:00, 2018-01-01T01:01+00:00] }';
-    prettyList(this.minPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerMinute.exec(this.ctx)).should.equal(e);
 
-    this.minPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.minPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.minPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.minPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands an hour precision datetime', function () {
+  it('expands an hour precision datetime', async function () {
     // define HourPrecPerYear: expand { Interval[@2016-01-01T00+00:00, @2018-01-01T00+00:00] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.hourPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define HourPrecPerMonth: expand { Interval[@2018-01-01T00+00:00, @2018-03-01T00+00:00] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.hourPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define HourPrecPerWeek: expand { Interval[@2018-01-01T00+00:00, @2018-01-21T00+00:00] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14], [2018-01-15, 2018-01-21] }';
-    prettyList(this.hourPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define HourPrecPerDay: expand { Interval[@2018-01-01T00+00:00, @2018-01-03T00+00:00] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }';
-    prettyList(this.hourPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerDay.exec(this.ctx)).should.equal(e);
 
     // define HourPrecPerHour: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T02+00:00] } per hour
     e =
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00] }';
-    prettyList(this.hourPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerHour.exec(this.ctx)).should.equal(e);
 
-    this.hourPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.hourPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.hourPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.hourPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.hourPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.hourPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a day precision datetime', function () {
+  it('expands a day precision datetime', async function () {
     // define DayPrecPerYear: expand { Interval[DateTime(2016,01,01), DateTime(2018,01,01)] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.dayPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.dayPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define DayPrecPerMonth: expand { Interval[DateTime(2018,01,01), DateTime(2018,03,01)] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02], [2018-03, 2018-03] }';
-    prettyList(this.dayPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.dayPrecPerMonth.exec(this.ctx)).should.equal(e);
 
     // define DayPrecPerWeek: expand { Interval[DateTime(2018,01,01), DateTime(2018,01,14)] } per week
     e = '{ [2018-01-01, 2018-01-07], [2018-01-08, 2018-01-14] }';
-    prettyList(this.dayPrecPerWeek.exec(this.ctx)).should.equal(e);
+    prettyList(await this.dayPrecPerWeek.exec(this.ctx)).should.equal(e);
 
     // define DayPrecPerDay: expand { Interval[DateTime(2018,01,01), DateTime(2018,01,02)] } per day
     e = '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02] }';
-    prettyList(this.dayPrecPerDay.exec(this.ctx)).should.equal(e);
+    prettyList(await this.dayPrecPerDay.exec(this.ctx)).should.equal(e);
 
-    this.dayPrecPerHour.exec(this.ctx).should.be.empty();
-    this.dayPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.dayPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.dayPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.dayPrecPerHour.exec(this.ctx)).should.be.empty();
+    (await this.dayPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.dayPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.dayPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a month precision datetime', function () {
+  it('expands a month precision datetime', async function () {
     // define MonthPrecPerYear: expand { Interval[DateTime(2016,01), DateTime(2018,01)] } per year
     let e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.monthPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.monthPrecPerYear.exec(this.ctx)).should.equal(e);
 
     // define MonthPrecPerMonth: expand { Interval[DateTime(2018,01), DateTime(2018,02)] } per month
     e = '{ [2018-01, 2018-01], [2018-02, 2018-02] }';
-    prettyList(this.monthPrecPerMonth.exec(this.ctx)).should.equal(e);
+    prettyList(await this.monthPrecPerMonth.exec(this.ctx)).should.equal(e);
 
-    this.monthPrecPerWeek.exec(this.ctx).should.be.empty();
-    this.monthPrecPerDay.exec(this.ctx).should.be.empty();
-    this.monthPrecPerHour.exec(this.ctx).should.be.empty();
-    this.monthPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.monthPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.monthPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.monthPrecPerWeek.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerDay.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerHour.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.monthPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a year precision datetime', function () {
+  it('expands a year precision datetime', async function () {
     // define YearPrecPerYear: expand { Interval[DateTime(2016), DateTime(2018)] } per year
     const e = '{ [2016, 2016], [2017, 2017], [2018, 2018] }';
-    prettyList(this.yearPrecPerYear.exec(this.ctx)).should.equal(e);
+    prettyList(await this.yearPrecPerYear.exec(this.ctx)).should.equal(e);
 
-    this.yearPrecPerMonth.exec(this.ctx).should.be.empty();
-    this.yearPrecPerWeek.exec(this.ctx).should.be.empty();
-    this.yearPrecPerDay.exec(this.ctx).should.be.empty();
-    this.yearPrecPerHour.exec(this.ctx).should.be.empty();
-    this.yearPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.yearPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.yearPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.yearPrecPerMonth.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerWeek.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerDay.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerHour.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.yearPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('ignores null item in list', function () {
+  it('ignores null item in list', async function () {
     // define NullInList: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T01+00:00], null } per hour
-    const a = this.nullInList.exec(this.ctx);
+    const a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-01T01+00:00, 2018-01-01T01+00:00] }');
   });
 
-  it('expands two overlapping intervals', function () {
+  it('expands two overlapping intervals', async function () {
     // define Overlapping: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T03+00:00], Interval[@2018-01-01T02+00:00, @2018-01-01T04+00:00] } per hour
-    const a = this.overlapping.exec(this.ctx);
+    const a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T03+00:00, 2018-01-01T03+00:00], [2018-01-01T04+00:00, 2018-01-01T04+00:00] }'
     );
   });
 
-  it('expands two non overlapping intervals', function () {
+  it('expands two non overlapping intervals', async function () {
     // define NonOverlapping: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T02+00:00], Interval[@2018-01-01T05+00:00, @2018-01-01T05+00:00] } per hour
-    const a = this.nonOverlapping.exec(this.ctx);
+    const a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01+00:00, 2018-01-01T01+00:00], [2018-01-01T02+00:00, 2018-01-01T02+00:00], [2018-01-01T05+00:00, 2018-01-01T05+00:00] }'
     );
   });
 
-  it('expands an interval with default per', function () {
+  it('expands an interval with default per', async function () {
     // # define NoPerDefaultMS: expand { Interval[@2018-01-01T01:00:00.000+00:00, @2018-01-01T01:00:00.001+00:00] }
-    let a = this.noPerDefaultMS.exec(this.ctx);
+    let a = await this.noPerDefaultMS.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01:00:00.000+00:00, 2018-01-01T01:00:00.000+00:00], [2018-01-01T01:00:00.001+00:00, 2018-01-01T01:00:00.001+00:00] }'
     );
 
     // # define NoPerDefaultSec: expand { Interval[@2018-01-01T01:00:00+00:00, @2018-01-01T01:00:01+00:00] }
-    a = this.noPerDefaultSec.exec(this.ctx);
+    a = await this.noPerDefaultSec.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01:00:00+00:00, 2018-01-01T01:00:00+00:00], [2018-01-01T01:00:01+00:00, 2018-01-01T01:00:01+00:00] }'
     );
 
     // # define NoPerDefaultMin: expand { Interval[@2018-01-01T01:00+00:00, @2018-01-01T01:01+00:00] }
-    a = this.noPerDefaultMin.exec(this.ctx);
+    a = await this.noPerDefaultMin.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01T01:00+00:00, 2018-01-01T01:00+00:00], [2018-01-01T01:01+00:00, 2018-01-01T01:01+00:00] }'
     );
 
     // define NoPerDefaultHour: expand { Interval[@2018-01-01T01+00:00, @2018-01-01T01+00:00] }
-    a = this.noPerDefaultHour.exec(this.ctx);
+    a = await this.noPerDefaultHour.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-01T01+00:00, 2018-01-01T01+00:00] }');
 
     // define NoPerDefaultDay: expand { Interval[DateTime(2018,01,01), DateTime(2018,01,01)] }
-    a = this.noPerDefaultDay.exec(this.ctx);
+    a = await this.noPerDefaultDay.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01-01, 2018-01-01] }');
 
     // define NoPerDefaultMonth: expand { Interval[DateTime(2018,01), DateTime(2018,01)]  }
-    a = this.noPerDefaultMonth.exec(this.ctx);
+    a = await this.noPerDefaultMonth.exec(this.ctx);
     prettyList(a).should.equal('{ [2018-01, 2018-01] }');
 
     // define NoPerDefaultYear: expand { Interval[DateTime(2018), DateTime(2018)]  }
-    a = this.noPerDefaultYear.exec(this.ctx);
+    a = await this.noPerDefaultYear.exec(this.ctx);
     prettyList(a).should.equal('{ [2018, 2018] }');
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(@2018-01-01T01+00:00, @2018-01-03T01+00:00] } per day
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
 
     // define OpenEnd: expand { Interval[@2018-01-01T01+00:00, @2018-01-03T01+00:00) } per day
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
 
     // define OpenBoth: expand { Interval(@2018-01-01T01+00:00, @2018-01-03T01+00:00) } per day
-    a = this.openBoth.exec(this.ctx);
+    a = await this.openBoth.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2018-01-01, 2018-01-01], [2018-01-02, 2018-01-02], [2018-01-03, 2018-01-03] }'
     );
   });
 
-  it('handles ends with mismatched precision', function () {
+  it('handles ends with mismatched precision', async function () {
     // define MismatchPrecision: expand { Interval[@2012-01-01T12:00+00:00, @2012-01-02T12:00:00+00:00] } per day
     let e = '{ [2012-01-01, 2012-01-01], [2012-01-02, 2012-01-02] }';
-    prettyList(this.mismatchPrecision.exec(this.ctx)).should.equal(e);
+    prettyList(await this.mismatchPrecision.exec(this.ctx)).should.equal(e);
 
     // define MismatchPrecisionResultLongerThanInput: expand { Interval[@2012-01-01T13:00:00+00:00, @2012-01-02T12:59+00:00] } per day
     e = '{ [2012-01-01, 2012-01-01], [2012-01-02, 2012-01-02] }';
-    prettyList(this.mismatchPrecisionResultLongerThanInput.exec(this.ctx)).should.equal(e);
+    prettyList(await this.mismatchPrecisionResultLongerThanInput.exec(this.ctx)).should.equal(e);
   });
 
-  it('returns an empty list if we get an empty list', function () {
+  it('returns an empty list if we get an empty list', async function () {
     // define EmptyList: List<Interval<Date>>{}
-    const a = this.emptyList.exec(this.ctx);
+    const a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullOpen: expand { Interval[null, @2018-01-03T01+00:00] } per day
-    let a = this.nullOpen.exec(this.ctx);
+    let a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
 
     // define NullClose: expand { Interval[@2018-01-01T01+00:00, null] } per day
-    a = this.nullClose.exec(this.ctx);
+    a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
 
     // define NullBoth: expand { Interval[null, null] } per day
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns null when per not applicable', function () {
+  it('returns null when per not applicable', async function () {
     // define BadPerGram: expand { Interval[@2018-01-01T01+00:00, @2018-01-04T01+00:00] } per 1 'g'
-    const a = this.badPerGram.exec(this.ctx);
+    const a = await this.badPerGram.exec(this.ctx);
     should.not.exist(a);
   });
 });
@@ -2629,61 +2651,61 @@ describe('TimeIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands a millisecond precision time', function () {
+  it('expands a millisecond precision time', async function () {
     // define MsPrecPerHour: expand { Interval[@T01:00:00.000, @T03:00:00.000] } per hour
     let e = '{ [01, 01], [02, 02], [03, 03] }';
-    prettyList(this.msPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMinute: expand { Interval[@T01:00:00.000, @T01:02:00.000] } per minute
     e = '{ [01:00, 01:00], [01:01, 01:01], [01:02, 01:02] }';
-    prettyList(this.msPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMinute.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerSecond: expand { Interval[@T01:00:00.000, @T01:00:02.000] } per second
     e = '{ [01:00:00, 01:00:00], [01:00:01, 01:00:01], [01:00:02, 01:00:02] }';
-    prettyList(this.msPrecPerSecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerSecond.exec(this.ctx)).should.equal(e);
 
     // define MsPrecPerMillisecond: expand { Interval[@T01:00:00.000, @T01:00:00.001] } per millisecond
     e = '{ [01:00:00.000, 01:00:00.000], [01:00:00.001, 01:00:00.001] }';
-    prettyList(this.msPrecPerMillisecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.msPrecPerMillisecond.exec(this.ctx)).should.equal(e);
   });
 
-  it('expands a second precision datetime', function () {
+  it('expands a second precision datetime', async function () {
     // define SecPrecPerHour: expand { Interval[@T01:00:00, @T03:00:00] } per hour
     let e = '{ [01, 01], [02, 02], [03, 03] }';
-    prettyList(this.secPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerMinute: expand { Interval[@T01:00:00, @T01:02:00] } per minute
     e = '{ [01:00, 01:00], [01:01, 01:01], [01:02, 01:02] }';
-    prettyList(this.secPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerMinute.exec(this.ctx)).should.equal(e);
 
     // define SecPrecPerSecond: expand { Interval[@T01:00:00, @T01:00:01] } per second
     e = '{ [01:00:00, 01:00:00], [01:00:01, 01:00:01] }';
-    prettyList(this.secPrecPerSecond.exec(this.ctx)).should.equal(e);
+    prettyList(await this.secPrecPerSecond.exec(this.ctx)).should.equal(e);
 
-    this.secPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.secPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands a minute precision datetime', function () {
+  it('expands a minute precision datetime', async function () {
     // define MinPrecPerHour: expand { Interval[@T01:00, @T03:00] } per hour
     let e = '{ [01, 01], [02, 02], [03, 03] }';
-    prettyList(this.minPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerHour.exec(this.ctx)).should.equal(e);
 
     // define MinPrecPerMinute: expand { Interval[@T01:00, @T01:01] } per minute
     e = '{ [01:00, 01:00], [01:01, 01:01] }';
-    prettyList(this.minPrecPerMinute.exec(this.ctx)).should.equal(e);
+    prettyList(await this.minPrecPerMinute.exec(this.ctx)).should.equal(e);
 
-    this.minPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.minPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.minPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.minPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 
-  it('expands an hour precision datetime', function () {
+  it('expands an hour precision datetime', async function () {
     // define HourPrecPerHour: expand { Interval[@T01, @T02] } per hour
     const e = '{ [01, 01], [02, 02] }';
-    prettyList(this.hourPrecPerHour.exec(this.ctx)).should.equal(e);
+    prettyList(await this.hourPrecPerHour.exec(this.ctx)).should.equal(e);
 
-    this.hourPrecPerMinute.exec(this.ctx).should.be.empty();
-    this.hourPrecPerSecond.exec(this.ctx).should.be.empty();
-    this.hourPrecPerMillisecond.exec(this.ctx).should.be.empty();
+    (await this.hourPrecPerMinute.exec(this.ctx)).should.be.empty();
+    (await this.hourPrecPerSecond.exec(this.ctx)).should.be.empty();
+    (await this.hourPrecPerMillisecond.exec(this.ctx)).should.be.empty();
   });
 });
 
@@ -2692,119 +2714,119 @@ describe('QuantityIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands single intervals', function () {
+  it('expands single intervals', async function () {
     // define ClosedSingleGPerG: expand { Interval[2 'g', 4 'g'] } per 1 'g'
-    let a = this.closedSingleGPerG.exec(this.ctx);
+    let a = await this.closedSingleGPerG.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define ClosedSingleGPerGDecimal: expand { Interval[2.1 'g', 4.1 'g'] } per 1 'g'
-    a = this.closedSingleGPerGDecimal.exec(this.ctx);
+    a = await this.closedSingleGPerGDecimal.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define ClosedSingleGPerMG: expand { Interval[2 'g', 2.003 'g'] } per 1 'mg'
-    a = this.closedSingleGPerMG.exec(this.ctx);
+    a = await this.closedSingleGPerMG.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2000 'mg', 2000 'mg'], [2001 'mg', 2001 'mg'], [2002 'mg', 2002 'mg'], [2003 'mg', 2003 'mg'] }"
     );
 
     // define ClosedSingleMGPerGTrunc: expand { Interval[2999 'mg', 4200 'mg'] } per 1 'g'
-    a = this.closedSingleMGPerGTrunc.exec(this.ctx);
+    a = await this.closedSingleMGPerGTrunc.exec(this.ctx);
     prettyList(a).should.equal("{ [2999 'mg', 3998 'mg'] }");
 
     // define ClosedSingleMGPerMGTrunc: expand { Interval[2000 'mg', 4500 'mg'] } per 800 'mg'
-    a = this.closedSingleMGPerMGTrunc.exec(this.ctx);
+    a = await this.closedSingleMGPerMGTrunc.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2000 'mg', 2799 'mg'], [2800 'mg', 3599 'mg'], [3600 'mg', 4399 'mg'] }"
     );
 
     // define ClosedSingleMGPerMGDecimal: expand { Interval[2000.01 'mg', 4500 'mg'] } per 800 'mg'
-    a = this.closedSingleMGPerMGDecimal.exec(this.ctx);
+    a = await this.closedSingleMGPerMGDecimal.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2000 'mg', 2799 'mg'], [2800 'mg', 3599 'mg'], [3600 'mg', 4399 'mg'] }"
     );
   });
 
-  it('expands lists of multiple intervals', function () {
+  it('expands lists of multiple intervals', async function () {
     // define NullInList: expand { Interval[2 'g', 4 'g'], null } per 1 'g'
-    let a = this.nullInList.exec(this.ctx);
+    let a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define Overlapping: expand { Interval[2 'g', 4 'g'], Interval[3 'g', 5 'g'] } per 1 'g'
-    a = this.overlapping.exec(this.ctx);
+    a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'], [5 'g', 5 'g'] }"
     );
 
     // define NonOverlapping: expand { Interval[2 'g', 4 'g'], Interval[6 'g', 6 'g'] } per 1 'g'
-    a = this.nonOverlapping.exec(this.ctx);
+    a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal(
       "{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'], [6 'g', 6 'g'] }"
     );
   });
 
-  it('expands interval using the first items units if no per provided', function () {
+  it('expands interval using the first items units if no per provided', async function () {
     // define NoPerDefaultM: expand { Interval[2 'm', 400 'cm'] }
-    let a = this.noPerDefaultM.exec(this.ctx);
+    let a = await this.noPerDefaultM.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'm', 2 'm'], [3 'm', 3 'm'], [4 'm', 4 'm'] }");
 
     // define NoPerDefaultG: expand { Interval[2 'g', 4 'g'] }
-    a = this.noPerDefaultG.exec(this.ctx);
+    a = await this.noPerDefaultG.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(2 'g', 4 'g'] } per 1 'g'
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal("{ [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define OpenEnd: expand { Interval[2 'g', 4 'g') } per 1 'g'
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'] }");
 
     // define OpenBoth: expand { Interval(2 'g', 4 'g') } per 1 'g'
-    a = this.openBoth.exec(this.ctx);
+    a = await this.openBoth.exec(this.ctx);
     prettyList(a).should.equal("{ [3 'g', 3 'g'] }");
 
     // define OpenBothDecimal: expand { Interval(2.1 'g', 4.1 'g') } per 1 'g'
-    a = this.openBothDecimal.exec(this.ctx);
+    a = await this.openBothDecimal.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
 
     // define OpenBothDecimalTrunc: expand { Interval(2.1 'g', 4.101 'g') } per 1 'g'
-    a = this.openBothDecimalTrunc.exec(this.ctx);
+    a = await this.openBothDecimalTrunc.exec(this.ctx);
     prettyList(a).should.equal("{ [2 'g', 2 'g'], [3 'g', 3 'g'], [4 'g', 4 'g'] }");
   });
 
-  it('returns an empty list if we get an empty list or if there are no results', function () {
+  it('returns an empty list if we get an empty list or if there are no results', async function () {
     // define EmptyList: List<Interval<Date>>{}
-    let a = this.emptyList.exec(this.ctx);
+    let a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
 
     // define PerTooBig: expand { Interval[2 'g', 4 'g'], null } per 5 'g'
-    a = this.perTooBig.exec(this.ctx);
+    a = await this.perTooBig.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullClose: expand { Interval[2 'g', null] } per 1 'g'
-    let a = this.nullClose.exec(this.ctx);
+    let a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
     // define NullOpen: expand { Interval[null, 4 'g'] } per 1 'g'
-    a = this.nullOpen.exec(this.ctx);
+    a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
     // define NullBoth: expand { Interval[null, null] } per 1 'g'
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns null when per not applicable or mismatch interval', function () {
+  it('returns null when per not applicable or mismatch interval', async function () {
     // define BadPerMinute: expand { Interval(2 'g', 4 'g'] } per 1 minute
-    let a = this.badPerMinute.exec(this.ctx);
+    let a = await this.badPerMinute.exec(this.ctx);
     should.not.exist(a);
 
     // define BadPerGram: expand { Interval(2 'km', 4 'km'] }  per 1 'g'
-    a = this.badPerGram.exec(this.ctx);
+    a = await this.badPerGram.exec(this.ctx);
     should.not.exist(a);
   });
 });
@@ -2814,87 +2836,87 @@ describe('IntegerIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands single intervals', function () {
+  it('expands single intervals', async function () {
     // define ClosedSinglePer1: expand { Interval[2, 4] } per 1 '1'
-    let a = this.closedSinglePer1.exec(this.ctx);
+    let a = await this.closedSinglePer1.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4] }');
 
     // define ClosedSinglePer3: expand { Interval[2, 10] } per 3 '1'
-    a = this.closedSinglePer3.exec(this.ctx);
+    a = await this.closedSinglePer3.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 4], [5, 7], [8, 10] }');
 
     // define ClosedSinglePer3NoteTheWidth: expand { Interval[2, 4] } per 3 '1'
-    a = this.closedSinglePer3NoteTheWidth.exec(this.ctx);
+    a = await this.closedSinglePer3NoteTheWidth.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 4] }');
   });
 
-  it('expands lists of multiple intervals', function () {
+  it('expands lists of multiple intervals', async function () {
     // define NullInList: expand { Interval[2, 4], null } per 1 '1'
-    let a = this.nullInList.exec(this.ctx);
+    let a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4] }');
 
     // define Overlapping: expand { Interval[2, 4], Interval[3, 5] } per 1 '1'
-    a = this.overlapping.exec(this.ctx);
+    a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4], [5, 5] }');
 
     // define NonOverlapping: expand { Interval[2, 4], Interval[6, 6] } per 1 '1'
-    a = this.nonOverlapping.exec(this.ctx);
+    a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4], [6, 6] }');
   });
 
-  it('expands interval using default per of 1', function () {
+  it('expands interval using default per of 1', async function () {
     // define NoPer: expand { Interval[2, 4] }
-    const a = this.noPer.exec(this.ctx);
+    const a = await this.noPer.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4] }');
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(2, 4] } per 1 '1'
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal('{ [3, 3], [4, 4] }');
 
     // define OpenEnd: expand { Interval[2, 4) } per 1 '1'
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3] }');
 
     // define OpenBoth: expand { Interval(2, 4) } per 1 '1'
-    a = this.openBoth.exec(this.ctx);
+    a = await this.openBoth.exec(this.ctx);
     prettyList(a).should.equal('{ [3, 3] }');
   });
 
-  it('returns an empty list if we get an empty list or if there are no results', function () {
+  it('returns an empty list if we get an empty list or if there are no results', async function () {
     // define EmptyList: List<Interval<Integer>>{}
-    let a = this.emptyList.exec(this.ctx);
+    let a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
 
     // define PerTooBig: expand { Interval[2, 4], null } per 5 '1'
-    a = this.perTooBig.exec(this.ctx);
+    a = await this.perTooBig.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.length.should.equal(0);
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullClose: expand { Interval[2, null] } per 1 '1'
-    let a = this.nullClose.exec(this.ctx);
+    let a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
     // define NullOpen: expand { Interval[null, 4] } per 1 '1'
-    a = this.nullOpen.exec(this.ctx);
+    a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
     // define NullBoth: expand { Interval[null, null] } per 1 '1'
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns null when per not applicable or mismatch interval', function () {
+  it('returns null when per not applicable or mismatch interval', async function () {
     // define BadPerMinute: expand { Interval(2, 4] } per 1 minute
-    const a = this.badPerMinute.exec(this.ctx);
+    const a = await this.badPerMinute.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('produces a more precise value for output intervals', function () {
+  it('produces a more precise value for output intervals', async function () {
     // define PerDecimalMorePrecise: expand { Interval[10, 10] } per 0.1
-    const a = this.perDecimalMorePrecise.exec(this.ctx);
+    const a = await this.perDecimalMorePrecise.exec(this.ctx);
     // JavaScript truncates 10.0 to 10.
     prettyList(a).should.equal(
       '{ [10, 10.09999999], [10.1, 10.19999999], [10.2, 10.29999999], [10.3, 10.39999999], [10.4, 10.49999999], [10.5, 10.59999999], [10.6, 10.69999999], [10.7, 10.79999999], [10.8, 10.89999999], [10.9, 10.99999999] }'
@@ -2907,84 +2929,84 @@ describe('DecimalIntervalExpand', () => {
     setup(this, data);
   });
 
-  it('expands single intervals', function () {
+  it('expands single intervals', async function () {
     // define ClosedSingle: expand { Interval[2, 5] } per 1.5 '1'
-    let a = this.closedSingle.exec(this.ctx);
+    let a = await this.closedSingle.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999], [3.5, 4.99999999] }');
 
     // define ClosedSingle1: expand { Interval[2.5, 10] } per 2 '1'
-    a = this.closedSingle1.exec(this.ctx);
+    a = await this.closedSingle1.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3], [4, 5], [6, 7], [8, 9] }');
 
     // define ClosedSingle2: expand { Interval[2, 4.5] } per 0.5 '1'
-    a = this.closedSingle2.exec(this.ctx);
+    a = await this.closedSingle2.exec(this.ctx);
     prettyList(a).should.equal(
       '{ [2, 2.49999999], [2.5, 2.99999999], [3, 3.49999999], [3.5, 3.99999999], [4, 4.49999999] }'
     );
   });
 
-  it('expands lists of multiple intervals', function () {
+  it('expands lists of multiple intervals', async function () {
     // define NullInList: expand { Interval[2, 5], null } per 1.5 '1'
-    let a = this.nullInList.exec(this.ctx);
+    let a = await this.nullInList.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999], [3.5, 4.99999999] }');
 
     // define Overlapping: expand { Interval[2, 5], Interval[4, 7] } per 1.5 '1'
-    a = this.overlapping.exec(this.ctx);
+    a = await this.overlapping.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999], [3.5, 4.99999999], [5, 6.49999999] }');
 
     // define NonOverlapping: expand { Interval[2, 4], Interval[6, 8] } per 1.5 '1'
-    a = this.nonOverlapping.exec(this.ctx);
+    a = await this.nonOverlapping.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999], [6, 7.49999999] }');
   });
 
-  it('expands interval using default per of 1', function () {
+  it('expands interval using default per of 1', async function () {
     // define NoPer: expand { Interval[2.5, 4.5] }
-    const a = this.noPer.exec(this.ctx);
+    const a = await this.noPer.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 2], [3, 3], [4, 4] }');
   });
 
-  it('expands interval with open ends', function () {
+  it('expands interval with open ends', async function () {
     // define OpenStart: expand { Interval(2, 5] } per 1.5 '1'
-    let a = this.openStart.exec(this.ctx);
+    let a = await this.openStart.exec(this.ctx);
     prettyList(a).should.equal('{ [3, 4.49999999] }');
 
     // define OpenEnd: expand { Interval[2, 5) } per 1.5 '1'
-    a = this.openEnd.exec(this.ctx);
+    a = await this.openEnd.exec(this.ctx);
     prettyList(a).should.equal('{ [2, 3.49999999] }');
 
     // define OpenBoth: expand { Interval(2, 5) } per 1.5 '1'
-    this.openBoth.exec(this.ctx).should.be.empty();
+    (await this.openBoth.exec(this.ctx)).should.be.empty();
   });
 
-  it('returns an empty list if we get an empty list', function () {
+  it('returns an empty list if we get an empty list', async function () {
     // define EmptyList: List<Interval<Decimal>>{}
-    const a = this.emptyList.exec(this.ctx);
+    const a = await this.emptyList.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.should.be.empty();
   });
 
-  it('returns an empty list if we get an interval with a null boundary', function () {
+  it('returns an empty list if we get an interval with a null boundary', async function () {
     // define PerTooBig: expand { Interval[2, 4], null } per 5.5 '1'
-    const a = this.perTooBig.exec(this.ctx);
+    const a = await this.perTooBig.exec(this.ctx);
     a.should.be.instanceof(Array);
     a.should.be.empty();
   });
 
-  it('returns null with open ended intervals', function () {
+  it('returns null with open ended intervals', async function () {
     // define NullClose: expand { Interval[2, null] } per 1.5 '1'
-    let a = this.nullClose.exec(this.ctx);
+    let a = await this.nullClose.exec(this.ctx);
     should.not.exist(a);
     // define NullOpen: expand { Interval[null, 4] } per 1.5 '1'
-    a = this.nullOpen.exec(this.ctx);
+    a = await this.nullOpen.exec(this.ctx);
     should.not.exist(a);
     // define NullBoth: expand { Interval[null, null] } per 1.5 '1'
-    a = this.nullBoth.exec(this.ctx);
+    a = await this.nullBoth.exec(this.ctx);
     should.not.exist(a);
   });
 
-  it('returns null when per not applicable or mismatch interval', function () {
+  it('returns null when per not applicable or mismatch interval', async function () {
     // define BadPerMinute: expand { Interval(2.1, 4.1] } per 0.5 minute
-    const a = this.badPerMinute.exec(this.ctx);
+    const a = await this.badPerMinute.exec(this.ctx);
     should.not.exist(a);
   });
 });
@@ -2994,240 +3016,240 @@ describe('SameAs', () => {
     setup(this, data);
   });
 
-  it('returns true when both intervals values are null and closed', function () {
+  it('returns true when both intervals values are null and closed', async function () {
     // define NullBoth: Interval[null,null] same as Interval[null,null]
-    this.nullBoth.exec(this.ctx).should.be.true();
+    (await this.nullBoth.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when one intervals low and high are null', function () {
+  it('returns false when one intervals low and high are null', async function () {
     // define NullOne: Interval[DateTime(2018,01,01), DateTime(2018,02,02)] same as Interval[null,null]
-    this.nullOne.exec(this.ctx).should.be.false();
+    (await this.nullOne.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when both intervals are the same', function () {
+  it('returns true when both intervals are the same', async function () {
     // define Equal: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[DateTime(2018,01,01), DateTime(2018,01,01)]
-    this.equal.exec(this.ctx).should.be.true();
+    (await this.equal.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when both intervals are not the same', function () {
+  it('returns false when both intervals are not the same', async function () {
     // define NotEqual: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[DateTime(2018,02,01), DateTime(2018,05,01)]
-    this.notEqual.exec(this.ctx).should.be.false();
+    (await this.notEqual.exec(this.ctx)).should.be.false();
   });
 
-  it('returns null when comparing date and datetime because precision is changed when converting date to datetime', function () {
+  it('returns null when comparing date and datetime because precision is changed when converting date to datetime', async function () {
     // define DateTimeAndDateComparisonEqual: Interval[DateTime(2018,01,01), DateTime(2018,01,01)] same as Interval[Date(2018,01,01), Date(2018,01,01)]
-    const a = this.dateTimeAndDateComparisonEqual.exec(this.ctx);
+    const a = await this.dateTimeAndDateComparisonEqual.exec(this.ctx);
     should(a).be.null();
   });
 
-  it('returns null when both intervals are null', function () {
+  it('returns null when both intervals are null', async function () {
     // define NullIntervals: (null as Interval<DateTime>) same as (null as Interval<DateTime>)
-    const a = this.nullIntervals.exec(this.ctx);
+    const a = await this.nullIntervals.exec(this.ctx);
     should(a).be.null();
   });
 
-  it('returns true when comparing a closed interval and open interval after it is converted', function () {
+  it('returns true when comparing a closed interval and open interval after it is converted', async function () {
     // define OpenAndClosed: Interval[DateTime(2018,01,01,00,00,00,0), DateTime(2019,01,01,00,00,00,0)) same as Interval[DateTime(2018,01,01,00,00,00,0), DateTime(2018,12,31,23,59,59,999)]
-    this.openAndClosed.exec(this.ctx).should.be.true();
+    (await this.openAndClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when both intervals are open ended', function () {
+  it('returns true when both intervals are open ended', async function () {
     // define OpenEnded: Interval[DateTime(2018,01,01), null] same day as Interval[DateTime(2018,01,01), null]
-    this.openEnded.exec(this.ctx).should.be.true();
+    (await this.openEnded.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when the first interval is open ended and the second is not', function () {
+  it('returns false when the first interval is open ended and the second is not', async function () {
     // define OpenEndedNotSame: Interval[DateTime(2018,01,01), null] same day as Interval[DateTime(2018,01,01), DateTime(2019,01,01)]
-    this.openEndedNotSame.exec(this.ctx).should.be.false();
+    (await this.openEndedNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns false when the second interval is open and the first is not', function () {
+  it('returns false when the second interval is open and the first is not', async function () {
     // define OpenEndedNotSame2: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same day as Interval[DateTime(2018,01,01), null]
-    this.openEndedNotSame2.exec(this.ctx).should.be.false();
+    (await this.openEndedNotSame2.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when both intervals start at null and end at the same time', function () {
+  it('returns true when both intervals start at null and end at the same time', async function () {
     // define OpenBeginningSame: Interval[null,DateTime(2018,01,01)] same as Interval[null,DateTime(2018,01,01)]
-    this.openBeginningSame.exec(this.ctx).should.be.true();
+    (await this.openBeginningSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when one interval starts at null and the other does not', function () {
+  it('returns false when one interval starts at null and the other does not', async function () {
     // define OpenBeginningNotSame: Interval[DateTime(2017,01,01),DateTime(2018,01,01)] same as Interval[null,DateTime(2018,01,01)]
-    this.openBeginningNotSame.exec(this.ctx).should.be.false();
+    (await this.openBeginningNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when comparing a closed interval of Dates to an open interval after it is converted', function () {
+  it('returns true when comparing a closed interval of Dates to an open interval after it is converted', async function () {
     // define DateOpenAndClosed: Interval[Date(2018,01,01), Date(2018,02,02)] same as Interval[Date(2018,01,01), Date(2018,02,03))
-    this.dateOpenAndClosed.exec(this.ctx).should.be.true();
+    (await this.dateOpenAndClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when both Date intervals are open ended', function () {
+  it('returns true when both Date intervals are open ended', async function () {
     // define DateOpenEnded: Interval[Date(2018,01,01), null] same as Interval[Date(2018,01,01), null)]
-    this.dateOpenEnded.exec(this.ctx).should.be.true();
+    (await this.dateOpenEnded.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when comparing a closed interval of Times to an open interval after it is converted', function () {
+  it('returns true when comparing a closed interval of Times to an open interval after it is converted', async function () {
     // define TimeOpenAndClosed: Interval[Time(01,01), Time(02,02)] same as Interval[Time(01,01), Time(02,03))
-    this.timeOpenAndClosed.exec(this.ctx).should.be.true();
+    (await this.timeOpenAndClosed.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when both Time intervals are open ended', function () {
+  it('returns true when both Time intervals are open ended', async function () {
     // define TimeOpenEnded: Interval[Time(01,01), null] same as Interval[Time(01,01), null)]
-    this.timeOpenEnded.exec(this.ctx).should.be.true();
+    (await this.timeOpenEnded.exec(this.ctx)).should.be.true();
   });
 
-  it('returns true when both Date intervals are the same', function () {
+  it('returns true when both Date intervals are the same', async function () {
     // define DateIntervalComparisonSame: Interval[Date(2018,01,01), Date(2018,02,02)] same as Interval[Date(2018,01,01), Date(2018,02,02)]
-    this.dateIntervalComparisonSame.exec(this.ctx).should.be.true();
+    (await this.dateIntervalComparisonSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when Date intervals are not the same', function () {
+  it('returns false when Date intervals are not the same', async function () {
     // define DateIntervalComparisonNotSame: Interval[Date(2018,01,01), Date(2018,02,02)] same as Interval[Date(2018,01,01), Date(2018,02,01)]
-    this.dateIntervalComparisonNotSame.exec(this.ctx).should.be.false();
+    (await this.dateIntervalComparisonNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when both Time intervals are the same', function () {
+  it('returns true when both Time intervals are the same', async function () {
     // define TimeIntervalComparisonSame: Interval[Time(01,01), Time(02,02)] same as Interval[Time(01,01), Time(02,02)]
-    this.timeIntervalComparisonSame.exec(this.ctx).should.be.true();
+    (await this.timeIntervalComparisonSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when Time intervals are not the same', function () {
+  it('returns false when Time intervals are not the same', async function () {
     // define TimeIntervalComparisonNotSame: Interval[Time(01,01), Time(02,02)] same as Interval[Time(01,01), Time(08,01)]
-    this.timeIntervalComparisonNotSame.exec(this.ctx).should.be.false();
+    (await this.timeIntervalComparisonNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the year precision', function () {
+  it('returns true when DateTime intervals are same on the year precision', async function () {
     // define DateTimeYearPrecisionSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same year as Interval[DateTime(2018,02,01), DateTime(2019,05,01)]
-    this.dateTimeYearPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeYearPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested year precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested year precision', async function () {
     // define DateTimeYearPrecisionNotSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same year as Interval[DateTime(2018,02,01), DateTime(2020,05,01)]
-    this.dateTimeYearPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeYearPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the year precision', function () {
+  it('returns true when DateTime intervals are same on the year precision', async function () {
     // define DateYearPrecisionSame: Interval[Date(2018,01,01), Date(2019,01,01)] same year as Interval[Date(2018,02,01), Date(2019,05,01)]
-    this.dateYearPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateYearPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested year precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested year precision', async function () {
     // define DateYearPrecisionNotSame: Interval[Date(2018,01,01), Date(2019,01,01)] same year as Interval[Date(2018,02,01), Date(2020,05,01)]
-    this.dateYearPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateYearPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the month precision', function () {
+  it('returns true when DateTime intervals are same on the month precision', async function () {
     // define DateTimeMonthPrecisionSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same month as Interval[DateTime(2018,01,01), DateTime(2019,01,03)]
-    this.dateTimeMonthPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeMonthPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested month precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested month precision', async function () {
     // define DateTimeMonthPrecisionNotSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same month as Interval[DateTime(2018,02,01), DateTime(2019,01,01)]
-    this.dateTimeMonthPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeMonthPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the day precision', function () {
+  it('returns true when DateTime intervals are same on the day precision', async function () {
     // define DateTimeDayPrecisionSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same day as Interval[DateTime(2018,01,01,05), DateTime(2019,01,01,09)]
-    this.dateTimeDayPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeDayPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested day precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested day precision', async function () {
     // define DateTimeDayPrecisionNotSame: Interval[DateTime(2018,01,01), DateTime(2019,01,01)] same day as Interval[DateTime(2018,01,01), DateTime(2019,01,02,06)]
-    this.dateTimeDayPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeDayPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the hour precision', function () {
+  it('returns true when DateTime intervals are same on the hour precision', async function () {
     // define DateTimeHourPrecisionSame: Interval[DateTime(2018,01,01,01), DateTime(2019,01,01,01)] same hour as Interval[DateTime(2018,01,01,01), DateTime(2019,01,01,01,05)]
-    this.dateTimeHourPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeHourPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested hour precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested hour precision', async function () {
     // define DateTimeHourPrecisionNotSame: Interval[DateTime(2018,01,01,01), DateTime(2019,01,01,01)] same hour as Interval[DateTime(2018,01,01,06), DateTime(2019,01,01,01)]
-    this.dateTimeHourPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeHourPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the minute precision', function () {
+  it('returns true when DateTime intervals are same on the minute precision', async function () {
     // define DateTimeMinutePrecisionSame: Interval[DateTime(2018,01,01,01,01), DateTime(2019,01,01,01,01)] same minute as Interval[DateTime(2018,01,01,01,01,09), DateTime(2019,01,01,01,01,06)]
-    this.dateTimeMinutePrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeMinutePrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested minute precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested minute precision', async function () {
     // define DateTimeMinutePrecisionNotSame: Interval[DateTime(2018,01,01,01,01), DateTime(2019,01,01,01,01)] same minute as Interval[DateTime(2018,01,01,06,03), DateTime(2019,01,01,01,06)]
-    this.dateTimeMinutePrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeMinutePrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the second precision', function () {
+  it('returns true when DateTime intervals are same on the second precision', async function () {
     // define DateTimeSecondPrecisionSame: Interval[DateTime(2018,01,01,01,01,01), DateTime(2019,01,01,01,01,01)] same second as Interval[DateTime(2018,01,01,01,01,01), DateTime(2019,01,01,01,01,01,07)]
-    this.dateTimeSecondPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeSecondPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested second precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested second precision', async function () {
     // define DateTimeSecondPrecisionNotSame: Interval[DateTime(2018,01,01,01,01,01), DateTime(2019,01,01,01,01,01)] same second as Interval[DateTime(2018,01,01,01,01,01), DateTime(2019,01,01,01,07,55)]
-    this.dateTimeSecondPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeSecondPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when DateTime intervals are same on the millisecond precision', function () {
+  it('returns true when DateTime intervals are same on the millisecond precision', async function () {
     // define DateTimeMillisecondPrecisionSame: Interval[DateTime(2018,01,01,01,01,01,01), DateTime(2019,01,01,01,01,01,01)] same millisecond as Interval[DateTime(2018,01,01,01,01,01,01), DateTime(2019,01,01,01,01,01,01)]
-    this.dateTimeMillisecondPrecisionSame.exec(this.ctx).should.be.true();
+    (await this.dateTimeMillisecondPrecisionSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when DateTime intervals are not the same on the requested millisecond precision', function () {
+  it('returns false when DateTime intervals are not the same on the requested millisecond precision', async function () {
     // define DateTimeMillisecondPrecisionNotSame: Interval[DateTime(2018,01,01,01,01,01,01), DateTime(2019,01,01,01,01,01,01)] same millisecond as Interval[DateTime(2018,01,01,01,01,01,01), DateTime(2019,01,01,01,01,01,09)]
-    this.dateTimeMillisecondPrecisionNotSame.exec(this.ctx).should.be.false();
+    (await this.dateTimeMillisecondPrecisionNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when integer interval is the same', function () {
+  it('returns true when integer interval is the same', async function () {
     // define IntegerIntervalSame: Interval[2,5] same as Interval[2,5]
-    this.integerIntervalSame.exec(this.ctx).should.be.true();
+    (await this.integerIntervalSame.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false when integer interval is not the same', function () {
+  it('returns false when integer interval is not the same', async function () {
     // define IntegerIntervalNotSame: Interval[2,5] same as Interval[2,4]
-    this.integerIntervalNotSame.exec(this.ctx).should.be.false();
+    (await this.integerIntervalNotSame.exec(this.ctx)).should.be.false();
   });
 
-  it('returns true when integer interval is same after the open interval is closed', function () {
+  it('returns true when integer interval is same after the open interval is closed', async function () {
     // define IntegerIntervalSameOpen: Interval[2,5] same as Interval[2,6)
-    this.integerIntervalSameOpen.exec(this.ctx).should.be.true();
+    (await this.integerIntervalSameOpen.exec(this.ctx)).should.be.true();
   });
 
-  it('returns false even with an open ended null because the lows are not null and not same', function () {
+  it('returns false even with an open ended null because the lows are not null and not same', async function () {
     // define OpenNullHighLowDifferent: Interval(3,null) same as Interval(2,4)
-    this.openNullHighLowDifferent.exec(this.ctx).should.be.false();
+    (await this.openNullHighLowDifferent.exec(this.ctx)).should.be.false();
   });
 
-  it('returns false even with an open ended null because the highs are not null and not same', function () {
+  it('returns false even with an open ended null because the highs are not null and not same', async function () {
     // define OpenNullLowHighDifferent: Interval(1,5) same as Interval(null,4)
-    this.openNullLowHighDifferent.exec(this.ctx).should.be.false();
+    (await this.openNullLowHighDifferent.exec(this.ctx)).should.be.false();
   });
 
-  it('returns null if lows are same and highs have an open null', function () {
+  it('returns null if lows are same and highs have an open null', async function () {
     // OpenNullHighLowSame: Interval(2,null) same as Interval(2,4)
-    should(this.openNullHighLowSame.exec(this.ctx)).be.null();
+    should(await this.openNullHighLowSame.exec(this.ctx)).be.null();
   });
 
-  it('returns null if lows have an open null and highs are same', function () {
+  it('returns null if lows have an open null and highs are same', async function () {
     // OpenNullLowHighSame: Interval(1,4) same as Interval(null,4)
-    should(this.openNullLowHighSame.exec(this.ctx)).be.null();
+    should(await this.openNullLowHighSame.exec(this.ctx)).be.null();
   });
 
-  it('returns null if both lows and highs have open null', function () {
+  it('returns null if both lows and highs have open null', async function () {
     // OpenNullLowOpenNullHigh: Interval(1,null) same as Interval(null,4)
-    should(this.openNullLowOpenNullHigh.exec(this.ctx)).be.null();
+    should(await this.openNullLowOpenNullHigh.exec(this.ctx)).be.null();
   });
 
-  it('returns false if lows are different and highs have open null', function () {
+  it('returns false if lows are different and highs have open null', async function () {
     // OpenNullHighsLowsDifferent: Interval(1,null) same as Interval(2,null)
-    this.openNullHighsLowsDifferent.exec(this.ctx).should.be.false();
+    (await this.openNullHighsLowsDifferent.exec(this.ctx)).should.be.false();
   });
 
-  it('returns null if lows are same and highs have open null', function () {
+  it('returns null if lows are same and highs have open null', async function () {
     // OpenNullHighsLowsSame: Interval(1,null) same as Interval(1,null)
-    should(this.openNullHighsLowsSame.exec(this.ctx)).be.null();
+    should(await this.openNullHighsLowsSame.exec(this.ctx)).be.null();
   });
 
-  it('returns null if lows have open null and highs are same', function () {
+  it('returns null if lows have open null and highs are same', async function () {
     // OpenNullLowsHighsSame: Interval(null,3) same as Interval(null,3)
-    should(this.openNullLowsHighsSame.exec(this.ctx)).be.null();
+    should(await this.openNullLowsHighsSame.exec(this.ctx)).be.null();
   });
 });

--- a/test/elm/library/library-test.ts
+++ b/test/elm/library/library-test.ts
@@ -8,9 +8,11 @@ import { Repository, Code } from '../../../src/cql';
 const { p1, p2 } = require('./patients');
 
 describe('In Age Demographic', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, data, [p1, p2]);
-    this.results = this.executor.withLibrary(this.lib).exec_patient_context(this.patientSource);
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
   });
 
   it('should have correct patient results', function () {
@@ -43,18 +45,20 @@ describe('Using CommonLib', () => {
     this.lib.includes.should.not.be.empty();
   });
 
-  it('should be able to execute expression from included library', function () {
-    this.results = this.executor.withLibrary(this.lib).exec_patient_context(this.patientSource);
+  it('should be able to execute expression from included library', async function () {
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
     this.results.patientResults['1'].ID.should.equal(false);
     this.results.patientResults['2'].ID.should.equal(true);
     this.results.patientResults['2'].FuncTest.should.equal(7);
     this.results.patientResults['1'].FuncTest.should.equal(7);
   });
 
-  it('should find the code defined in the included library', function () {
-    should.exist(this.supportLibCode.exec(this.ctx));
+  it('should find the code defined in the included library', async function () {
+    should.exist(await this.supportLibCode.exec(this.ctx));
     equivalent(
-      this.supportLibCode.exec(this.ctx),
+      await this.supportLibCode.exec(this.ctx),
       new Code('428371000124100', '2.16.840.1.113883.6.96', 'foo', 'directReferenceCode')
     ).should.be.true();
   });
@@ -65,71 +69,81 @@ describe('Using CommonLib2', () => {
     setup(this, data, [], {}, { AnotherNumber: 50 }, new Repository(data));
   });
 
-  it('should execute expression from included library that uses parameter', function () {
-    this.exprUsesParam.exec(this.ctx).should.equal(17);
+  it('should execute expression from included library that uses parameter', async function () {
+    (await this.exprUsesParam.exec(this.ctx)).should.equal(17);
   });
 
-  it('should execute expression from included library that uses sent-in parameter', function () {
-    this.exprUsesParam.exec(this.ctx.withParameters({ SomeNumber: 42 })).should.equal(42);
+  it('should execute expression from included library that uses sent-in parameter', async function () {
+    (await this.exprUsesParam.exec(this.ctx.withParameters({ SomeNumber: 42 }))).should.equal(42);
   });
 
-  it('should execute parameter from included library', function () {
-    this.exprUsesParamDirectly.exec(this.ctx).should.equal(17);
+  it('should execute parameter from included library', async function () {
+    (await this.exprUsesParamDirectly.exec(this.ctx)).should.equal(17);
   });
 
-  it('should execute sent-in parameter from included library', function () {
-    this.exprUsesParamDirectly.exec(this.ctx.withParameters({ SomeNumber: 73 })).should.equal(73);
+  it('should execute sent-in parameter from included library', async function () {
+    (
+      await this.exprUsesParamDirectly.exec(this.ctx.withParameters({ SomeNumber: 73 }))
+    ).should.equal(73);
   });
 
-  it('should execute expression from included library that uses parameter', function () {
-    this.exprUsesAnotherParam.exec(this.ctx).should.equal(50);
+  it('should execute expression from included library that uses parameter', async function () {
+    (await this.exprUsesAnotherParam.exec(this.ctx)).should.equal(50);
   });
 
-  it('should execute expression from included library that uses sent-in parameter', function () {
-    this.exprUsesAnotherParam.exec(this.ctx.withParameters({ AnotherNumber: 66 })).should.equal(66);
+  it('should execute expression from included library that uses sent-in parameter', async function () {
+    (
+      await this.exprUsesAnotherParam.exec(this.ctx.withParameters({ AnotherNumber: 66 }))
+    ).should.equal(66);
   });
 
-  it('should execute parameter from included library', function () {
-    this.exprUsesAnotherParamDirectly.exec(this.ctx).should.equal(50);
+  it('should execute parameter from included library', async function () {
+    (await this.exprUsesAnotherParamDirectly.exec(this.ctx)).should.equal(50);
   });
 
-  it('should execute sent-in parameter from included library', function () {
-    this.exprUsesAnotherParamDirectly
-      .exec(this.ctx.withParameters({ AnotherNumber: 73 }))
-      .should.equal(73);
+  it('should execute sent-in parameter from included library', async function () {
+    (
+      await this.exprUsesAnotherParamDirectly.exec(this.ctx.withParameters({ AnotherNumber: 73 }))
+    ).should.equal(73);
   });
 
-  it('should execute function from included library that uses parameter', function () {
-    this.funcUsesParam.exec(this.ctx).should.equal(22);
+  it('should execute function from included library that uses parameter', async function () {
+    (await this.funcUsesParam.exec(this.ctx)).should.equal(22);
   });
 
-  it('should execute expression from included library that calls function', function () {
-    this.exprCallsFunc.exec(this.ctx).should.equal(6);
+  it('should execute expression from included library that calls function', async function () {
+    (await this.exprCallsFunc.exec(this.ctx)).should.equal(6);
   });
 
-  it('should execute function from included library that calls function', function () {
-    this.funcCallsFunc.exec(this.ctx).should.equal(25);
+  it('should execute function from included library that calls function', async function () {
+    (await this.funcCallsFunc.exec(this.ctx)).should.equal(25);
   });
 
-  it('should execute expression from included library that uses expression', function () {
-    this.exprUsesExpr.exec(this.ctx).should.equal(3);
+  it('should execute expression from included library that uses expression', async function () {
+    (await this.exprUsesExpr.exec(this.ctx)).should.equal(3);
   });
 
-  it('should execute function from included library that uses expression', function () {
-    this.funcUsesExpr.exec(this.ctx).should.equal(7);
+  it('should execute function from included library that uses expression', async function () {
+    (await this.funcUsesExpr.exec(this.ctx)).should.equal(7);
   });
 
-  it('should execute function from included library that uses expression', function () {
-    this.exprSortsOnFunc
-      .exec(this.ctx)
-      .should.eql([{ N: 1 }, { N: 2 }, { N: 3 }, { N: 4 }, { N: 5 }]);
+  it('should execute function from included library that uses expression', async function () {
+    (await this.exprSortsOnFunc.exec(this.ctx)).should.eql([
+      { N: 1 },
+      { N: 2 },
+      { N: 3 },
+      { N: 4 },
+      { N: 5 }
+    ]);
   });
 });
 
 describe('Using CommonLib and CommonLib2', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, data, [p1], {}, {}, new Repository(data));
-    this.results = this.executor.withLibrary(this.lib).exec_patient_context(this.patientSource);
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
     this.commonLocalIdObject = this.results.localIdPatientResultsMap['1'].Common;
     this.common2LocalIdObject = this.results.localIdPatientResultsMap['1'].Common2;
   });
@@ -164,9 +178,11 @@ describe('Using CommonLib and CommonLib2', () => {
 // NOTE: These all use the manually maintained fixture, see
 //       https://github.com/cqframework/cql-execution/pull/251
 describe('Using CommonLib and CommonLib2 with namespace support', () => {
-  beforeEach(function () {
+  beforeEach(async function () {
     setup(this, dataWithNamespace, [p1], {}, {}, new Repository(dataWithNamespace));
-    this.results = this.executor.withLibrary(this.lib).exec_patient_context(this.patientSource);
+    this.results = await this.executor
+      .withLibrary(this.lib)
+      .exec_patient_context(this.patientSource);
     this.commonLocalIdObject = this.results.localIdPatientResultsMap['1'].Common;
     this.common2LocalIdObject = this.results.localIdPatientResultsMap['1'].Common2;
   });

--- a/test/elm/list/list-test.ts
+++ b/test/elm/list/list-test.ts
@@ -7,20 +7,20 @@ describe('List', () => {
     setup(this, data);
   });
 
-  it('should execute to an array (ints)', function () {
-    this.intList.exec(this.ctx).should.eql([9, 7, 8]);
+  it('should execute to an array (ints)', async function () {
+    (await this.intList.exec(this.ctx)).should.eql([9, 7, 8]);
   });
 
-  it('should execute to an array (strings)', function () {
-    this.stringList.exec(this.ctx).should.eql(['a', 'bee', 'see']);
+  it('should execute to an array (strings)', async function () {
+    (await this.stringList.exec(this.ctx)).should.eql(['a', 'bee', 'see']);
   });
 
-  it('should execute to an array (mixed)', function () {
-    this.mixedList.exec(this.ctx).should.eql([1, 'two', 3]);
+  it('should execute to an array (mixed)', async function () {
+    (await this.mixedList.exec(this.ctx)).should.eql([1, 'two', 3]);
   });
 
-  it('should execute to an empty array', function () {
-    this.emptyList.exec(this.ctx).should.eql([]);
+  it('should execute to an empty array', async function () {
+    (await this.emptyList.exec(this.ctx)).should.eql([]);
   });
 });
 
@@ -29,35 +29,35 @@ describe('Exists', () => {
     setup(this, data);
   });
 
-  it('should return false for empty list', function () {
-    this.emptyList.exec(this.ctx).should.be.false();
+  it('should return false for empty list', async function () {
+    (await this.emptyList.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true for full list', function () {
-    this.fullList.exec(this.ctx).should.be.true();
+  it('should return true for full list', async function () {
+    (await this.fullList.exec(this.ctx)).should.be.true();
   });
 
-  it('should return false for list with only one null', function () {
-    this.listWithOneNull.exec(this.ctx).should.be.false();
+  it('should return false for list with only one null', async function () {
+    (await this.listWithOneNull.exec(this.ctx)).should.be.false();
   });
 
-  it('should return false for list with only two nulls', function () {
-    this.listWithTwoNulls.exec(this.ctx).should.be.false();
+  it('should return false for list with only two nulls', async function () {
+    (await this.listWithTwoNulls.exec(this.ctx)).should.be.false();
   });
 
-  it('should return true for list starting with null and with non-null elements', function () {
-    this.listStartingWithNull.exec(this.ctx).should.be.true();
+  it('should return true for list starting with null and with non-null elements', async function () {
+    (await this.listStartingWithNull.exec(this.ctx)).should.be.true();
   });
 
-  it('should return true for list with null and non-null elements', function () {
-    this.listWithNull.exec(this.ctx).should.be.true();
+  it('should return true for list with null and non-null elements', async function () {
+    (await this.listWithNull.exec(this.ctx)).should.be.true();
   });
 
   // NOTE: This test is misleading due to list promotion of the null to a list with null.
   // Test will remain as it still tests a different list creation method. Additionally, it
   // will be useful if list promotion is disabled.
-  it('should return false for null argument', function () {
-    this.nullExists.exec(this.ctx).should.be.false();
+  it('should return false for null argument', async function () {
+    (await this.nullExists.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -66,45 +66,45 @@ describe('Equal', () => {
     setup(this, data);
   });
 
-  it('should identify equal lists of integers', function () {
-    this.equalIntList.exec(this.ctx).should.be.true();
+  it('should identify equal lists of integers', async function () {
+    (await this.equalIntList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify unequal lists of integers', function () {
-    this.unequalIntList.exec(this.ctx).should.be.false();
+  it('should identify unequal lists of integers', async function () {
+    (await this.unequalIntList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify re-ordered lists of integers as unequal', function () {
-    this.reverseIntList.exec(this.ctx).should.be.false();
+  it('should identify re-ordered lists of integers as unequal', async function () {
+    (await this.reverseIntList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify equal lists of strings', function () {
-    this.equalStringList.exec(this.ctx).should.be.true();
+  it('should identify equal lists of strings', async function () {
+    (await this.equalStringList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify unequal lists of strings', function () {
-    this.unequalStringList.exec(this.ctx).should.be.false();
+  it('should identify unequal lists of strings', async function () {
+    (await this.unequalStringList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify equal lists of tuples', function () {
-    this.equalTupleList.exec(this.ctx).should.be.true();
+  it('should identify equal lists of tuples', async function () {
+    (await this.equalTupleList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify unequal lists of tuples', function () {
-    this.unequalTupleList.exec(this.ctx).should.be.false();
+  it('should identify unequal lists of tuples', async function () {
+    (await this.unequalTupleList.exec(this.ctx)).should.be.false();
   });
 
   describe('should return null', () => {
-    it('when first list has a null element', function () {
-      should(this.firstListHasNull.exec(this.ctx)).be.null();
+    it('when first list has a null element', async function () {
+      should(await this.firstListHasNull.exec(this.ctx)).be.null();
     });
 
-    it('when second list has a null element', function () {
-      should(this.secondListHasNull.exec(this.ctx)).be.null();
+    it('when second list has a null element', async function () {
+      should(await this.secondListHasNull.exec(this.ctx)).be.null();
     });
 
-    it('when both lists have only null elements', function () {
-      should(this.bothListsHaveNull.exec(this.ctx)).be.null();
+    it('when both lists have only null elements', async function () {
+      should(await this.bothListsHaveNull.exec(this.ctx)).be.null();
     });
   });
 });
@@ -114,32 +114,32 @@ describe('NotEqual', () => {
     setup(this, data);
   });
 
-  it('should identify equal lists of integers', function () {
-    this.equalIntList.exec(this.ctx).should.be.false();
+  it('should identify equal lists of integers', async function () {
+    (await this.equalIntList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify unequal lists of integers', function () {
-    this.unequalIntList.exec(this.ctx).should.be.true();
+  it('should identify unequal lists of integers', async function () {
+    (await this.unequalIntList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify re-ordered lists of integers as unequal', function () {
-    this.reverseIntList.exec(this.ctx).should.be.true();
+  it('should identify re-ordered lists of integers as unequal', async function () {
+    (await this.reverseIntList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify equal lists of strings', function () {
-    this.equalStringList.exec(this.ctx).should.be.false();
+  it('should identify equal lists of strings', async function () {
+    (await this.equalStringList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify unequal lists of strings', function () {
-    this.unequalStringList.exec(this.ctx).should.be.true();
+  it('should identify unequal lists of strings', async function () {
+    (await this.unequalStringList.exec(this.ctx)).should.be.true();
   });
 
-  it('should identify equal lists of tuples', function () {
-    this.equalTupleList.exec(this.ctx).should.be.false();
+  it('should identify equal lists of tuples', async function () {
+    (await this.equalTupleList.exec(this.ctx)).should.be.false();
   });
 
-  it('should identify unequal lists of tuples', function () {
-    this.unequalTupleList.exec(this.ctx).should.be.true();
+  it('should identify unequal lists of tuples', async function () {
+    (await this.unequalTupleList.exec(this.ctx)).should.be.true();
   });
 });
 
@@ -148,35 +148,49 @@ describe('Union', () => {
     setup(this, data);
   });
 
-  it('should union two lists to a single list', function () {
-    this.oneToTen.exec(this.ctx).should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  it('should union two lists to a single list', async function () {
+    (await this.oneToTen.exec(this.ctx)).should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
   });
 
-  it('should remove duplicate elements (according to CQL 1.2 spec)', function () {
-    this.oneToFiveOverlapped.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should remove duplicate elements (according to CQL 1.2 spec)', async function () {
+    (await this.oneToFiveOverlapped.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should remove duplicate null elements', function () {
-    this.oneToFiveOverlappedWithNulls.exec(this.ctx).should.eql([1, null, 2, 3, 4, 5]);
+  it('should remove duplicate null elements', async function () {
+    (await this.oneToFiveOverlappedWithNulls.exec(this.ctx)).should.eql([1, null, 2, 3, 4, 5]);
   });
 
-  it('should not fill in values in a disjoint union', function () {
-    this.disjoint.exec(this.ctx).should.eql([1, 2, 4, 5]);
+  it('should not fill in values in a disjoint union', async function () {
+    (await this.disjoint.exec(this.ctx)).should.eql([1, 2, 4, 5]);
   });
 
-  it('should return one list for multiple nested unions', function () {
-    this.nestedToFifteen
-      .exec(this.ctx)
-      .should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+  it('should return one list for multiple nested unions', async function () {
+    (await this.nestedToFifteen.exec(this.ctx)).should.eql([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15
+    ]);
   });
 
-  it('should return other list if either arg is null', function () {
-    should(this.unionNull.exec(this.ctx)).be.eql([1, 2, 3]);
-    should(this.nullUnion.exec(this.ctx)).be.eql([1, 2, 3]);
+  it('should return other list if either arg is null', async function () {
+    should(await this.unionNull.exec(this.ctx)).be.eql([1, 2, 3]);
+    should(await this.nullUnion.exec(this.ctx)).be.eql([1, 2, 3]);
   });
 
-  it('should return an empty list if both args are null but expected to be lists', function () {
-    this.nullUnionNull.exec(this.ctx).should.be.eql([]);
+  it('should return an empty list if both args are null but expected to be lists', async function () {
+    (await this.nullUnionNull.exec(this.ctx)).should.be.eql([]);
   });
 });
 
@@ -185,48 +199,48 @@ describe('Except', () => {
     setup(this, data);
   });
 
-  it('should remove items in second list', function () {
-    this.exceptThreeFour.exec(this.ctx).should.eql([1, 2, 5]);
+  it('should remove items in second list', async function () {
+    (await this.exceptThreeFour.exec(this.ctx)).should.eql([1, 2, 5]);
   });
 
-  it('should not be commutative', function () {
-    this.threeFourExcept.exec(this.ctx).should.eql([]);
+  it('should not be commutative', async function () {
+    (await this.threeFourExcept.exec(this.ctx)).should.eql([]);
   });
 
-  it('should remove items in second list regardless of order', function () {
-    this.exceptFiveThree.exec(this.ctx).should.eql([1, 2, 4]);
+  it('should remove items in second list regardless of order', async function () {
+    (await this.exceptFiveThree.exec(this.ctx)).should.eql([1, 2, 4]);
   });
 
-  it('should be a no-op when lists have no common items', function () {
-    this.exceptNoOp.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should be a no-op when lists have no common items', async function () {
+    (await this.exceptNoOp.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should remove all items when lists are the same', function () {
-    this.exceptEverything.exec(this.ctx).should.eql([]);
+  it('should remove all items when lists are the same', async function () {
+    (await this.exceptEverything.exec(this.ctx)).should.eql([]);
   });
 
-  it('should return items in first list without 3 and null', function () {
-    this.multipleNullExcept.exec(this.ctx).should.eql([1, 5, 7]);
+  it('should return items in first list without 3 and null', async function () {
+    (await this.multipleNullExcept.exec(this.ctx)).should.eql([1, 5, 7]);
   });
 
-  it('should be a no-op when second list is empty', function () {
-    this.somethingExceptNothing.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should be a no-op when second list is empty', async function () {
+    (await this.somethingExceptNothing.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should be a no-op when first list is already empty', function () {
-    this.nothingExceptSomething.exec(this.ctx).should.eql([]);
+  it('should be a no-op when first list is already empty', async function () {
+    (await this.nothingExceptSomething.exec(this.ctx)).should.eql([]);
   });
 
-  it('should except lists of tuples', function () {
-    this.exceptTuples.exec(this.ctx).should.eql([{ a: 1 }, { a: 3 }]);
+  it('should except lists of tuples', async function () {
+    (await this.exceptTuples.exec(this.ctx)).should.eql([{ a: 1 }, { a: 3 }]);
   });
 
-  it('should return null if first arg is null', function () {
-    should(this.nullExcept.exec(this.ctx)).be.null();
+  it('should return null if first arg is null', async function () {
+    should(await this.nullExcept.exec(this.ctx)).be.null();
   });
 
-  it('should return first arg if second arg is null', function () {
-    this.exceptNull.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should return first arg if second arg is null', async function () {
+    (await this.exceptNull.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 });
 
@@ -235,44 +249,44 @@ describe('Intersect', () => {
     setup(this, data);
   });
 
-  it('should intersect two disjoint lists  to an empty list', function () {
-    this.noIntersection.exec(this.ctx).should.eql([]);
+  it('should intersect two disjoint lists  to an empty list', async function () {
+    (await this.noIntersection.exec(this.ctx)).should.eql([]);
   });
 
-  it('should intersect two lists with a single common element', function () {
-    this.intersectOnFive.exec(this.ctx).should.eql([5]);
+  it('should intersect two lists with a single common element', async function () {
+    (await this.intersectOnFive.exec(this.ctx)).should.eql([5]);
   });
 
-  it('should intersect two lists with a single common element even with duplicates', function () {
-    this.intersectionOnFourDuplicates.exec(this.ctx).should.eql([4]);
+  it('should intersect two lists with a single common element even with duplicates', async function () {
+    (await this.intersectionOnFourDuplicates.exec(this.ctx)).should.eql([4]);
   });
 
-  it('should intersect two lists with several common elements', function () {
-    this.intersectOnEvens.exec(this.ctx).should.eql([2, 4, 6, 8, 10]);
+  it('should intersect two lists with several common elements', async function () {
+    (await this.intersectOnEvens.exec(this.ctx)).should.eql([2, 4, 6, 8, 10]);
   });
 
-  it('should intersect two identical lists to the same list', function () {
-    this.intersectOnAll.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should intersect two identical lists to the same list', async function () {
+    (await this.intersectOnAll.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should intersect multiple lists to only those elements common across all', function () {
-    this.nestedIntersects.exec(this.ctx).should.eql([4, 5]);
+  it('should intersect multiple lists to only those elements common across all', async function () {
+    (await this.nestedIntersects.exec(this.ctx)).should.eql([4, 5]);
   });
 
-  it('should intersect lists of tuples', function () {
-    this.intersectTuples.exec(this.ctx).should.eql([
+  it('should intersect lists of tuples', async function () {
+    (await this.intersectTuples.exec(this.ctx)).should.eql([
       { a: 1, b: 'c' },
       { a: 2, b: 'c' }
     ]);
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.intersectNull.exec(this.ctx)).be.null();
-    should(this.nullIntersect.exec(this.ctx)).be.null();
+  it('should return null if either arg is null', async function () {
+    should(await this.intersectNull.exec(this.ctx)).be.null();
+    should(await this.nullIntersect.exec(this.ctx)).be.null();
   });
 
-  it('should intersect two lists that contain null', function () {
-    this.multipleNullInListIntersect.exec(this.ctx).should.eql([3, null]);
+  it('should intersect two lists that contain null', async function () {
+    (await this.multipleNullInListIntersect.exec(this.ctx)).should.eql([3, null]);
   });
 });
 
@@ -281,44 +295,44 @@ describe('IndexOf', () => {
     setup(this, data);
   });
 
-  it('should return the correct 0-based index when an item is in the list', function () {
-    this.indexOfSecond.exec(this.ctx).should.equal(1);
+  it('should return the correct 0-based index when an item is in the list', async function () {
+    (await this.indexOfSecond.exec(this.ctx)).should.equal(1);
     this.ctx.rootContext().localId_context[this.indexOfSecond.source.localId].should.not.be.null();
     this.ctx.rootContext().localId_context[this.indexOfSecond.element.localId].should.not.be.null();
   });
 
-  it('should work with complex types like tuples', function () {
-    this.indexOfThirdTuple.exec(this.ctx).should.equal(2);
+  it('should work with complex types like tuples', async function () {
+    (await this.indexOfThirdTuple.exec(this.ctx)).should.equal(2);
   });
 
-  it('should return the first index when there are multiple matches', function () {
-    this.multipleMatches.exec(this.ctx).should.equal(3);
+  it('should return the first index when there are multiple matches', async function () {
+    (await this.multipleMatches.exec(this.ctx)).should.equal(3);
   });
 
-  it('should return -1 when the item is not in the list', function () {
-    this.itemNotFound.exec(this.ctx).should.equal(-1);
+  it('should return -1 when the item is not in the list', async function () {
+    (await this.itemNotFound.exec(this.ctx)).should.equal(-1);
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.nullList.exec(this.ctx)).be.null();
-    should(this.nullItem.exec(this.ctx)).be.null();
+  it('should return null if either arg is null', async function () {
+    should(await this.nullList.exec(this.ctx)).be.null();
+    should(await this.nullItem.exec(this.ctx)).be.null();
   });
 
   describe('should use equality to determine presence in List', () => {
-    it('when code is in list but have undefined displays', function () {
-      this.listCodeUndefined.exec(this.ctx).should.equal(0);
+    it('when code is in list but have undefined displays', async function () {
+      (await this.listCodeUndefined.exec(this.ctx)).should.equal(0);
     });
 
-    it('when code is in list', function () {
-      this.listCode.exec(this.ctx).should.equal(0);
+    it('when code is in list', async function () {
+      (await this.listCode.exec(this.ctx)).should.equal(0);
     });
 
-    it('when code is not in list', function () {
-      this.listWrongCode.exec(this.ctx).should.equal(-1);
+    it('when code is not in list', async function () {
+      (await this.listWrongCode.exec(this.ctx)).should.equal(-1);
     });
 
-    it('when code system is not in list', function () {
-      this.listWrongCodeSystem.exec(this.ctx).should.equal(-1);
+    it('when code system is not in list', async function () {
+      (await this.listWrongCodeSystem.exec(this.ctx)).should.equal(-1);
     });
   });
 });
@@ -328,21 +342,21 @@ describe('Indexer', () => {
     setup(this, data);
   });
 
-  it('should return the correct item based on the 0-based index', function () {
-    this.secondItem.exec(this.ctx).should.equal('b');
+  it('should return the correct item based on the 0-based index', async function () {
+    (await this.secondItem.exec(this.ctx)).should.equal('b');
   });
 
-  it('should NOT return null when accessing index 0', function () {
-    should(this.zeroIndex.exec(this.ctx)).not.be.null();
+  it('should NOT return null when accessing index 0', async function () {
+    should(await this.zeroIndex.exec(this.ctx)).not.be.null();
   });
 
-  it('should return null when accessing out of bounds index', function () {
-    should(this.outOfBounds.exec(this.ctx)).be.null();
+  it('should return null when accessing out of bounds index', async function () {
+    should(await this.outOfBounds.exec(this.ctx)).be.null();
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.nullList.exec(this.ctx)).be.null();
-    should(this.nullIndexer.exec(this.ctx)).be.null();
+  it('should return null if either arg is null', async function () {
+    should(await this.nullList.exec(this.ctx)).be.null();
+    should(await this.nullIndexer.exec(this.ctx)).be.null();
   });
 });
 
@@ -351,32 +365,32 @@ describe('In', () => {
     setup(this, data);
   });
 
-  it('should execute to true when item is in list', function () {
-    this.isIn.exec(this.ctx).should.be.true();
+  it('should execute to true when item is in list', async function () {
+    (await this.isIn.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when item is not in list', function () {
-    this.isNotIn.exec(this.ctx).should.be.false();
+  it('should execute to false when item is not in list', async function () {
+    (await this.isNotIn.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple is in list', function () {
-    this.tupleIsIn.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple is in list', async function () {
+    (await this.tupleIsIn.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple is not in list', function () {
-    this.tupleIsNotIn.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple is not in list', async function () {
+    (await this.tupleIsNotIn.exec(this.ctx)).should.be.false();
   });
 
-  it('should return false if list is null', function () {
-    this.inNull.exec(this.ctx).should.be.false();
+  it('should return false if list is null', async function () {
+    (await this.inNull.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null if null is in list', function () {
-    should(this.nullIn.exec(this.ctx)).be.null();
+  it('should return null if null is in list', async function () {
+    should(await this.nullIn.exec(this.ctx)).be.null();
   });
 
-  it('should return null if null is not in list', function () {
-    should(this.nullNotIn.exec(this.ctx)).be.null();
+  it('should return null if null is not in list', async function () {
+    should(await this.nullNotIn.exec(this.ctx)).be.null();
   });
 });
 
@@ -385,32 +399,32 @@ describe('Contains', () => {
     setup(this, data);
   });
 
-  it('should execute to true when item is in list', function () {
-    this.isIn.exec(this.ctx).should.be.true();
+  it('should execute to true when item is in list', async function () {
+    (await this.isIn.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when item is not in list', function () {
-    this.isNotIn.exec(this.ctx).should.be.false();
+  it('should execute to false when item is not in list', async function () {
+    (await this.isNotIn.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple is in list', function () {
-    this.tupleIsIn.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple is in list', async function () {
+    (await this.tupleIsIn.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple is not in list', function () {
-    this.tupleIsNotIn.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple is not in list', async function () {
+    (await this.tupleIsNotIn.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null if null is contained in the list', function () {
-    should(this.nullIn.exec(this.ctx)).be.null();
+  it('should return null if null is contained in the list', async function () {
+    should(await this.nullIn.exec(this.ctx)).be.null();
   });
 
-  it('should return null if null is not contained in the list', function () {
-    should(this.nullNotIn.exec(this.ctx)).be.null();
+  it('should return null if null is not contained in the list', async function () {
+    should(await this.nullNotIn.exec(this.ctx)).be.null();
   });
 
-  it('should return false if list is null', function () {
-    this.inNull.exec(this.ctx).should.be.false();
+  it('should return false if list is null', async function () {
+    (await this.inNull.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -419,47 +433,47 @@ describe('Includes', () => {
     setup(this, data);
   });
 
-  it('should execute to true when sublist is in list', function () {
-    this.isIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list', async function () {
+    (await this.isIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when sublist is in list in different order', function () {
-    this.isIncludedReversed.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list in different order', async function () {
+    (await this.isIncludedReversed.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when lists are the same', function () {
-    this.isSame.exec(this.ctx).should.be.true();
+  it('should execute to true when lists are the same', async function () {
+    (await this.isSame.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when sublist is not in list', function () {
-    this.isNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when sublist is not in list', async function () {
+    (await this.isNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple sublist is in list', function () {
-    this.tuplesIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple sublist is in list', async function () {
+    (await this.tuplesIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple sublist is not in list', function () {
-    this.tuplesNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple sublist is not in list', async function () {
+    (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it.skip('should return true if right arg is null', function () {
+  it.skip('should return true if right arg is null', async function () {
     // TODO: currently returns false
-    should(this.nullIncluded.exec(this.ctx)).be.true();
+    should(await this.nullIncluded.exec(this.ctx)).be.true();
   });
 
-  it.skip('should return false if left arg is null', function () {
+  it.skip('should return false if left arg is null', async function () {
     // TODO: currently returns null
-    should(this.nullIncludes.exec(this.ctx)).be.false();
+    should(await this.nullIncludes.exec(this.ctx)).be.false();
   });
 
-  it('should correctly handle point comparisons', function () {
-    this.dayIncluded.exec(this.ctx).should.be.true();
-    this.dayNotIncluded.exec(this.ctx).should.be.false();
-    this.integerIncluded.exec(this.ctx).should.be.true();
-    this.integerNotIncluded.exec(this.ctx).should.be.false();
-    this.quantityInList.exec(this.ctx).should.be.true();
-    this.quantityNotInList.exec(this.ctx).should.be.false();
+  it('should correctly handle point comparisons', async function () {
+    (await this.dayIncluded.exec(this.ctx)).should.be.true();
+    (await this.dayNotIncluded.exec(this.ctx)).should.be.false();
+    (await this.integerIncluded.exec(this.ctx)).should.be.true();
+    (await this.integerNotIncluded.exec(this.ctx)).should.be.false();
+    (await this.quantityInList.exec(this.ctx)).should.be.true();
+    (await this.quantityNotInList.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -468,47 +482,47 @@ describe('IncludedIn', () => {
     setup(this, data);
   });
 
-  it('should execute to true when sublist is in list', function () {
-    this.isIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list', async function () {
+    (await this.isIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when sublist is in list in different order', function () {
-    this.isIncludedReversed.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list in different order', async function () {
+    (await this.isIncludedReversed.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when lists are the same', function () {
-    this.isSame.exec(this.ctx).should.be.true();
+  it('should execute to true when lists are the same', async function () {
+    (await this.isSame.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when sublist is not in list', function () {
-    this.isNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when sublist is not in list', async function () {
+    (await this.isNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple sublist is in list', function () {
-    this.tuplesIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple sublist is in list', async function () {
+    (await this.tuplesIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple sublist is not in list', function () {
-    this.tuplesNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple sublist is not in list', async function () {
+    (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it.skip('should return true if left arg is null', function () {
+  it.skip('should return true if left arg is null', async function () {
     // TODO: currently returns false
-    should(this.nullIncluded.exec(this.ctx)).be.true();
+    should(await this.nullIncluded.exec(this.ctx)).be.true();
   });
 
-  it.skip('should return false if right arg is null', function () {
+  it.skip('should return false if right arg is null', async function () {
     // TODO: currently returns null
-    should(this.nullIncludes.exec(this.ctx)).be.false();
+    should(await this.nullIncludes.exec(this.ctx)).be.false();
   });
 
-  it('should correctly handle point comparisons', function () {
-    this.dayIncluded.exec(this.ctx).should.be.true();
-    this.dayNotIncluded.exec(this.ctx).should.be.false();
-    this.integerIncluded.exec(this.ctx).should.be.true();
-    this.integerNotIncluded.exec(this.ctx).should.be.false();
-    this.quantityInList.exec(this.ctx).should.be.true();
-    this.quantityNotInList.exec(this.ctx).should.be.false();
+  it('should correctly handle point comparisons', async function () {
+    (await this.dayIncluded.exec(this.ctx)).should.be.true();
+    (await this.dayNotIncluded.exec(this.ctx)).should.be.false();
+    (await this.integerIncluded.exec(this.ctx)).should.be.true();
+    (await this.integerNotIncluded.exec(this.ctx)).should.be.false();
+    (await this.quantityInList.exec(this.ctx)).should.be.true();
+    (await this.quantityNotInList.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -517,34 +531,34 @@ describe('ProperIncludes', () => {
     setup(this, data);
   });
 
-  it('should execute to true when sublist is in list', function () {
-    this.isIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list', async function () {
+    (await this.isIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when sublist is in list in different order', function () {
-    this.isIncludedReversed.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list in different order', async function () {
+    (await this.isIncludedReversed.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when lists are the same', function () {
-    this.isSame.exec(this.ctx).should.be.false();
+  it('should execute to false when lists are the same', async function () {
+    (await this.isSame.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to false when sublist is not in list', function () {
-    this.isNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when sublist is not in list', async function () {
+    (await this.isNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple sublist is in list', function () {
-    this.tuplesIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple sublist is in list', async function () {
+    (await this.tuplesIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple sublist is not in list', function () {
-    this.tuplesNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple sublist is not in list', async function () {
+    (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
   // TODO: Support for ProperContains
-  it.skip('should return null if either arg is null', function () {
-    should(this.nullIncluded.exec(this.ctx)).be.null();
-    should(this.nullIncludes.exec(this.ctx)).be.null();
+  it.skip('should return null if either arg is null', async function () {
+    should(await this.nullIncluded.exec(this.ctx)).be.null();
+    should(await this.nullIncludes.exec(this.ctx)).be.null();
   });
 });
 
@@ -553,33 +567,33 @@ describe('ProperIncludedIn', () => {
     setup(this, data);
   });
 
-  it('should execute to true when sublist is in list', function () {
-    this.isIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list', async function () {
+    (await this.isIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to true when sublist is in list in different order', function () {
-    this.isIncludedReversed.exec(this.ctx).should.be.true();
+  it('should execute to true when sublist is in list in different order', async function () {
+    (await this.isIncludedReversed.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when lists are the same', function () {
-    this.isSame.exec(this.ctx).should.be.false();
+  it('should execute to false when lists are the same', async function () {
+    (await this.isSame.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to false when sublist is not in list', function () {
-    this.isNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when sublist is not in list', async function () {
+    (await this.isNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute to true when tuple sublist is in list', function () {
-    this.tuplesIncluded.exec(this.ctx).should.be.true();
+  it('should execute to true when tuple sublist is in list', async function () {
+    (await this.tuplesIncluded.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute to false when tuple sublist is not in list', function () {
-    this.tuplesNotIncluded.exec(this.ctx).should.be.false();
+  it('should execute to false when tuple sublist is not in list', async function () {
+    (await this.tuplesNotIncluded.exec(this.ctx)).should.be.false();
   });
 
-  it('should return null if either arg is null', function () {
-    should(this.nullIncluded.exec(this.ctx)).be.null();
-    should(this.nullIncludes.exec(this.ctx)).be.null();
+  it('should return null if either arg is null', async function () {
+    should(await this.nullIncluded.exec(this.ctx)).be.null();
+    should(await this.nullIncludes.exec(this.ctx)).be.null();
   });
 });
 
@@ -588,14 +602,31 @@ describe('Flatten', () => {
     setup(this, data);
   });
 
-  it('should flatten a list of lists', function () {
-    this.listOfLists
-      .exec(this.ctx)
-      .should.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+  it('should flatten a list of lists', async function () {
+    (await this.listOfLists.exec(this.ctx)).should.eql([
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      9,
+      8,
+      7,
+      6,
+      5,
+      4,
+      3,
+      2,
+      1
+    ]);
   });
 
-  it('should return null for a null list', function () {
-    should(this.nullValue.exec(this.ctx)).be.null();
+  it('should return null for a null list', async function () {
+    should(await this.nullValue.exec(this.ctx)).be.null();
   });
 });
 
@@ -604,27 +635,32 @@ describe('Distinct', () => {
     setup(this, data);
   });
 
-  it('should remove duplicates', function () {
-    this.lotsOfDups.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should remove duplicates', async function () {
+    (await this.lotsOfDups.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should do nothing to an already distinct array', function () {
-    this.noDups.exec(this.ctx).should.eql([2, 4, 6, 8, 10]);
+  it('should do nothing to an already distinct array', async function () {
+    (await this.noDups.exec(this.ctx)).should.eql([2, 4, 6, 8, 10]);
   });
 
-  it('should remove duplicate tuples', function () {
-    this.dupsTuples
-      .exec(this.ctx)
-      .should.eql([{ hello: 'world' }, { hello: 'cleveland' }, { hello: 'dolly' }]);
+  it('should remove duplicate tuples', async function () {
+    (await this.dupsTuples.exec(this.ctx)).should.eql([
+      { hello: 'world' },
+      { hello: 'cleveland' },
+      { hello: 'dolly' }
+    ]);
   });
 
-  it('should do nothing to an array of distinct tuples', function () {
-    this.noDupsTuples.exec(this.ctx).should.eql([{ hello: 'world' }, { hello: 'cleveland' }]);
+  it('should do nothing to an array of distinct tuples', async function () {
+    (await this.noDupsTuples.exec(this.ctx)).should.eql([
+      { hello: 'world' },
+      { hello: 'cleveland' }
+    ]);
   });
 
-  it('should remove duplicate null values', function () {
+  it('should remove duplicate null values', async function () {
     // define DuplicateNulls: distinct {null, 1, 2, null, 3, 4, 5, null}
-    this.duplicateNulls.exec(this.ctx).should.eql([null, 1, 2, 3, 4, 5]);
+    (await this.duplicateNulls.exec(this.ctx)).should.eql([null, 1, 2, 3, 4, 5]);
   });
 });
 
@@ -633,32 +669,32 @@ describe('First', () => {
     setup(this, data);
   });
 
-  it('should get first of a list of numbers', function () {
-    this.numbers.exec(this.ctx).should.equal(1);
+  it('should get first of a list of numbers', async function () {
+    (await this.numbers.exec(this.ctx)).should.equal(1);
   });
 
-  it('should get first of a list of letters', function () {
-    this.letters.exec(this.ctx).should.equal('a');
+  it('should get first of a list of letters', async function () {
+    (await this.letters.exec(this.ctx)).should.equal('a');
   });
 
-  it('should get first of a list of lists', function () {
-    this.lists.exec(this.ctx).should.eql(['a', 'b', 'c']);
+  it('should get first of a list of lists', async function () {
+    (await this.lists.exec(this.ctx)).should.eql(['a', 'b', 'c']);
   });
 
-  it('should get first of a list of tuples', function () {
-    this.tuples.exec(this.ctx).should.eql({ a: 1, b: 2, c: 3 });
+  it('should get first of a list of tuples', async function () {
+    (await this.tuples.exec(this.ctx)).should.eql({ a: 1, b: 2, c: 3 });
   });
 
-  it('should get first of a list of unordered numbers', function () {
-    this.unordered.exec(this.ctx).should.equal(3);
+  it('should get first of a list of unordered numbers', async function () {
+    (await this.unordered.exec(this.ctx)).should.equal(3);
   });
 
-  it('should return null for an empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for an empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
 
-  it('should return null for a null list', function () {
-    should(this.nullValue.exec(this.ctx)).be.null();
+  it('should return null for a null list', async function () {
+    should(await this.nullValue.exec(this.ctx)).be.null();
   });
 });
 
@@ -667,32 +703,32 @@ describe('Last', () => {
     setup(this, data);
   });
 
-  it('should get last of a list of numbers', function () {
-    this.numbers.exec(this.ctx).should.equal(4);
+  it('should get last of a list of numbers', async function () {
+    (await this.numbers.exec(this.ctx)).should.equal(4);
   });
 
-  it('should get last of a list of letters', function () {
-    this.letters.exec(this.ctx).should.equal('c');
+  it('should get last of a list of letters', async function () {
+    (await this.letters.exec(this.ctx)).should.equal('c');
   });
 
-  it('should get last of a list of lists', function () {
-    this.lists.exec(this.ctx).should.eql(['d', 'e', 'f']);
+  it('should get last of a list of lists', async function () {
+    (await this.lists.exec(this.ctx)).should.eql(['d', 'e', 'f']);
   });
 
-  it('should get last of a list of tuples', function () {
-    this.tuples.exec(this.ctx).should.eql({ a: 24, b: 25, c: 26 });
+  it('should get last of a list of tuples', async function () {
+    (await this.tuples.exec(this.ctx)).should.eql({ a: 24, b: 25, c: 26 });
   });
 
-  it('should get last of a list of unordered numbers', function () {
-    this.unordered.exec(this.ctx).should.equal(2);
+  it('should get last of a list of unordered numbers', async function () {
+    (await this.unordered.exec(this.ctx)).should.equal(2);
   });
 
-  it('should return null for an empty list', function () {
-    should(this.empty.exec(this.ctx)).be.null();
+  it('should return null for an empty list', async function () {
+    should(await this.empty.exec(this.ctx)).be.null();
   });
 
-  it('should return null for a null list', function () {
-    should(this.nullValue.exec(this.ctx)).be.null();
+  it('should return null for a null list', async function () {
+    should(await this.nullValue.exec(this.ctx)).be.null();
   });
 });
 
@@ -701,24 +737,24 @@ describe('Length', () => {
     setup(this, data);
   });
 
-  it('should get length of a list of numbers', function () {
-    this.numbers.exec(this.ctx).should.equal(5);
+  it('should get length of a list of numbers', async function () {
+    (await this.numbers.exec(this.ctx)).should.equal(5);
   });
 
-  it('should get length of a list of lists', function () {
-    this.lists.exec(this.ctx).should.equal(4);
+  it('should get length of a list of lists', async function () {
+    (await this.lists.exec(this.ctx)).should.equal(4);
   });
 
-  it('should get length of a list of tuples', function () {
-    this.tuples.exec(this.ctx).should.equal(2);
+  it('should get length of a list of tuples', async function () {
+    (await this.tuples.exec(this.ctx)).should.equal(2);
   });
 
-  it('should get length of an empty list', function () {
-    this.empty.exec(this.ctx).should.equal(0);
+  it('should get length of an empty list', async function () {
+    (await this.empty.exec(this.ctx)).should.equal(0);
   });
 
-  it('should return zero for a null list', function () {
-    this.nullValue.exec(this.ctx).should.equal(0);
+  it('should return zero for a null list', async function () {
+    (await this.nullValue.exec(this.ctx)).should.equal(0);
   });
 });
 
@@ -727,16 +763,16 @@ describe('ToList', () => {
     setup(this, data);
   });
 
-  it('should return true that 5 is in 5', function () {
-    this.fiveInFive.exec(this.ctx).should.be.true();
+  it('should return true that 5 is in 5', async function () {
+    (await this.fiveInFive.exec(this.ctx)).should.be.true();
   });
 
-  it('should return false that 4 is in 5', function () {
-    this.fourInFive.exec(this.ctx).should.be.false();
+  it('should return false that 4 is in 5', async function () {
+    (await this.fourInFive.exec(this.ctx)).should.be.false();
   });
 
-  it('should make null into an empty list', function () {
-    this.lengthOfNull.exec(this.ctx).should.equal(0);
+  it('should make null into an empty list', async function () {
+    (await this.lengthOfNull.exec(this.ctx)).should.equal(0);
   });
 });
 
@@ -745,20 +781,20 @@ describe('Skip', () => {
     setup(this, data);
   });
 
-  it('should skip two elements', function () {
-    this.skip2.exec(this.ctx).should.eql([3, 4, 5]);
+  it('should skip two elements', async function () {
+    (await this.skip2.exec(this.ctx)).should.eql([3, 4, 5]);
   });
 
-  it('should not skip when using null', function () {
-    this.skipNull.exec(this.ctx).should.eql([1, 3, 5]);
+  it('should not skip when using null', async function () {
+    (await this.skipNull.exec(this.ctx)).should.eql([1, 3, 5]);
   });
 
-  it('should return empty list when using negative number', function () {
-    this.skipEmpty.exec(this.ctx).should.eql([]);
+  it('should return empty list when using negative number', async function () {
+    (await this.skipEmpty.exec(this.ctx)).should.eql([]);
   });
 
-  it('should return null when given null', function () {
-    should(this.skipIsNull.exec(this.ctx)).be.null();
+  it('should return null when given null', async function () {
+    should(await this.skipIsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -767,16 +803,16 @@ describe('Tail', () => {
     setup(this, data);
   });
 
-  it('should get tail of list', function () {
-    this.tail234.exec(this.ctx).should.eql([2, 3, 4]);
+  it('should get tail of list', async function () {
+    (await this.tail234.exec(this.ctx)).should.eql([2, 3, 4]);
   });
 
-  it('should return empty list when given empty list', function () {
-    this.tailEmpty.exec(this.ctx).should.eql([]);
+  it('should return empty list when given empty list', async function () {
+    (await this.tailEmpty.exec(this.ctx)).should.eql([]);
   });
 
-  it('should return null when given null', function () {
-    should(this.tailIsNull.exec(this.ctx)).be.null();
+  it('should return null when given null', async function () {
+    should(await this.tailIsNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -785,19 +821,19 @@ describe('Take', () => {
     setup(this, data);
   });
 
-  it('should take two elements', function () {
-    this.take2.exec(this.ctx).should.eql([1, 2]);
+  it('should take two elements', async function () {
+    (await this.take2.exec(this.ctx)).should.eql([1, 2]);
   });
 
-  it('should return full list when asked for too many elements', function () {
-    this.takeTooMany.exec(this.ctx).should.eql([1, 2]);
+  it('should return full list when asked for too many elements', async function () {
+    (await this.takeTooMany.exec(this.ctx)).should.eql([1, 2]);
   });
 
-  it('should return empty list when using null', function () {
-    this.takeEmpty.exec(this.ctx).should.eql([]);
+  it('should return empty list when using null', async function () {
+    (await this.takeEmpty.exec(this.ctx)).should.eql([]);
   });
 
-  it('should return null when given null', function () {
-    should(this.takeIsNull.exec(this.ctx)).be.null();
+  it('should return null when given null', async function () {
+    should(await this.takeIsNull.exec(this.ctx)).be.null();
   });
 });

--- a/test/elm/literal/literal-test.ts
+++ b/test/elm/literal/literal-test.ts
@@ -7,48 +7,48 @@ describe('Literal', () => {
     setup(this, data);
   });
 
-  it('should convert true to boolean true', function () {
+  it('should convert true to boolean true', async function () {
     this.boolTrue.value.should.be.true();
   });
 
-  it('should execute true as true', function () {
-    this.boolTrue.exec(this.ctx).should.be.true();
+  it('should execute true as true', async function () {
+    (await this.boolTrue.exec(this.ctx)).should.be.true();
   });
 
-  it('should convert false to boolean false', function () {
+  it('should convert false to boolean false', async function () {
     this.boolFalse.value.should.be.false();
   });
 
-  it('should execute false as false', function () {
-    this.boolFalse.exec(this.ctx).should.be.false();
+  it('should execute false as false', async function () {
+    (await this.boolFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should convert 1 to int 1', function () {
+  it('should convert 1 to int 1', async function () {
     this.intOne.value.should.equal(1);
   });
 
-  it('should execute 1 as 1', function () {
-    this.intOne.exec(this.ctx).should.equal(1);
+  it('should execute 1 as 1', async function () {
+    (await this.intOne.exec(this.ctx)).should.equal(1);
   });
 
-  it('should convert .1 to decimal .1', function () {
+  it('should convert .1 to decimal .1', async function () {
     this.decimalTenth.value.should.equal(0.1);
   });
 
-  it('should execute .1 as .1', function () {
-    this.decimalTenth.exec(this.ctx).should.equal(0.1);
+  it('should execute .1 as .1', async function () {
+    (await this.decimalTenth.exec(this.ctx)).should.equal(0.1);
   });
 
-  it("should convert 'true' to string 'true'", function () {
+  it("should convert 'true' to string 'true'", async function () {
     this.stringTrue.value.should.equal('true');
   });
 
-  it("should execute 'true' as 'true'", function () {
-    this.stringTrue.exec(this.ctx).should.equal('true');
+  it("should execute 'true' as 'true'", async function () {
+    (await this.stringTrue.exec(this.ctx)).should.equal('true');
   });
 
-  it("should execute '' as correct DateTime", function () {
-    const d = this.dateTimeX.exec(this.ctx);
+  it("should execute '' as correct DateTime", async function () {
+    const d = await this.dateTimeX.exec(this.ctx);
     d.isTime().should.be.false();
     d.year.should.equal(2012);
     d.month.should.equal(2);
@@ -60,8 +60,8 @@ describe('Literal', () => {
     d.timezoneOffset.should.equal(0);
   });
 
-  it("should execute '' as correct Time", function () {
-    const d = this.timeX.exec(this.ctx);
+  it("should execute '' as correct Time", async function () {
+    const d = await this.timeX.exec(this.ctx);
     d.isTime().should.be.true();
     d.year.should.equal(0);
     d.month.should.equal(1);
@@ -79,39 +79,39 @@ describe('Escape', () => {
     setup(this, data);
   });
 
-  it('should escape single quote', function () {
+  it('should escape single quote', async function () {
     this.singleQuote.value.should.equal("'");
   });
 
-  it('should escape double quote', function () {
+  it('should escape double quote', async function () {
     this.doubleQuote.value.should.equal('"');
   });
 
-  it('should escape backtick', function () {
+  it('should escape backtick', async function () {
     this.backtick.value.should.equal('`');
   });
 
-  it('should escape carriage return', function () {
+  it('should escape carriage return', async function () {
     this.carriageReturn.value.should.equal('\r');
   });
 
-  it('should escape line feed', function () {
+  it('should escape line feed', async function () {
     this.lineFeed.value.should.equal('\n');
   });
 
-  it('should escape tab', function () {
+  it('should escape tab', async function () {
     this.tab.value.should.equal('\t');
   });
 
-  it('should escape form feed', function () {
+  it('should escape form feed', async function () {
     this.formFeed.value.should.equal('\f');
   });
 
-  it('should escape backslash', function () {
+  it('should escape backslash', async function () {
     this.backslash.value.should.equal('\\');
   });
 
-  it('should escape unicode', function () {
+  it('should escape unicode', async function () {
     this.unicode.value.should.equal('H');
   });
 });

--- a/test/elm/literal/literal-test.ts
+++ b/test/elm/literal/literal-test.ts
@@ -7,7 +7,7 @@ describe('Literal', () => {
     setup(this, data);
   });
 
-  it('should convert true to boolean true', async function () {
+  it('should convert true to boolean true', function () {
     this.boolTrue.value.should.be.true();
   });
 
@@ -15,7 +15,7 @@ describe('Literal', () => {
     (await this.boolTrue.exec(this.ctx)).should.be.true();
   });
 
-  it('should convert false to boolean false', async function () {
+  it('should convert false to boolean false', function () {
     this.boolFalse.value.should.be.false();
   });
 
@@ -23,7 +23,7 @@ describe('Literal', () => {
     (await this.boolFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should convert 1 to int 1', async function () {
+  it('should convert 1 to int 1', function () {
     this.intOne.value.should.equal(1);
   });
 
@@ -31,7 +31,7 @@ describe('Literal', () => {
     (await this.intOne.exec(this.ctx)).should.equal(1);
   });
 
-  it('should convert .1 to decimal .1', async function () {
+  it('should convert .1 to decimal .1', function () {
     this.decimalTenth.value.should.equal(0.1);
   });
 
@@ -39,7 +39,7 @@ describe('Literal', () => {
     (await this.decimalTenth.exec(this.ctx)).should.equal(0.1);
   });
 
-  it("should convert 'true' to string 'true'", async function () {
+  it("should convert 'true' to string 'true'", function () {
     this.stringTrue.value.should.equal('true');
   });
 
@@ -79,39 +79,39 @@ describe('Escape', () => {
     setup(this, data);
   });
 
-  it('should escape single quote', async function () {
+  it('should escape single quote', function () {
     this.singleQuote.value.should.equal("'");
   });
 
-  it('should escape double quote', async function () {
+  it('should escape double quote', function () {
     this.doubleQuote.value.should.equal('"');
   });
 
-  it('should escape backtick', async function () {
+  it('should escape backtick', function () {
     this.backtick.value.should.equal('`');
   });
 
-  it('should escape carriage return', async function () {
+  it('should escape carriage return', function () {
     this.carriageReturn.value.should.equal('\r');
   });
 
-  it('should escape line feed', async function () {
+  it('should escape line feed', function () {
     this.lineFeed.value.should.equal('\n');
   });
 
-  it('should escape tab', async function () {
+  it('should escape tab', function () {
     this.tab.value.should.equal('\t');
   });
 
-  it('should escape form feed', async function () {
+  it('should escape form feed', function () {
     this.formFeed.value.should.equal('\f');
   });
 
-  it('should escape backslash', async function () {
+  it('should escape backslash', function () {
     this.backslash.value.should.equal('\\');
   });
 
-  it('should escape unicode', async function () {
+  it('should escape unicode', function () {
     this.unicode.value.should.equal('H');
   });
 });

--- a/test/elm/logical/logical-test.ts
+++ b/test/elm/logical/logical-test.ts
@@ -7,22 +7,22 @@ describe('And', () => {
     setup(this, data);
   });
 
-  it('should execute true and...', function () {
-    this.tT.exec(this.ctx).should.be.true();
-    this.tF.exec(this.ctx).should.be.false();
-    should(this.tN.exec(this.ctx)).be.null();
+  it('should execute true and...', async function () {
+    (await this.tT.exec(this.ctx)).should.be.true();
+    (await this.tF.exec(this.ctx)).should.be.false();
+    should(await this.tN.exec(this.ctx)).be.null();
   });
 
-  it('should execute false and...', function () {
-    this.fF.exec(this.ctx).should.be.false();
-    this.fT.exec(this.ctx).should.be.false();
-    this.fN.exec(this.ctx).should.be.false();
+  it('should execute false and...', async function () {
+    (await this.fF.exec(this.ctx)).should.be.false();
+    (await this.fT.exec(this.ctx)).should.be.false();
+    (await this.fN.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute null and...', function () {
-    should(this.nN.exec(this.ctx)).be.null();
-    should(this.nT.exec(this.ctx)).be.null();
-    this.nF.exec(this.ctx).should.be.false();
+  it('should execute null and...', async function () {
+    should(await this.nN.exec(this.ctx)).be.null();
+    should(await this.nT.exec(this.ctx)).be.null();
+    (await this.nF.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -31,22 +31,22 @@ describe('Or', () => {
     setup(this, data);
   });
 
-  it('should execute true or...', function () {
-    this.tT.exec(this.ctx).should.be.true();
-    this.tF.exec(this.ctx).should.be.true();
-    this.tN.exec(this.ctx).should.be.true();
+  it('should execute true or...', async function () {
+    (await this.tT.exec(this.ctx)).should.be.true();
+    (await this.tF.exec(this.ctx)).should.be.true();
+    (await this.tN.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute false or...', function () {
-    this.fF.exec(this.ctx).should.be.false();
-    this.fT.exec(this.ctx).should.be.true();
-    should(this.fN.exec(this.ctx)).be.null();
+  it('should execute false or...', async function () {
+    (await this.fF.exec(this.ctx)).should.be.false();
+    (await this.fT.exec(this.ctx)).should.be.true();
+    should(await this.fN.exec(this.ctx)).be.null();
   });
 
-  it('should execute null or...', function () {
-    should(this.nN.exec(this.ctx)).be.null();
-    this.nT.exec(this.ctx).should.be.true();
-    should(this.nF.exec(this.ctx)).be.null();
+  it('should execute null or...', async function () {
+    should(await this.nN.exec(this.ctx)).be.null();
+    (await this.nT.exec(this.ctx)).should.be.true();
+    should(await this.nF.exec(this.ctx)).be.null();
   });
 });
 
@@ -55,16 +55,16 @@ describe('Not', () => {
     setup(this, data);
   });
 
-  it('should execute not true as false', function () {
-    this.notTrue.exec(this.ctx).should.be.false();
+  it('should execute not true as false', async function () {
+    (await this.notTrue.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute not false as true', function () {
-    this.notFalse.exec(this.ctx).should.be.true();
+  it('should execute not false as true', async function () {
+    (await this.notFalse.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute not null as null', function () {
-    should(this.notNull.exec(this.ctx)).be.null();
+  it('should execute not null as null', async function () {
+    should(await this.notNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -73,22 +73,22 @@ describe('XOr', () => {
     setup(this, data);
   });
 
-  it('should execute true xor...', function () {
-    this.tT.exec(this.ctx).should.be.false();
-    this.tF.exec(this.ctx).should.be.true();
-    should(this.tN.exec(this.ctx)).be.null();
+  it('should execute true xor...', async function () {
+    (await this.tT.exec(this.ctx)).should.be.false();
+    (await this.tF.exec(this.ctx)).should.be.true();
+    should(await this.tN.exec(this.ctx)).be.null();
   });
 
-  it('should execute false xor...', function () {
-    this.fF.exec(this.ctx).should.be.false();
-    this.fT.exec(this.ctx).should.be.true();
-    should(this.fN.exec(this.ctx)).be.null();
+  it('should execute false xor...', async function () {
+    (await this.fF.exec(this.ctx)).should.be.false();
+    (await this.fT.exec(this.ctx)).should.be.true();
+    should(await this.fN.exec(this.ctx)).be.null();
   });
 
-  it('should execute null xor...', function () {
-    should(this.nN.exec(this.ctx)).be.null();
-    should(this.nT.exec(this.ctx)).be.null();
-    should(this.nF.exec(this.ctx)).be.null();
+  it('should execute null xor...', async function () {
+    should(await this.nN.exec(this.ctx)).be.null();
+    should(await this.nT.exec(this.ctx)).be.null();
+    should(await this.nF.exec(this.ctx)).be.null();
   });
 });
 
@@ -97,16 +97,16 @@ describe('IsTrue', () => {
     setup(this, data);
   });
 
-  it('should execute true is true...', function () {
-    this.trueIsTrue.exec(this.ctx).should.be.true();
+  it('should execute true is true...', async function () {
+    (await this.trueIsTrue.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute false is true...', function () {
-    this.falseIsTrue.exec(this.ctx).should.be.false();
+  it('should execute false is true...', async function () {
+    (await this.falseIsTrue.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute null is true...', function () {
-    this.nullIsTrue.exec(this.ctx).should.be.false();
+  it('should execute null is true...', async function () {
+    (await this.nullIsTrue.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -115,15 +115,15 @@ describe('IsFalse', () => {
     setup(this, data);
   });
 
-  it('should execute true is false...', function () {
-    this.trueIsFalse.exec(this.ctx).should.be.false();
+  it('should execute true is false...', async function () {
+    (await this.trueIsFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should execute false is false...', function () {
-    this.falseIsFalse.exec(this.ctx).should.be.true();
+  it('should execute false is false...', async function () {
+    (await this.falseIsFalse.exec(this.ctx)).should.be.true();
   });
 
-  it('should execute null is false...', function () {
-    this.nullIsFalse.exec(this.ctx).should.be.false();
+  it('should execute null is false...', async function () {
+    (await this.nullIsFalse.exec(this.ctx)).should.be.false();
   });
 });

--- a/test/elm/message/message-test.ts
+++ b/test/elm/message/message-test.ts
@@ -11,18 +11,18 @@ describe('Message', () => {
     this.ctx.messageListener = messageCollector;
   });
 
-  it('should always return the first argument as-is', function () {
-    this.oneOverTwo.exec(this.ctx).should.equal(0.5);
-    should(this.oneOverZero.exec(this.ctx)).be.null();
+  it('should always return the first argument as-is', async function () {
+    (await this.oneOverTwo.exec(this.ctx)).should.equal(0.5);
+    should(await this.oneOverZero.exec(this.ctx)).be.null();
   });
 
-  it('should not log a message when the condition is false', function () {
-    this.oneOverTwo.exec(this.ctx);
+  it('should not log a message when the condition is false', async function () {
+    await this.oneOverTwo.exec(this.ctx);
     messageCollector.messages.length.should.equal(0);
   });
 
-  it('should log a message when the condition is true', function () {
-    this.oneOverZero.exec(this.ctx);
+  it('should log a message when the condition is true', async function () {
+    await this.oneOverZero.exec(this.ctx);
     messageCollector.messages.length.should.equal(1);
     messageCollector.messages[0].should.equal('Error: [DivideByZero] Cannot divide by zero (null)');
   });

--- a/test/elm/nullological/nullological-test.ts
+++ b/test/elm/nullological/nullological-test.ts
@@ -7,8 +7,8 @@ describe('Nil', () => {
     setup(this, data);
   });
 
-  it('should execute as null', function () {
-    should(this.nil.exec(this.ctx)).be.null();
+  it('should execute as null', async function () {
+    should(await this.nil.exec(this.ctx)).be.null();
   });
 });
 
@@ -17,20 +17,20 @@ describe('IsNull', () => {
     setup(this, data);
   });
 
-  it('should detect that null is null', function () {
-    this.nullIsNull.exec(this.ctx).should.be.true();
+  it('should detect that null is null', async function () {
+    (await this.nullIsNull.exec(this.ctx)).should.be.true();
   });
 
-  it('should detect that null variable is null', function () {
-    this.nullVarIsNull.exec(this.ctx).should.be.true();
+  it('should detect that null variable is null', async function () {
+    (await this.nullVarIsNull.exec(this.ctx)).should.be.true();
   });
 
-  it('should detect that string is not null', function () {
-    this.stringIsNull.exec(this.ctx).should.be.false();
+  it('should detect that string is not null', async function () {
+    (await this.stringIsNull.exec(this.ctx)).should.be.false();
   });
 
-  it('should detect that non-null variable is not null', function () {
-    this.nonNullVarIsNull.exec(this.ctx).should.be.false();
+  it('should detect that non-null variable is not null', async function () {
+    (await this.nonNullVarIsNull.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -39,35 +39,35 @@ describe('Coalesce', () => {
     setup(this, data);
   });
 
-  it('should return first non-null when leading args are null', function () {
-    this.nullNullHelloNullWorld.exec(this.ctx).should.equal('Hello');
+  it('should return first non-null when leading args are null', async function () {
+    (await this.nullNullHelloNullWorld.exec(this.ctx)).should.equal('Hello');
   });
 
-  it('should return first arg when it is non-null', function () {
-    this.fooNullNullBar.exec(this.ctx).should.equal('Foo');
+  it('should return first arg when it is non-null', async function () {
+    (await this.fooNullNullBar.exec(this.ctx)).should.equal('Foo');
   });
 
-  it('should return null when they are all null', function () {
-    should(this.allNull.exec(this.ctx)).be.null();
+  it('should return null when they are all null', async function () {
+    should(await this.allNull.exec(this.ctx)).be.null();
   });
 
-  it('should return first non-null in array', function () {
-    this.listArgStartsWithNull.exec(this.ctx).should.equal('One');
+  it('should return first non-null in array', async function () {
+    (await this.listArgStartsWithNull.exec(this.ctx)).should.equal('One');
   });
 
-  it('should return null for all-null array', function () {
-    should(this.listArgAllNull.exec(this.ctx)).be.null();
+  it('should return null for all-null array', async function () {
+    should(await this.listArgAllNull.exec(this.ctx)).be.null();
   });
 
-  it('should be able to handle ExpressionRef with list', function () {
-    this.listExpressionRef.exec(this.ctx).should.equal('One');
+  it('should be able to handle ExpressionRef with list', async function () {
+    (await this.listExpressionRef.exec(this.ctx)).should.equal('One');
   });
 
-  it('should be able to handle Retrieve as list', function () {
-    should(this.retrieveAsList.exec(this.ctx)).be.null();
+  it('should be able to handle Retrieve as list', async function () {
+    should(await this.retrieveAsList.exec(this.ctx)).be.null();
   });
 
-  it('should be able to handle Union as list', function () {
-    this.unionAsList.exec(this.ctx).should.equal(3);
+  it('should be able to handle Union as list', async function () {
+    (await this.unionAsList.exec(this.ctx)).should.equal(3);
   });
 });

--- a/test/elm/parameters/parameters-test.ts
+++ b/test/elm/parameters/parameters-test.ts
@@ -12,34 +12,36 @@ describe('ParameterDef', () => {
     this.param = this.lib.parameters.MeasureYear;
   });
 
-  it('should have a name', function () {
+  it('should have a name', async function () {
     this.param.name.should.equal('MeasureYear');
   });
 
-  it('should execute to default value', function () {
-    this.param.exec(this.ctx).should.equal(2012);
+  it('should execute to default value', async function () {
+    (await this.param.exec(this.ctx)).should.equal(2012);
   });
 
-  it('should execute to provided value', function () {
-    this.param.exec(this.ctx.withParameters({ MeasureYear: 2013 })).should.equal(2013);
+  it('should execute to provided value', async function () {
+    (await this.param.exec(this.ctx.withParameters({ MeasureYear: 2013 }))).should.equal(2013);
   });
 
-  it('should work with typed int parameters', function () {
+  it('should work with typed int parameters', async function () {
     const intParam = this.lib.parameters.IntParameter;
-    intParam.exec(this.ctx.withParameters({ IntParameter: 17 })).should.equal(17);
+    (await intParam.exec(this.ctx.withParameters({ IntParameter: 17 }))).should.equal(17);
   });
 
-  it('should work with typed list parameters', function () {
+  it('should work with typed list parameters', async function () {
     const listParam = this.lib.parameters.ListParameter;
-    listParam
-      .exec(this.ctx.withParameters({ ListParameter: ['a', 'b', 'c'] }))
-      .should.eql(['a', 'b', 'c']);
+    (await listParam.exec(this.ctx.withParameters({ ListParameter: ['a', 'b', 'c'] }))).should.eql([
+      'a',
+      'b',
+      'c'
+    ]);
   });
 
-  it('should work with typed tuple parameters', function () {
+  it('should work with typed tuple parameters', async function () {
     const tupleParam = this.lib.parameters.TupleParameter;
     const v = { a: 1, b: 'bee', c: true, d: [10, 9, 8], e: { f: 'eff', g: false } };
-    tupleParam.exec(this.ctx.withParameters({ TupleParameter: v })).should.eql(v);
+    (await tupleParam.exec(this.ctx.withParameters({ TupleParameter: v }))).should.eql(v);
   });
 });
 
@@ -48,16 +50,16 @@ describe('ParameterRef', () => {
     setup(this, data);
   });
 
-  it('should have a name', function () {
+  it('should have a name', async function () {
     this.foo.name.should.equal('FooP');
   });
 
-  it('should execute to default value', function () {
-    this.foo.exec(this.ctx).should.equal('Bar');
+  it('should execute to default value', async function () {
+    (await this.foo.exec(this.ctx)).should.equal('Bar');
   });
 
-  it('should execute to provided value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: 'Bah' })).should.equal('Bah');
+  it('should execute to provided value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: 'Bah' }))).should.equal('Bah');
   });
 
   it('should fail when provided value is wrong type', function () {
@@ -70,20 +72,20 @@ describe('BooleanParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: true })).should.equal(true);
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: true }))).should.equal(true);
   });
 
   it('should throw when provided value is wrong type', function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 12 }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.equal(true);
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.equal(true);
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2.exec(this.ctx.withParameters({ FooDP: false })).should.equal(false);
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: false }))).should.equal(false);
   });
 
   it('should throw when overriding value is wrong type', function () {
@@ -96,20 +98,20 @@ describe('DecimalParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: 3.0 })).should.equal(3.0);
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: 3.0 }))).should.equal(3.0);
   });
 
   it('should throw when provided value is wrong type', function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: '3' }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.equal(1.5);
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.equal(1.5);
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2.exec(this.ctx.withParameters({ FooDP: 3.0 })).should.equal(3.0);
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: 3.0 }))).should.equal(3.0);
   });
 
   it('should throw when overriding value is wrong type', function () {
@@ -122,20 +124,20 @@ describe('IntegerParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: 3 })).should.equal(3);
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: 3 }))).should.equal(3);
   });
 
   it('should throw when provided value is wrong type', function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 3.5 }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.equal(2);
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.equal(2);
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2.exec(this.ctx.withParameters({ FooDP: 3 })).should.equal(3);
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: 3 }))).should.equal(3);
   });
 
   it('should throw when overriding value is wrong type', function () {
@@ -148,20 +150,24 @@ describe('StringParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooP: 'Hello World' })).should.equal('Hello World');
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).should.equal(
+      'Hello World'
+    );
   });
 
   it('should throw when provided value is wrong type', function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 42 }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.equal('Hello');
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.equal('Hello');
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2.exec(this.ctx.withParameters({ FooDP: 'Hello World' })).should.equal('Hello World');
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: 'Hello World' }))).should.equal(
+      'Hello World'
+    );
   });
 
   it('should throw when overriding value is wrong type', function () {
@@ -174,28 +180,28 @@ describe('CodeParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const c = new Code('foo', 'http://foo.org', null, 'Foo');
-    this.foo.exec(this.ctx.withParameters({ FooP: c })).should.equal(c);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: c }))).should.equal(c);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const c = new Concept([new Code('foo', 'http://foo.org')], 'Foo');
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: c }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2
-      .exec(this.ctx)
-      .should.eql(new Code('FooTest', 'http://footest.org', undefined, 'Foo Test'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(
+      new Code('FooTest', 'http://footest.org', undefined, 'Foo Test')
+    );
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const c = new Code('foo', 'http://foo.org', null, 'Foo');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: c })).should.equal(c);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: c }))).should.equal(c);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const c = new Concept([new Code('foo', 'http://foo.org')], 'Foo');
     should(() => this.foo2.exec(this.ctx.withParameters({ FooDP: c }))).throw(/.*wrong type.*/);
   });
@@ -206,28 +212,28 @@ describe('ConceptParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const c = new Concept([new Code('foo', 'http://foo.org')], 'Foo');
-    this.foo.exec(this.ctx.withParameters({ FooP: c })).should.equal(c);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: c }))).should.equal(c);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const c = new Code('foo', 'http://foo.org');
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: c }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2
-      .exec(this.ctx)
-      .should.eql(new Concept([new Code('FooTest', 'http://footest.org')], 'Foo Test'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(
+      new Concept([new Code('FooTest', 'http://footest.org')], 'Foo Test')
+    );
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const c = new Concept([new Code('foo', 'http://foo.org')], 'Foo');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: c })).should.equal(c);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: c }))).should.equal(c);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const c = new Code('foo', 'http://foo.org');
     should(() => this.foo2.exec(this.ctx.withParameters({ FooDP: c }))).throw(/.*wrong type.*/);
   });
@@ -238,26 +244,26 @@ describe('DateTimeParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const d = DateTime.parse('2012-10-25T12:55:14.456+00');
-    this.foo.exec(this.ctx.withParameters({ FooP: d })).should.equal(d);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: d }))).should.equal(d);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const d = '2012-10-25T12:55:14.456+00';
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: d }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(DateTime.parse('2012-04-01T12:11:10'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(DateTime.parse('2012-04-01T12:11:10'));
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const d = DateTime.parse('2012-10-25T12:55:14.456+00');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: d })).should.equal(d);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: d }))).should.equal(d);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const d = '2012-10-25T12:55:14.456+00';
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: d }))).throw(/.*wrong type.*/);
   });
@@ -268,26 +274,26 @@ describe('DateParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const d = Date.parse('2012-10-25');
-    this.foo.exec(this.ctx.withParameters({ FooP: d })).should.equal(d);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: d }))).should.equal(d);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const d = '2012-10-25';
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: d }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(Date.parse('2012-04-01'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(Date.parse('2012-04-01'));
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const d = Date.parse('2012-10-25');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: d })).should.equal(d);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: d }))).should.equal(d);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const d = '2012-10-25';
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: d }))).throw(/.*wrong type.*/);
   });
@@ -298,26 +304,26 @@ describe('QuantityParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const q = new Quantity(5, 'mg');
-    this.foo.exec(this.ctx.withParameters({ FooP: q })).should.equal(q);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: q }))).should.equal(q);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const q = 5;
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: q }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(new Quantity(10, 'dL'));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(new Quantity(10, 'dL'));
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const q = new Quantity(5, 'mg');
-    this.foo2.exec(this.ctx.withParameters({ FooDP: q })).should.equal(q);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: q }))).should.equal(q);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const q = 5;
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: q }))).throw(/.*wrong type.*/);
   });
@@ -328,26 +334,26 @@ describe('TimeParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const t = DateTime.parse('2012-10-25T12:55:14.456+00').getTime();
-    this.foo.exec(this.ctx.withParameters({ FooP: t })).should.equal(t);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: t }))).should.equal(t);
   });
 
-  it('should throw when provided value is wrong type', function () {
+  it('should throw when provided value is wrong type', async function () {
     const t = DateTime.parse('2012-10-25T12:55:14.456+00');
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: t }))).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(DateTime.parse('2012-10-25T12:00:00').getTime());
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(DateTime.parse('2012-10-25T12:00:00').getTime());
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const t = DateTime.parse('2012-10-25T12:55:14.456+00').getTime();
-    this.foo2.exec(this.ctx.withParameters({ FooDP: t })).should.equal(t);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: t }))).should.equal(t);
   });
 
-  it('should throw when overriding value is wrong type', function () {
+  it('should throw when overriding value is wrong type', async function () {
     const t = DateTime.parse('2012-10-25T12:55:14.456+00');
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: t }))).throw(/.*wrong type.*/);
   });
@@ -358,41 +364,43 @@ describe('ListParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo
-      .exec(this.ctx.withParameters({ FooP: ['Hello', 'World'] }))
-      .should.eql(['Hello', 'World']);
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: ['Hello', 'World'] }))).should.eql([
+      'Hello',
+      'World'
+    ]);
   });
 
-  it('should throw when provided value is not a list', function () {
+  it('should throw when provided value is not a list', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should throw when list contains a wrong type', function () {
+  it('should throw when list contains a wrong type', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: ['Hello', 2468] }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(['a', 'b', 'c']);
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(['a', 'b', 'c']);
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2
-      .exec(this.ctx.withParameters({ FooDP: ['Hello', 'World'] }))
-      .should.eql(['Hello', 'World']);
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: ['Hello', 'World'] }))).should.eql([
+      'Hello',
+      'World'
+    ]);
   });
 
-  it('should throw when overriding value is not a list', function () {
+  it('should throw when overriding value is not a list', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should throw when overriding list contains a wrong type', function () {
+  it('should throw when overriding list contains a wrong type', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: ['Hello', 2468] }))).throw(
       /.*wrong type.*/
     );
@@ -404,37 +412,37 @@ describe('IntervalParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
-    this.foo
-      .exec(this.ctx.withParameters({ FooP: new Interval(1, 5) }))
-      .should.eql(new Interval(1, 5));
+  it('should execute to provided valid value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooP: new Interval(1, 5) }))).should.eql(
+      new Interval(1, 5)
+    );
   });
 
-  it('should throw when provided value is not an interval', function () {
+  it('should throw when provided value is not an interval', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: [1, 5] }))).throw(/.*wrong type.*/);
   });
 
-  it('should throw when interval contains a wrong point type', function () {
+  it('should throw when interval contains a wrong point type', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: new Interval(1.5, 5.5) }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql(new Interval(2, 6));
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql(new Interval(2, 6));
   });
 
-  it('should execute to overriding valid value', function () {
-    this.foo2
-      .exec(this.ctx.withParameters({ FooDP: new Interval(1, 5) }))
-      .should.eql(new Interval(1, 5));
+  it('should execute to overriding valid value', async function () {
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: new Interval(1, 5) }))).should.eql(
+      new Interval(1, 5)
+    );
   });
 
-  it('should throw when overriding value is not an interval', function () {
+  it('should throw when overriding value is not an interval', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: [1, 5] }))).throw(/.*wrong type.*/);
   });
 
-  it('should throw when overriding interval contains a wrong point type', function () {
+  it('should throw when overriding interval contains a wrong point type', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: new Interval(1.5, 5.5) }))).throw(
       /.*wrong type.*/
     );
@@ -446,23 +454,23 @@ describe('TupleParameterTypes', () => {
     setup(this, data);
   });
 
-  it('should execute to provided valid value', function () {
+  it('should execute to provided valid value', async function () {
     const t = { Hello: 'World', MeaningOfLife: 42 };
-    this.foo.exec(this.ctx.withParameters({ FooP: t })).should.eql(t);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: t }))).should.eql(t);
   });
 
-  it('should allow missing tuple properties', function () {
+  it('should allow missing tuple properties', async function () {
     const t = { MeaningOfLife: 42 };
-    this.foo.exec(this.ctx.withParameters({ FooP: t })).should.eql(t);
+    (await this.foo.exec(this.ctx.withParameters({ FooP: t }))).should.eql(t);
   });
 
-  it('should throw when provided value is not a tuple', function () {
+  it('should throw when provided value is not a tuple', async function () {
     should(() => this.foo.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should throw when tuple contains a wrong property type', function () {
+  it('should throw when tuple contains a wrong property type', async function () {
     should(() =>
       this.foo.exec(
         this.ctx.withParameters({ FooP: { Hello: 'World', MeaningOfLife: 'Forty-Two' } })
@@ -470,27 +478,27 @@ describe('TupleParameterTypes', () => {
     ).throw(/.*wrong type.*/);
   });
 
-  it('should execute to default value', function () {
-    this.foo2.exec(this.ctx).should.eql({ Hello: 'Universe', MeaningOfLife: 24 });
+  it('should execute to default value', async function () {
+    (await this.foo2.exec(this.ctx)).should.eql({ Hello: 'Universe', MeaningOfLife: 24 });
   });
 
-  it('should execute to overriding valid value', function () {
+  it('should execute to overriding valid value', async function () {
     const t = { Hello: 'World', MeaningOfLife: 42 };
-    this.foo2.exec(this.ctx.withParameters({ FooDP: t })).should.eql(t);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: t }))).should.eql(t);
   });
 
-  it('should allow missing tuple properties in overriding tuple', function () {
+  it('should allow missing tuple properties in overriding tuple', async function () {
     const t = { MeaningOfLife: 42 };
-    this.foo2.exec(this.ctx.withParameters({ FooDP: t })).should.eql(t);
+    (await this.foo2.exec(this.ctx.withParameters({ FooDP: t }))).should.eql(t);
   });
 
-  it('should throw when overriding value is not a tuple', function () {
+  it('should throw when overriding value is not a tuple', async function () {
     should(() => this.foo2.exec(this.ctx.withParameters({ FooP: 'Hello World' }))).throw(
       /.*wrong type.*/
     );
   });
 
-  it('should throw when overriding tuple contains a wrong property type', function () {
+  it('should throw when overriding tuple contains a wrong property type', async function () {
     should(() =>
       this.foo2.exec(
         this.ctx.withParameters({ FooP: { Hello: 'World', MeaningOfLife: 'Forty-Two' } })
@@ -504,9 +512,9 @@ describe('DefaultAndNoDefault', () => {
     setup(this, data);
   });
 
-  it('should be able to retrieve a provided value and a default value', function () {
-    this.foo.exec(this.ctx.withParameters({ FooWithNoDefault: 1 })).should.eql(1);
-    this.foo2.exec(this.ctx.withParameters({ FooWithNoDefault: 1 })).should.eql(5);
+  it('should be able to retrieve a provided value and a default value', async function () {
+    (await this.foo.exec(this.ctx.withParameters({ FooWithNoDefault: 1 }))).should.eql(1);
+    (await this.foo2.exec(this.ctx.withParameters({ FooWithNoDefault: 1 }))).should.eql(5);
   });
 });
 
@@ -515,7 +523,7 @@ describe('MeasurementPeriodParameter', () => {
     setup(this, data);
   });
 
-  it('should execute expression with a passed in measurement period in a child context', function () {
+  it('should execute expression with a passed in measurement period in a child context', async function () {
     this.ctx = this.ctx.withParameters({
       'Measurement Period': new Interval(
         new DateTime(2012, 1, 1, 0, 0, 0, 0),
@@ -523,10 +531,10 @@ describe('MeasurementPeriodParameter', () => {
       )
     });
     const rctx = this.ctx.childContext();
-    this.measurementPeriod.exec(rctx).should.equal(true);
+    (await this.measurementPeriod.exec(rctx)).should.equal(true);
   });
 
-  it('should execute expression with a passed in measurement period in a child context', function () {
+  it('should execute expression with a passed in measurement period in a child context', async function () {
     this.ctx = this.ctx.withParameters({
       'Measurement Period': new Interval(
         new DateTime(2012, 1, 1, 0, 0, 0, 0),
@@ -536,6 +544,6 @@ describe('MeasurementPeriodParameter', () => {
     const r1ctx = this.ctx.childContext();
     const r2ctx = r1ctx.childContext();
     const r3ctx = r2ctx.childContext();
-    this.measurementPeriod.exec(r3ctx).should.equal(true);
+    (await this.measurementPeriod.exec(r3ctx)).should.equal(true);
   });
 });

--- a/test/elm/query/query-test.ts
+++ b/test/elm/query/query-test.ts
@@ -12,20 +12,20 @@ describe('DateRangeOptimizedQuery', () => {
     setup(this, data, [p1], vsets);
   });
 
-  it('should find encounters performed during the MP', function () {
-    const e = this.encountersDuringMP.exec(this.ctx);
+  it('should find encounters performed during the MP', async function () {
+    const e = await this.encountersDuringMP.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/5');
   });
 
-  it('should find ambulatory encounters performed during the MP', function () {
-    const e = this.ambulatoryEncountersDuringMP.exec(this.ctx);
+  it('should find ambulatory encounters performed during the MP', async function () {
+    const e = await this.ambulatoryEncountersDuringMP.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/5');
   });
 
-  it('should find ambulatory encounter performances included in the MP', function () {
-    const e = this.ambulatoryEncountersIncludedInMP.exec(this.ctx);
+  it('should find ambulatory encounter performances included in the MP', async function () {
+    const e = await this.ambulatoryEncountersIncludedInMP.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/5');
   });
@@ -36,19 +36,19 @@ describe('FunctionQuery', () => {
     setup(this, data, [p1], vsets);
   });
 
-  it('function with this', function () {
-    const functionReturnsDates = this.queryWithThis.exec(this.ctx);
+  it('function with this', async function () {
+    const functionReturnsDates = await this.queryWithThis.exec(this.ctx);
     functionReturnsDates.should.eql(true);
   });
 });
 
-describe.skip('IncludesQuery', function () {
+describe.skip('IncludesQuery', async function () {
   beforeEach(function () {
     setup(this, data, [p1], vsets);
   });
 
-  it('should find ambulatory encounter performances included in the MP', function () {
-    const e = this.mPIncludedAmbulatoryEncounters.exec(this.ctx);
+  it('should find ambulatory encounter performances included in the MP', async function () {
+    const e = await this.mPIncludedAmbulatoryEncounters.exec(this.ctx);
     e.should.have.length(1);
     e[0].id.should.equal('http://cqframework.org/3/5');
   });
@@ -59,44 +59,44 @@ describe('MultiSourceQuery', () => {
     setup(this, data, [p1], vsets);
   });
 
-  it('should find all Encounters performed and Conditions', function () {
-    const e = this.msQuery.exec(this.ctx);
+  it('should find all Encounters performed and Conditions', async function () {
+    const e = await this.msQuery.exec(this.ctx);
     e.should.have.length(6);
   });
 
-  it.skip('should find encounters performed during the MP and All conditions', function () {
-    const e = this.msQueryWhere.exec(this.ctx);
+  it.skip('should find encounters performed during the MP and All conditions', async function () {
+    const e = await this.msQueryWhere.exec(this.ctx);
     e.should.have.length(2);
   });
 
-  it.skip('should be able to filter items in the where clause', function () {
-    const e = this.msQueryWhere2.exec(this.ctx);
+  it.skip('should be able to filter items in the where clause', async function () {
+    const e = await this.msQueryWhere2.exec(this.ctx);
     e.should.have.length(1);
   });
 });
 
-describe.skip('QueryRelationship', function () {
+describe.skip('QueryRelationship', async function () {
   beforeEach(function () {
     setup(this, data, [p1]);
   });
 
-  it('should be able to filter items with a with clause', function () {
-    const e = this.withQuery.exec(this.ctx);
+  it('should be able to filter items with a with clause', async function () {
+    const e = await this.withQuery.exec(this.ctx);
     e.should.have.length(3);
   });
 
-  it('with clause should filter out items not available', function () {
-    const e = this.withQuery2.exec(this.ctx);
+  it('with clause should filter out items not available', async function () {
+    const e = await this.withQuery2.exec(this.ctx);
     e.should.have.length(0);
   });
 
-  it('should be able to filter items with a without clause', function () {
-    const e = this.withOutQuery.exec(this.ctx);
+  it('should be able to filter items with a without clause', async function () {
+    const e = await this.withOutQuery.exec(this.ctx);
     e.should.have.length(3);
   });
 
-  it('without clause should be able to filter items with a without clause', function () {
-    const e = this.withOutQuery2.exec(this.ctx);
+  it('without clause should be able to filter items with a without clause', async function () {
+    const e = await this.withOutQuery2.exec(this.ctx);
     e.should.have.length(0);
   });
 });
@@ -106,8 +106,8 @@ describe('QueryLet', () => {
     setup(this, data, [p1]);
   });
 
-  it('should be able to define a variable in a query and use it', function () {
-    const e = this.query.exec(this.ctx);
+  it('should be able to define a variable in a query and use it', async function () {
+    const e = await this.query.exec(this.ctx);
     e.should.have.length(3);
     e[0]['a'].should.equal(e[0]['E']);
     e[1]['a'].should.equal(e[1]['E']);
@@ -120,8 +120,8 @@ describe('Tuple', () => {
     setup(this, data, [p1]);
   });
 
-  it('should be able to return tuple from a query', function () {
-    const e = this.query.exec(this.ctx);
+  it('should be able to return tuple from a query', async function () {
+    const e = await this.query.exec(this.ctx);
     e.should.have.length(3);
   });
 });
@@ -131,8 +131,8 @@ describe('QueryFilterNulls', () => {
     setup(this, data, [p1]);
   });
 
-  it('should properly handle querying over nulls', function () {
-    const e = this.query.exec(this.ctx);
+  it('should properly handle querying over nulls', async function () {
+    const e = await this.query.exec(this.ctx);
     e.should.have.length(2);
     e.should.eql(['One', 'Two']);
   });
@@ -143,103 +143,129 @@ describe('Sorting', () => {
     setup(this, data, [p1]);
   });
 
-  it('should correctly sort quantities asc', function () {
-    const e = this.quantityListAsc.exec(this.ctx);
+  it('should correctly sort quantities asc', async function () {
+    const e = await this.quantityListAsc.exec(this.ctx);
     e.should.have.length(2);
     e[0]['value'].should.equal(2);
   });
 
-  it('should correctly sort quantities', function () {
-    const e = this.quantityListSort.exec(this.ctx);
+  it('should correctly sort quantities', async function () {
+    const e = await this.quantityListSort.exec(this.ctx);
     e[0]['N']['value'].should.equal(2);
   });
 
-  it('should be able to sort by a tuple field asc', function () {
-    let e = this.tupleAsc.exec(this.ctx);
+  it('should be able to sort by a tuple field asc', async function () {
+    let e = await this.tupleAsc.exec(this.ctx);
     e.should.have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[2].id.should.equal('http://cqframework.org/3/5');
 
-    e = this.tupleReturnAsc.exec(this.ctx);
+    e = await this.tupleReturnAsc.exec(this.ctx);
     e.should.have.length(3);
     e[0].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[2].id.should.equal('http://cqframework.org/3/5');
 
-    e = this.tupleReturnTupleAsc.exec(this.ctx);
+    e = await this.tupleReturnTupleAsc.exec(this.ctx);
     e.should.have.length(3);
     e[0].E.id.should.equal('http://cqframework.org/3/1');
     e[1].E.id.should.equal('http://cqframework.org/3/3');
     e[2].E.id.should.equal('http://cqframework.org/3/5');
   });
 
-  it('should be able to sort by a tuple field desc', function () {
-    let e = this.tupleDesc.exec(this.ctx);
+  it('should be able to sort by a tuple field desc', async function () {
+    let e = await this.tupleDesc.exec(this.ctx);
     e.should.have.length(3);
     e[2].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[0].id.should.equal('http://cqframework.org/3/5');
 
-    e = this.tupleReturnDesc.exec(this.ctx);
+    e = await this.tupleReturnDesc.exec(this.ctx);
     e.should.have.length(3);
     e[2].id.should.equal('http://cqframework.org/3/1');
     e[1].id.should.equal('http://cqframework.org/3/3');
     e[0].id.should.equal('http://cqframework.org/3/5');
 
-    e = this.tupleReturnTupleDesc.exec(this.ctx);
+    e = await this.tupleReturnTupleDesc.exec(this.ctx);
     e.should.have.length(3);
     e[2].E.id.should.equal('http://cqframework.org/3/1');
     e[1].E.id.should.equal('http://cqframework.org/3/3');
     e[0].E.id.should.equal('http://cqframework.org/3/5');
   });
 
-  it('should be able to sort dates by this', function () {
-    const unsortedDate = this.lastDateUnsorted.exec(this.ctx);
+  it('should be able to sort dates by this', async function () {
+    const unsortedDate = await this.lastDateUnsorted.exec(this.ctx);
     unsortedDate.year.should.eql(1982);
-    const sortedDate = this.lastDateByThis.exec(this.ctx);
+    const sortedDate = await this.lastDateByThis.exec(this.ctx);
     sortedDate.year.should.eql(2010);
   });
 
-  it('should be able to sort by number asc', function () {
-    const e = this.numberAsc.exec(this.ctx);
+  it('should be able to sort by number asc', async function () {
+    const e = await this.numberAsc.exec(this.ctx);
     e.should.eql([0, 3, 5, 6, 7, 8, 9]);
   });
 
-  it('should be able to sort by number desc', function () {
-    const e = this.numberDesc.exec(this.ctx);
+  it('should be able to sort by number desc', async function () {
+    const e = await this.numberDesc.exec(this.ctx);
     e.should.eql([9, 8, 7, 6, 5, 3, 0]);
   });
 
-  it('should be able to sort by string asc', function () {
-    this.stringAsc.exec(this.ctx).should.eql(['change', 'dont', 'jenny', 'number', 'your']);
-    this.stringReturnAsc.exec(this.ctx).should.eql(['change', 'dont', 'jenny', 'number', 'your']);
+  it('should be able to sort by string asc', async function () {
+    (await this.stringAsc.exec(this.ctx)).should.eql(['change', 'dont', 'jenny', 'number', 'your']);
+    (await this.stringReturnAsc.exec(this.ctx)).should.eql([
+      'change',
+      'dont',
+      'jenny',
+      'number',
+      'your'
+    ]);
   });
 
-  it('should be able to sort by string desc', function () {
-    this.stringDesc.exec(this.ctx).should.eql(['your', 'number', 'jenny', 'dont', 'change']);
-    this.stringReturnDesc.exec(this.ctx).should.eql(['your', 'number', 'jenny', 'dont', 'change']);
+  it('should be able to sort by string desc', async function () {
+    (await this.stringDesc.exec(this.ctx)).should.eql([
+      'your',
+      'number',
+      'jenny',
+      'dont',
+      'change'
+    ]);
+    (await this.stringReturnDesc.exec(this.ctx)).should.eql([
+      'your',
+      'number',
+      'jenny',
+      'dont',
+      'change'
+    ]);
   });
 
-  it('should be able to sort by an expression that uses another expression in the library', function () {
-    this.sortByExpression
-      .exec(this.ctx)
-      .should.eql([{ N: 0 }, { N: 3 }, { N: 5 }, { N: 6 }, { N: 7 }, { N: 8 }, { N: 9 }]);
+  it('should be able to sort by an expression that uses another expression in the library', async function () {
+    (await this.sortByExpression.exec(this.ctx)).should.eql([
+      { N: 0 },
+      { N: 3 },
+      { N: 5 },
+      { N: 6 },
+      { N: 7 },
+      { N: 8 },
+      { N: 9 }
+    ]);
   });
 
-  it('should be able to sort by an expression when some results are null', function () {
-    this.sortByExpressionWithNullResults
-      .exec(this.ctx)
-      .should.eql([{ N: null }, { N: 7 }, { N: 8 }]);
+  it('should be able to sort by an expression when some results are null', async function () {
+    (await this.sortByExpressionWithNullResults.exec(this.ctx)).should.eql([
+      { N: null },
+      { N: 7 },
+      { N: 8 }
+    ]);
   });
 
-  it('should be able to sort using the ascending keyword', function () {
-    const e = this.sortWithAscendingKeyword.exec(this.ctx);
+  it('should be able to sort using the ascending keyword', async function () {
+    const e = await this.sortWithAscendingKeyword.exec(this.ctx);
     e.should.eql([0, 3, 5, 6, 7, 8, 9]);
   });
 
-  it('should be able to sort using the descending keyword', function () {
-    const e = this.sortWithDescendingKeyword.exec(this.ctx);
+  it('should be able to sort using the descending keyword', async function () {
+    const e = await this.sortWithDescendingKeyword.exec(this.ctx);
     e.should.eql([9, 8, 7, 6, 5, 3, 0]);
   });
 });
@@ -249,28 +275,45 @@ describe('Distinct', () => {
     setup(this, data);
   });
 
-  it('should return distinct by default', function () {
-    this.defaultNumbers.exec(this.ctx).should.eql([1, 2, 3, 4]);
-    this.defaultStrings.exec(this.ctx).should.eql(['foo', 'bar', 'baz']);
-    this.defaultTuples.exec(this.ctx).should.eql([
+  it('should return distinct by default', async function () {
+    (await this.defaultNumbers.exec(this.ctx)).should.eql([1, 2, 3, 4]);
+    (await this.defaultStrings.exec(this.ctx)).should.eql(['foo', 'bar', 'baz']);
+    (await this.defaultTuples.exec(this.ctx)).should.eql([
       { a: 1, b: 2 },
       { a: 2, b: 3 }
     ]);
   });
 
-  it('should eliminate duplicates when returning distinct', function () {
-    this.distinctNumbers.exec(this.ctx).should.eql([1, 2, 3, 4]);
-    this.distinctStrings.exec(this.ctx).should.eql(['foo', 'bar', 'baz']);
-    this.distinctTuples.exec(this.ctx).should.eql([
+  it('should eliminate duplicates when returning distinct', async function () {
+    (await this.distinctNumbers.exec(this.ctx)).should.eql([1, 2, 3, 4]);
+    (await this.distinctStrings.exec(this.ctx)).should.eql(['foo', 'bar', 'baz']);
+    (await this.distinctTuples.exec(this.ctx)).should.eql([
       { a: 1, b: 2 },
       { a: 2, b: 3 }
     ]);
   });
 
-  it('should not eliminate duplicates when returning all', function () {
-    this.allNumbers.exec(this.ctx).should.eql([1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 3, 3, 3, 2, 2, 1]);
-    this.allStrings.exec(this.ctx).should.eql(['foo', 'bar', 'baz', 'bar']);
-    this.allTuples.exec(this.ctx).should.eql([
+  it('should not eliminate duplicates when returning all', async function () {
+    (await this.allNumbers.exec(this.ctx)).should.eql([
+      1,
+      2,
+      2,
+      3,
+      3,
+      3,
+      4,
+      4,
+      4,
+      4,
+      3,
+      3,
+      3,
+      2,
+      2,
+      1
+    ]);
+    (await this.allStrings.exec(this.ctx)).should.eql(['foo', 'bar', 'baz', 'bar']);
+    (await this.allTuples.exec(this.ctx)).should.eql([
       { a: 1, b: 2 },
       { a: 2, b: 3 },
       { a: 1, b: 2 }
@@ -283,60 +326,60 @@ describe('SingleObjectAlias', () => {
     setup(this, data, [p1]);
   });
 
-  it('should return object for single object alias', function () {
-    const firstEncounter = this.firstEncounter.exec(this.ctx);
-    this.singleAlias.exec(this.ctx).should.eql(firstEncounter);
+  it('should return object for single object alias', async function () {
+    const firstEncounter = await this.firstEncounter.exec(this.ctx);
+    (await this.singleAlias.exec(this.ctx)).should.eql(firstEncounter);
   });
 
-  it('should return object for single object alias with a where clause', function () {
-    const firstEncounter = this.firstEncounter.exec(this.ctx);
-    this.singleAliasWhere.exec(this.ctx).should.eql(firstEncounter);
+  it('should return object for single object alias with a where clause', async function () {
+    const firstEncounter = await this.firstEncounter.exec(this.ctx);
+    (await this.singleAliasWhere.exec(this.ctx)).should.eql(firstEncounter);
   });
 
-  it('should return single object when multisource query is based on single alias queries', function () {
-    const firstEncounter = this.firstEncounter.exec(this.ctx);
-    const firstConditon = this.firstCondition.exec(this.ctx);
-    this.singleAliases.exec(this.ctx).should.eql({ E: firstEncounter, C: firstConditon });
+  it('should return single object when multisource query is based on single alias queries', async function () {
+    const firstEncounter = await this.firstEncounter.exec(this.ctx);
+    const firstConditon = await this.firstCondition.exec(this.ctx);
+    (await this.singleAliases.exec(this.ctx)).should.eql({ E: firstEncounter, C: firstConditon });
   });
 
-  it('should return list for multisource query that contains and single alias and list sources', function () {
-    const conditions = this.conditions.exec(this.ctx);
-    const firstEncounter = this.firstEncounter.exec(this.ctx);
-    const firstCondition = this.firstCondition.exec(this.ctx);
+  it('should return list for multisource query that contains and single alias and list sources', async function () {
+    const conditions = await this.conditions.exec(this.ctx);
+    const firstEncounter = await this.firstEncounter.exec(this.ctx);
+    const firstCondition = await this.firstCondition.exec(this.ctx);
     const expt = conditions.map((con: any) => ({ Con: con, E: firstEncounter, C: firstCondition }));
-    const q = this.singleAliasesAndList.exec(this.ctx);
+    const q = await this.singleAliasesAndList.exec(this.ctx);
     q.should.have.length(conditions.length);
     q.should.eql(expt);
   });
 
-  it('should be able to filter to null with where clause ', function () {
-    should.not.exist(this.singleAliasWhereToNull.exec(this.ctx));
+  it('should be able to filter to null with where clause ', async function () {
+    should.not.exist(await this.singleAliasWhereToNull.exec(this.ctx));
   });
 
-  it('should be able to return different object ', function () {
-    this.singleAliasReturnTuple.exec(this.ctx).should.eql({ a: 1 });
+  it('should be able to return different object ', async function () {
+    (await this.singleAliasReturnTuple.exec(this.ctx)).should.eql({ a: 1 });
   });
 
-  it('should be able to return different object that is a list', function () {
-    this.singleAliasReturnList.exec(this.ctx).should.eql(['foo', 'bar', 'baz', 'bar']);
+  it('should be able to return different object that is a list', async function () {
+    (await this.singleAliasReturnList.exec(this.ctx)).should.eql(['foo', 'bar', 'baz', 'bar']);
   });
 
-  it('should be able to use a single object alias in a with clause', function () {
-    const encounters = this.encounters.exec(this.ctx);
-    const aw = this.singleAliasWith.exec(this.ctx);
+  it('should be able to use a single object alias in a with clause', async function () {
+    const encounters = await this.encounters.exec(this.ctx);
+    const aw = await this.singleAliasWith.exec(this.ctx);
     aw.should.eql(encounters);
-    const awe = this.singleAliasWithEmpty.exec(this.ctx);
+    const awe = await this.singleAliasWithEmpty.exec(this.ctx);
     awe.should.have.length(0);
   });
 
-  it('should be able to use a single object alias in a withOut clause', function () {
-    const encounters = this.encounters.exec(this.ctx);
-    this.singleAliasWithOut.exec(this.ctx).should.eql(encounters);
-    this.singleAliasWithOutEmpty.exec(this.ctx).should.have.length(0);
+  it('should be able to use a single object alias in a withOut clause', async function () {
+    const encounters = await this.encounters.exec(this.ctx);
+    (await this.singleAliasWithOut.exec(this.ctx)).should.eql(encounters);
+    (await this.singleAliasWithOutEmpty.exec(this.ctx)).should.have.length(0);
   });
 
-  it('should allow single source queries to be null and return null', function () {
-    should.not.exist(this.nullQuery.exec(this.ctx));
+  it('should allow single source queries to be null and return null', async function () {
+    should.not.exist(await this.nullQuery.exec(this.ctx));
   });
 });
 
@@ -345,32 +388,32 @@ describe('AggregateQuery', () => {
     setup(this, data, [p1]);
   });
 
-  it('should aggregate without a starting value', function () {
-    this.noStartingAggregation.exec(this.ctx).should.eql(120);
+  it('should aggregate without a starting value', async function () {
+    (await this.noStartingAggregation.exec(this.ctx)).should.eql(120);
   });
 
-  it('should be able to aggregate with an expression as the starting value', function () {
+  it('should be able to aggregate with an expression as the starting value', async function () {
     const ret = [
       new Interval(new DateTime(1970, 1, 1), new DateTime(1978, 7, 15, 10, 0)),
       new Interval(new DateTime(1978, 7, 16, 10, 0), new DateTime(1982, 3, 15, 15, 0)),
       new Interval(new DateTime(1982, 3, 16, 15, 0), new DateTime(2013, 5, 23, 10, 0))
     ];
-    this.expressionStartingAggregation.exec(this.ctx).should.eql(ret);
+    (await this.expressionStartingAggregation.exec(this.ctx)).should.eql(ret);
   });
 
-  it('should be able to aggregate over distinct values', function () {
-    this.distinctAggregation.exec(this.ctx).should.eql(15);
+  it('should be able to aggregate over distinct values', async function () {
+    (await this.distinctAggregation.exec(this.ctx)).should.eql(15);
   });
 
-  it('should be able to aggregate over non-distinct values', function () {
-    this.allAggregation.exec(this.ctx).should.eql(30);
+  it('should be able to aggregate over non-distinct values', async function () {
+    (await this.allAggregation.exec(this.ctx)).should.eql(30);
   });
 
-  it('should be able to aggregate with a String as the starting value', function () {
-    this.literalStartingAggregation.exec(this.ctx).should.eql('Start12345');
+  it('should be able to aggregate with a String as the starting value', async function () {
+    (await this.literalStartingAggregation.exec(this.ctx)).should.eql('Start12345');
   });
 
-  it('should be able to aggregate with a Quantity as the starting value', function () {
-    this.quantityStartingAggregation.exec(this.ctx).should.eql(new Quantity(15, 'ml'));
+  it('should be able to aggregate with a Quantity as the starting value', async function () {
+    (await this.quantityStartingAggregation.exec(this.ctx)).should.eql(new Quantity(15, 'ml'));
   });
 });

--- a/test/elm/reusable/reusable-test.ts
+++ b/test/elm/reusable/reusable-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 const { p1 } = require('./patients');
@@ -9,15 +10,15 @@ describe('ExpressionDef', () => {
   });
 
   it('should have a name', function () {
-    this.def.name.should.equal('Foo');
+    should(this.def.name).equal('Foo');
   });
 
   it('should have the correct context', function () {
-    this.def.context.should.equal('Patient');
+    should(this.def.context).equal('Patient');
   });
 
-  it('should execute to its value', function () {
-    this.def.exec(this.ctx).should.equal('Bar');
+  it('should execute to its value', async function () {
+    (await this.def.exec(this.ctx)).should.equal('Bar');
   });
 });
 
@@ -30,8 +31,8 @@ describe('ExpressionRef', () => {
     this.foo.name.should.equal('Life');
   });
 
-  it('should execute to expression value', function () {
-    this.foo.exec(this.ctx).should.equal(42);
+  it('should execute to expression value', async function () {
+    (await this.foo.exec(this.ctx)).should.equal(42);
   });
 });
 
@@ -40,62 +41,62 @@ describe('FunctionDefinitions', () => {
     setup(this, data);
   });
 
-  it('should be able to define and use a simple function', function () {
-    const e = this.testValue.exec(this.ctx);
+  it('should be able to define and use a simple function', async function () {
+    const e = await this.testValue.exec(this.ctx);
     e.should.equal(3);
   });
 });
 
-describe('FunctionOverloadsWithSingleArgument', function () {
+describe('FunctionOverloadsWithSingleArgument', async function () {
   beforeEach(function () {
     setup(this, data);
   });
 
-  it('should be able to invoke the correct function based on argument type', function () {
-    let e = this.testValue1.exec(this.ctx);
+  it('should be able to invoke the correct function based on argument type', async function () {
+    let e = await this.testValue1.exec(this.ctx);
     e.should.equal(2);
-    e = this.testValue2.exec(this.ctx);
+    e = await this.testValue2.exec(this.ctx);
     e.should.equal('Hello World');
   });
 });
 
-describe('FunctionOverloadsWithMultipleArguments', function () {
+describe('FunctionOverloadsWithMultipleArguments', async function () {
   beforeEach(function () {
     setup(this, data);
   });
 
-  it('should be able to invoke the correct function based on argument type', function () {
-    let e = this.testValue1.exec(this.ctx);
+  it('should be able to invoke the correct function based on argument type', async function () {
+    let e = await this.testValue1.exec(this.ctx);
     e.should.equal(0);
-    e = this.testValue2.exec(this.ctx);
+    e = await this.testValue2.exec(this.ctx);
     e.should.equal('Goodbye World');
   });
 });
 
-describe('FunctionOverloadsWithDifferentNumberOfArguments', function () {
+describe('FunctionOverloadsWithDifferentNumberOfArguments', async function () {
   beforeEach(function () {
     setup(this, data);
   });
 
-  it('should be able to invoke the correct function based on number of arguments', function () {
-    let e = this.testValue1.exec(this.ctx);
+  it('should be able to invoke the correct function based on number of arguments', async function () {
+    let e = await this.testValue1.exec(this.ctx);
     e.should.equal('Hello World');
-    e = this.testValue2.exec(this.ctx);
+    e = await this.testValue2.exec(this.ctx);
     e.should.equal('Hola World from Spain');
-    e = this.testValue3.exec(this.ctx);
+    e = await this.testValue3.exec(this.ctx);
     e.should.equal('Hello World from England');
   });
 });
 
-describe('FunctionOverloadsWithArgumentsFromCustomDataModel', function () {
+describe('FunctionOverloadsWithArgumentsFromCustomDataModel', async function () {
   beforeEach(function () {
     setup(this, data, [p1]);
   });
 
-  it('should be able to invoke the correct function based on argument type', function () {
-    let e = this.testValue1.exec(this.ctx);
+  it('should be able to invoke the correct function based on argument type', async function () {
+    let e = await this.testValue1.exec(this.ctx);
     e.should.equal('Encounter http://cqframework.org/3/1');
-    e = this.testValue2.exec(this.ctx);
+    e = await this.testValue2.exec(this.ctx);
     e.should.equal('Condition http://cqframework.org/3/2');
   });
 });

--- a/test/elm/string/string-test.ts
+++ b/test/elm/string/string-test.ts
@@ -15,20 +15,22 @@ describe('Concat', () => {
       this.helloWorldVariables.should.be.an.instanceOf(str.Concatenate);
     });
 
-    it('should concat two strings', function () {
-      this.helloWorld.exec(this.ctx).should.equal('HelloWorld');
+    it('should concat two strings', async function () {
+      (await this.helloWorld.exec(this.ctx)).should.equal('HelloWorld');
     });
 
-    it('should concat multiple strings', function () {
-      this.sentence.exec(this.ctx).should.equal('The quick brown fox jumps over the lazy dog.');
+    it('should concat multiple strings', async function () {
+      (await this.sentence.exec(this.ctx)).should.equal(
+        'The quick brown fox jumps over the lazy dog.'
+      );
     });
 
-    it('should return null when an arg is null', function () {
-      should(this.concatNull.exec(this.ctx)).be.null();
+    it('should return null when an arg is null', async function () {
+      should(await this.concatNull.exec(this.ctx)).be.null();
     });
 
-    it('should concat variables', function () {
-      this.helloWorldVariables.exec(this.ctx).should.equal('HelloWorld');
+    it('should concat variables', async function () {
+      (await this.helloWorldVariables.exec(this.ctx)).should.equal('HelloWorld');
     });
   });
 
@@ -38,20 +40,22 @@ describe('Concat', () => {
       this.andHelloWorldVariables.should.be.an.instanceOf(str.Concatenate);
     });
 
-    it('should concat two strings', function () {
-      this.andHelloWorld.exec(this.ctx).should.equal('HelloWorld');
+    it('should concat two strings', async function () {
+      (await this.andHelloWorld.exec(this.ctx)).should.equal('HelloWorld');
     });
 
-    it('should concat multiple strings', function () {
-      this.andSentence.exec(this.ctx).should.equal('The quick brown fox jumps over the lazy dog.');
+    it('should concat multiple strings', async function () {
+      (await this.andSentence.exec(this.ctx)).should.equal(
+        'The quick brown fox jumps over the lazy dog.'
+      );
     });
 
-    it('should treat null arg as empty string', function () {
-      this.andConcatNull.exec(this.ctx).should.equal('Hello');
+    it('should treat null arg as empty string', async function () {
+      (await this.andConcatNull.exec(this.ctx)).should.equal('Hello');
     });
 
-    it('should concat variables', function () {
-      this.andHelloWorldVariables.exec(this.ctx).should.equal('HelloWorld');
+    it('should concat variables', async function () {
+      (await this.andHelloWorldVariables.exec(this.ctx)).should.equal('HelloWorld');
     });
   });
 });
@@ -65,28 +69,28 @@ describe('Combine', () => {
     this.separator.should.be.an.instanceOf(str.Combine);
   });
 
-  it('should combine strings with no separator', function () {
-    this.noSeparator.exec(this.ctx).should.equal('abcdefghijkl');
+  it('should combine strings with no separator', async function () {
+    (await this.noSeparator.exec(this.ctx)).should.equal('abcdefghijkl');
   });
 
-  it('should combine strings with a separator', function () {
-    this.separator.exec(this.ctx).should.equal('abc;def;ghi;jkl');
+  it('should combine strings with a separator', async function () {
+    (await this.separator.exec(this.ctx)).should.equal('abc;def;ghi;jkl');
   });
 
-  it('should return null when the list is null', function () {
-    should(this.combineNull.exec(this.ctx)).be.null();
+  it('should return null when the list is null', async function () {
+    should(await this.combineNull.exec(this.ctx)).be.null();
   });
 
-  it('should ignore nulls in the list', function () {
-    this.combineNullItem.exec(this.ctx).should.equal('abc;def;jkl');
+  it('should ignore nulls in the list', async function () {
+    (await this.combineNullItem.exec(this.ctx)).should.equal('abc;def;jkl');
   });
 
-  it('should return null for list of null', function () {
-    should(this.combineOneNullItem.exec(this.ctx)).be.null();
+  it('should return null for list of null', async function () {
+    should(await this.combineOneNullItem.exec(this.ctx)).be.null();
   });
 
-  it('should return null for empty list', function () {
-    should(this.combineEmptyNull.exec(this.ctx)).be.null();
+  it('should return null for empty list', async function () {
+    should(await this.combineEmptyNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -99,20 +103,20 @@ describe('Split', () => {
     this.commaSeparated.should.be.an.instanceOf(str.Split);
   });
 
-  it('should split strings on comma', function () {
-    this.commaSeparated.exec(this.ctx).should.eql(['a', 'b', 'c', '', '1', '2', '3']);
+  it('should split strings on comma', async function () {
+    (await this.commaSeparated.exec(this.ctx)).should.eql(['a', 'b', 'c', '', '1', '2', '3']);
   });
 
-  it('should return single-item array when separator is not used', function () {
-    this.separatorNotUsed.exec(this.ctx).should.eql(['a,b,c,,1,2,3']);
+  it('should return single-item array when separator is not used', async function () {
+    (await this.separatorNotUsed.exec(this.ctx)).should.eql(['a,b,c,,1,2,3']);
   });
 
-  it('should return null when separating null', function () {
-    should(this.separateNull.exec(this.ctx)).be.null();
+  it('should return null when separating null', async function () {
+    should(await this.separateNull.exec(this.ctx)).be.null();
   });
 
-  it('should return list with original string when the separator is null', function () {
-    this.separateUsingNull.exec(this.ctx).should.eql(['a,b,c']);
+  it('should return list with original string when the separator is null', async function () {
+    (await this.separateUsingNull.exec(this.ctx)).should.eql(['a,b,c']);
   });
 });
 
@@ -121,28 +125,28 @@ describe('SplitOnMatches', () => {
     setup(this, data);
   });
 
-  it('should splitOnMatches strings into a list of 2', function () {
-    this.splitOnMatchesListReturn.exec(this.ctx).should.eql(['foo ', ' bar']);
+  it('should splitOnMatches strings into a list of 2', async function () {
+    (await this.splitOnMatchesListReturn.exec(this.ctx)).should.eql(['foo ', ' bar']);
   });
 
-  it('should return a list of two empty strings if its an exact match', function () {
-    this.splitOnMatchesOriginalString.exec(this.ctx).should.eql(['', '']);
+  it('should return a list of two empty strings if its an exact match', async function () {
+    (await this.splitOnMatchesOriginalString.exec(this.ctx)).should.eql(['', '']);
   });
 
-  it('should return original string because there was no match', function () {
-    this.splitOnMatchesNoMatch.exec(this.ctx).should.eql(['foobar']);
+  it('should return original string because there was no match', async function () {
+    (await this.splitOnMatchesNoMatch.exec(this.ctx)).should.eql(['foobar']);
   });
 
-  it('should return null when stringToSplit is null', function () {
-    should(this.splitOnMatchesIsNullFirst.exec(this.ctx)).be.null();
+  it('should return null when stringToSplit is null', async function () {
+    should(await this.splitOnMatchesIsNullFirst.exec(this.ctx)).be.null();
   });
 
-  it('should return list with original string when separatorPattern is null', function () {
-    this.splitOnMatchesIsNullSecond.exec(this.ctx).should.eql(['12three']);
+  it('should return list with original string when separatorPattern is null', async function () {
+    (await this.splitOnMatchesIsNullSecond.exec(this.ctx)).should.eql(['12three']);
   });
 
-  it('should return null when both parameters are null', function () {
-    should(this.splitOnMatchesAllNull.exec(this.ctx)).be.null();
+  it('should return null when both parameters are null', async function () {
+    should(await this.splitOnMatchesAllNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -151,24 +155,24 @@ describe('Matches', () => {
     setup(this, data);
   });
 
-  it('should match and return true', function () {
-    this.matchesTrue.exec(this.ctx).should.be.true();
+  it('should match and return true', async function () {
+    (await this.matchesTrue.exec(this.ctx)).should.be.true();
   });
 
-  it('should not match and return false', function () {
-    this.matchesFalse.exec(this.ctx).should.be.false();
+  it('should not match and return false', async function () {
+    (await this.matchesFalse.exec(this.ctx)).should.be.false();
   });
 
-  it('should not match when string to match is null and return null', function () {
-    should(this.matchesIsNullFirst.exec(this.ctx)).be.null();
+  it('should not match when string to match is null and return null', async function () {
+    should(await this.matchesIsNullFirst.exec(this.ctx)).be.null();
   });
 
-  it('should not match and return null', function () {
-    should(this.matchesIsNullSecond.exec(this.ctx)).be.null();
+  it('should not match and return null', async function () {
+    should(await this.matchesIsNullSecond.exec(this.ctx)).be.null();
   });
 
-  it('should return null if both arguments are null', function () {
-    should(this.matchesAllNull.exec(this.ctx)).be.null();
+  it('should return null if both arguments are null', async function () {
+    should(await this.matchesAllNull.exec(this.ctx)).be.null();
   });
 });
 
@@ -181,12 +185,12 @@ describe('Length', () => {
     this.elevenLetters.should.be.an.instanceOf(overloaded.Length);
   });
 
-  it('should count letters in string', function () {
-    this.elevenLetters.exec(this.ctx).should.equal(11);
+  it('should count letters in string', async function () {
+    (await this.elevenLetters.exec(this.ctx)).should.equal(11);
   });
 
-  it('should return null when string is null', function () {
-    should(this.nullString.exec(this.ctx)).be.null();
+  it('should return null when string is null', async function () {
+    should(await this.nullString.exec(this.ctx)).be.null();
   });
 });
 
@@ -199,20 +203,20 @@ describe('Upper', () => {
     this.upperC.should.be.an.instanceOf(str.Upper);
   });
 
-  it('should convert lower to upper', function () {
-    this.lowerC.exec(this.ctx).should.equal('ABCDEFG123');
+  it('should convert lower to upper', async function () {
+    (await this.lowerC.exec(this.ctx)).should.equal('ABCDEFG123');
   });
 
-  it('should leave upper as upper', function () {
-    this.upperC.exec(this.ctx).should.equal('ABCDEFG123');
+  it('should leave upper as upper', async function () {
+    (await this.upperC.exec(this.ctx)).should.equal('ABCDEFG123');
   });
 
-  it('should convert camel to upper', function () {
-    this.camelC.exec(this.ctx).should.equal('ABCDEFG123');
+  it('should convert camel to upper', async function () {
+    (await this.camelC.exec(this.ctx)).should.equal('ABCDEFG123');
   });
 
-  it('should return null when uppering null', function () {
-    should(this.nullString.exec(this.ctx)).be.null();
+  it('should return null when uppering null', async function () {
+    should(await this.nullString.exec(this.ctx)).be.null();
   });
 });
 
@@ -225,20 +229,20 @@ describe('Lower', () => {
     this.lowerC.should.be.an.instanceOf(str.Lower);
   });
 
-  it('should leave lower as lower', function () {
-    this.lowerC.exec(this.ctx).should.equal('abcdefg123');
+  it('should leave lower as lower', async function () {
+    (await this.lowerC.exec(this.ctx)).should.equal('abcdefg123');
   });
 
-  it('should convert upper to lower', function () {
-    this.upperC.exec(this.ctx).should.equal('abcdefg123');
+  it('should convert upper to lower', async function () {
+    (await this.upperC.exec(this.ctx)).should.equal('abcdefg123');
   });
 
-  it('should convert camel to lower', function () {
-    this.camelC.exec(this.ctx).should.equal('abcdefg123');
+  it('should convert camel to lower', async function () {
+    (await this.camelC.exec(this.ctx)).should.equal('abcdefg123');
   });
 
-  it('should return null when lowering null', function () {
-    should(this.nullString.exec(this.ctx)).be.null();
+  it('should return null when lowering null', async function () {
+    should(await this.nullString.exec(this.ctx)).be.null();
   });
 });
 
@@ -248,24 +252,24 @@ describe('Indexer', () => {
     setup(this, data);
   });
 
-  it('should get letter at index', function () {
-    this.helloWorldSix.exec(this.ctx).should.equal('o');
+  it('should get letter at index', async function () {
+    (await this.helloWorldSix.exec(this.ctx)).should.equal('o');
   });
 
-  it('should not return null on index 0 (no longer out of bounds)', function () {
-    should(this.helloWorldZero.exec(this.ctx)).not.be.null();
+  it('should not return null on index 0 (no longer out of bounds)', async function () {
+    should(await this.helloWorldZero.exec(this.ctx)).not.be.null();
   });
 
-  it('should return null on index 20 (out of bounds)', function () {
-    should(this.helloWorldTwenty.exec(this.ctx)).be.null();
+  it('should return null on index 20 (out of bounds)', async function () {
+    should(await this.helloWorldTwenty.exec(this.ctx)).be.null();
   });
 
-  it('should return null when string is null', function () {
-    should(this.nullString.exec(this.ctx)).be.null();
+  it('should return null when string is null', async function () {
+    should(await this.nullString.exec(this.ctx)).be.null();
   });
 
-  it('should return null when index is null', function () {
-    should(this.nullIndex.exec(this.ctx)).be.null();
+  it('should return null when index is null', async function () {
+    should(await this.nullIndex.exec(this.ctx)).be.null();
   });
 });
 
@@ -278,20 +282,20 @@ describe('PositionOf', () => {
     this.found.should.be.an.instanceOf(str.PositionOf);
   });
 
-  it('should return 0-based position', function () {
-    this.found.exec(this.ctx).should.equal(2);
+  it('should return 0-based position', async function () {
+    (await this.found.exec(this.ctx)).should.equal(2);
   });
 
-  it('should return -1 when not found', function () {
-    this.notFound.exec(this.ctx).should.equal(-1);
+  it('should return -1 when not found', async function () {
+    (await this.notFound.exec(this.ctx)).should.equal(-1);
   });
 
-  it('should return null when pattern is null', function () {
-    should(this.nullPattern.exec(this.ctx)).be.null();
+  it('should return null when pattern is null', async function () {
+    should(await this.nullPattern.exec(this.ctx)).be.null();
   });
 
-  it('should return null when string is null', function () {
-    should(this.nullString.exec(this.ctx)).be.null();
+  it('should return null when string is null', async function () {
+    should(await this.nullString.exec(this.ctx)).be.null();
   });
 });
 
@@ -304,20 +308,20 @@ describe('LastPositionOf', () => {
     this.found.should.be.an.instanceOf(str.LastPositionOf);
   });
 
-  it('should return 0-based position', function () {
-    this.found.exec(this.ctx).should.equal(7);
+  it('should return 0-based position', async function () {
+    (await this.found.exec(this.ctx)).should.equal(7);
   });
 
-  it('should return -1 when not found', function () {
-    this.notFound.exec(this.ctx).should.equal(-1);
+  it('should return -1 when not found', async function () {
+    (await this.notFound.exec(this.ctx)).should.equal(-1);
   });
 
-  it('should return null when pattern is null', function () {
-    should(this.nullPattern.exec(this.ctx)).be.null();
+  it('should return null when pattern is null', async function () {
+    should(await this.nullPattern.exec(this.ctx)).be.null();
   });
 
-  it('should return null when string is null', function () {
-    should(this.nullString.exec(this.ctx)).be.null();
+  it('should return null when string is null', async function () {
+    should(await this.nullString.exec(this.ctx)).be.null();
   });
 });
 
@@ -330,40 +334,40 @@ describe('Substring', () => {
     this.world.should.be.an.instanceOf(str.Substring);
   });
 
-  it('should get substring to end', function () {
-    this.world.exec(this.ctx).should.equal('World');
+  it('should get substring to end', async function () {
+    (await this.world.exec(this.ctx)).should.equal('World');
   });
 
-  it('should get substring with length', function () {
-    this.or.exec(this.ctx).should.equal('rl');
+  it('should get substring with length', async function () {
+    (await this.or.exec(this.ctx)).should.equal('rl');
   });
 
-  it('should get substring with zero length', function () {
-    this.zeroLength.exec(this.ctx).should.equal('');
+  it('should get substring with zero length', async function () {
+    (await this.zeroLength.exec(this.ctx)).should.equal('');
   });
 
-  it('should return null on index -1 (out of bounds)', function () {
-    should.not.exist(this.startTooLow.exec(this.ctx));
+  it('should return null on index -1 (out of bounds)', async function () {
+    should.not.exist(await this.startTooLow.exec(this.ctx));
   });
 
-  it('should not error on index 0 (not out of bounds)', function () {
-    this.startZero.exec(this.ctx).should.equal('HelloWorld');
+  it('should not error on index 0 (not out of bounds)', async function () {
+    (await this.startZero.exec(this.ctx)).should.equal('HelloWorld');
   });
 
-  it('should return rest of string on too much length', function () {
-    this.tooMuchLength.exec(this.ctx).should.equal('rld');
+  it('should return rest of string on too much length', async function () {
+    (await this.tooMuchLength.exec(this.ctx)).should.equal('rld');
   });
 
-  it('should return empty string on negative length', function () {
-    this.negativeLength.exec(this.ctx).should.equal('');
+  it('should return empty string on negative length', async function () {
+    (await this.negativeLength.exec(this.ctx)).should.equal('');
   });
 
-  it('should return null when string is null', function () {
-    should(this.nullString.exec(this.ctx)).be.null();
+  it('should return null when string is null', async function () {
+    should(await this.nullString.exec(this.ctx)).be.null();
   });
 
-  it('should return null when start is null', function () {
-    should(this.nullStart.exec(this.ctx)).be.null();
+  it('should return null when start is null', async function () {
+    should(await this.nullStart.exec(this.ctx)).be.null();
   });
 });
 
@@ -372,27 +376,27 @@ describe('StartsWith', () => {
     setup(this, data);
   });
 
-  it('should be true when it does start with', function () {
-    this.fooBarStartsWithFoo.exec(this.ctx).should.be.true();
+  it('should be true when it does start with', async function () {
+    (await this.fooBarStartsWithFoo.exec(this.ctx)).should.be.true();
   });
 
-  it('should be false when it does not start with', function () {
-    this.fooBarStartsWithBar.exec(this.ctx).should.be.false();
+  it('should be false when it does not start with', async function () {
+    (await this.fooBarStartsWithBar.exec(this.ctx)).should.be.false();
   });
 
-  it('should be true for starts with blank', function () {
-    this.fooBarStartsWithBlank.exec(this.ctx).should.be.true();
+  it('should be true for starts with blank', async function () {
+    (await this.fooBarStartsWithBlank.exec(this.ctx)).should.be.true();
   });
 
-  it('should be false for blank starts with', function () {
-    this.blankStartsWithFoo.exec(this.ctx).should.be.false();
+  it('should be false for blank starts with', async function () {
+    (await this.blankStartsWithFoo.exec(this.ctx)).should.be.false();
   });
 
-  it('should be null when either arg is null', function () {
-    should(this.startsWithNull.exec(this.ctx)).be.null();
-    should(this.startsWithNullAsString.exec(this.ctx)).be.null();
-    should(this.nullStartsWith.exec(this.ctx)).be.null();
-    should(this.nullAsStringStartsWith.exec(this.ctx)).be.null();
+  it('should be null when either arg is null', async function () {
+    should(await this.startsWithNull.exec(this.ctx)).be.null();
+    should(await this.startsWithNullAsString.exec(this.ctx)).be.null();
+    should(await this.nullStartsWith.exec(this.ctx)).be.null();
+    should(await this.nullAsStringStartsWith.exec(this.ctx)).be.null();
   });
 });
 
@@ -401,27 +405,27 @@ describe('EndsWith', () => {
     setup(this, data);
   });
 
-  it('should be true when it does end with', function () {
-    this.fooBarEndsWithBar.exec(this.ctx).should.be.true();
+  it('should be true when it does end with', async function () {
+    (await this.fooBarEndsWithBar.exec(this.ctx)).should.be.true();
   });
 
-  it('should be false when it does not end with', function () {
-    this.fooBarEndsWithFoo.exec(this.ctx).should.be.false();
+  it('should be false when it does not end with', async function () {
+    (await this.fooBarEndsWithFoo.exec(this.ctx)).should.be.false();
   });
 
-  it('should be true for ends with blank', function () {
-    this.fooBarEndsWithBlank.exec(this.ctx).should.be.true();
+  it('should be true for ends with blank', async function () {
+    (await this.fooBarEndsWithBlank.exec(this.ctx)).should.be.true();
   });
 
-  it('should be false for blank ends with', function () {
-    this.blankEndsWithFoo.exec(this.ctx).should.be.false();
+  it('should be false for blank ends with', async function () {
+    (await this.blankEndsWithFoo.exec(this.ctx)).should.be.false();
   });
 
-  it('should be null when either arg is null', function () {
-    should(this.endsWithNull.exec(this.ctx)).be.null();
-    should(this.endsWithNullAsString.exec(this.ctx)).be.null();
-    should(this.nullEndsWith.exec(this.ctx)).be.null();
-    should(this.nullAsStringEndsWith.exec(this.ctx)).be.null();
+  it('should be null when either arg is null', async function () {
+    should(await this.endsWithNull.exec(this.ctx)).be.null();
+    should(await this.endsWithNullAsString.exec(this.ctx)).be.null();
+    should(await this.nullEndsWith.exec(this.ctx)).be.null();
+    should(await this.nullAsStringEndsWith.exec(this.ctx)).be.null();
   });
 });
 
@@ -430,51 +434,51 @@ describe('ReplaceMatches', () => {
     setup(this, data);
   });
 
-  it('should make replacement with only one match', function () {
-    this.replaceOne.exec(this.ctx).should.equal('FooBaz');
+  it('should make replacement with only one match', async function () {
+    (await this.replaceOne.exec(this.ctx)).should.equal('FooBaz');
   });
 
-  it('should make replacement with multiple matches', function () {
-    this.replaceMany.exec(this.ctx).should.equal('FooBazFooBazFooBaz');
+  it('should make replacement with multiple matches', async function () {
+    (await this.replaceMany.exec(this.ctx)).should.equal('FooBazFooBazFooBaz');
   });
 
-  it('should replace only matching case', function () {
-    this.replaceCapital.exec(this.ctx).should.equal('Rattle');
+  it('should replace only matching case', async function () {
+    (await this.replaceCapital.exec(this.ctx)).should.equal('Rattle');
   });
 
-  it('should replace diacritical', function () {
-    this.replaceDiacritical.exec(this.ctx).should.equal('Café');
+  it('should replace diacritical', async function () {
+    (await this.replaceDiacritical.exec(this.ctx)).should.equal('Café');
   });
 
-  it('should replace unicode', function () {
-    this.replaceUnicode.exec(this.ctx).should.equal('Turn that frown 😃 upside down! 😃');
+  it('should replace unicode', async function () {
+    (await this.replaceUnicode.exec(this.ctx)).should.equal('Turn that frown 😃 upside down! 😃');
   });
 
-  it('should replace space', function () {
-    this.replaceSpace.exec(this.ctx).should.equal('(123)-456-7890');
+  it('should replace space', async function () {
+    (await this.replaceSpace.exec(this.ctx)).should.equal('(123)-456-7890');
   });
 
-  it('should replace empty string', function () {
-    this.replaceEmpty.exec(this.ctx).should.equal('.F.o.o.B.a.r.');
+  it('should replace empty string', async function () {
+    (await this.replaceEmpty.exec(this.ctx)).should.equal('.F.o.o.B.a.r.');
   });
 
-  it('should replace match groups', function () {
-    this.replaceMatchGroups.exec(this.ctx).should.equal('Bar[123]');
+  it('should replace match groups', async function () {
+    (await this.replaceMatchGroups.exec(this.ctx)).should.equal('Bar[123]');
   });
 
-  it('should return original string if no matches', function () {
-    this.replaceNone.exec(this.ctx).should.equal('Foo');
+  it('should return original string if no matches', async function () {
+    (await this.replaceNone.exec(this.ctx)).should.equal('Foo');
   });
 
-  it('should return null if argument is null', function () {
-    should(this.replaceArgumentIsNull.exec(this.ctx)).be.null();
+  it('should return null if argument is null', async function () {
+    should(await this.replaceArgumentIsNull.exec(this.ctx)).be.null();
   });
 
-  it('should return null if pattern is null', function () {
-    should(this.replacePatternIsNull.exec(this.ctx)).be.null();
+  it('should return null if pattern is null', async function () {
+    should(await this.replacePatternIsNull.exec(this.ctx)).be.null();
   });
 
-  it('should return null if substitution is null', function () {
-    should(this.replaceSubstitutionIsNull.exec(this.ctx)).be.null();
+  it('should return null if substitution is null', async function () {
+    should(await this.replaceSubstitutionIsNull.exec(this.ctx)).be.null();
   });
 });

--- a/test/elm/structured/structured-test.ts
+++ b/test/elm/structured/structured-test.ts
@@ -1,3 +1,4 @@
+import should from 'should';
 import setup from '../../setup';
 const data = require('./data');
 import 'should';
@@ -7,14 +8,14 @@ describe('Tuple', () => {
     setup(this, data);
   });
 
-  it('should be able to define a tuple', function () {
-    const e = this.tup.exec(this.ctx);
-    e['a'].should.equal(1);
-    e['b'].should.equal(2);
+  it('should be able to define a tuple', async function () {
+    const e = await this.tup.exec(this.ctx);
+    should(e['a']).equal(1);
+    should(e['b']).equal(2);
   });
 
-  it('should be able to define an empty tuple', function () {
-    const e = this.emptyTup.exec(this.ctx);
+  it('should be able to define an empty tuple', async function () {
+    const e = await this.emptyTup.exec(this.ctx);
     Object.keys(e).length.should.equal(0);
   });
 });

--- a/test/elm/type/type-test.ts
+++ b/test/elm/type/type-test.ts
@@ -9,14 +9,14 @@ describe('IsSystemType', () => {
     setup(this, data);
   });
 
-  it('should correctly accept matching types', function () {
-    this.fiveIsInteger.exec(this.ctx).should.be.true();
-    this.stringFiveIsString.exec(this.ctx).should.be.true();
+  it('should correctly accept matching types', async function () {
+    (await this.fiveIsInteger.exec(this.ctx)).should.be.true();
+    (await this.stringFiveIsString.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly reject non-matching types', function () {
-    this.fiveIsString.exec(this.ctx).should.be.false();
-    this.stringFiveIsInteger.exec(this.ctx).should.be.false();
+  it('should correctly reject non-matching types', async function () {
+    (await this.fiveIsString.exec(this.ctx)).should.be.false();
+    (await this.stringFiveIsInteger.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -25,12 +25,12 @@ describe('IsListType', () => {
     setup(this, data);
   });
 
-  it('should correctly accept matching types', function () {
-    this.listOfIntegersIsListOfIntegers.exec(this.ctx).should.be.true();
+  it('should correctly accept matching types', async function () {
+    (await this.listOfIntegersIsListOfIntegers.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly reject non-matching types', function () {
-    this.listOfDecimalsIsListOfIntegers.exec(this.ctx).should.be.false();
+  it('should correctly reject non-matching types', async function () {
+    (await this.listOfDecimalsIsListOfIntegers.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -39,12 +39,12 @@ describe('IsIntervalType', () => {
     setup(this, data);
   });
 
-  it('should correctly accept matching types', function () {
-    this.intervalOfIntegersIsIntervalOfIntegers.exec(this.ctx).should.be.true();
+  it('should correctly accept matching types', async function () {
+    (await this.intervalOfIntegersIsIntervalOfIntegers.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly reject non-matching types', function () {
-    this.intervalOfDecimalsIsIntervalOfIntegers.exec(this.ctx).should.be.false();
+  it('should correctly reject non-matching types', async function () {
+    (await this.intervalOfDecimalsIsIntervalOfIntegers.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -53,12 +53,12 @@ describe('IsTupleType', () => {
     setup(this, data);
   });
 
-  it('should correctly accept matching types', function () {
-    this.tupleOfIntegersIsTupleOfIntegers.exec(this.ctx).should.be.true();
+  it('should correctly accept matching types', async function () {
+    (await this.tupleOfIntegersIsTupleOfIntegers.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly reject non-matching types', function () {
-    this.tupleOfDecimalsIsTupleOfIntegers.exec(this.ctx).should.be.false();
+  it('should correctly reject non-matching types', async function () {
+    (await this.tupleOfDecimalsIsTupleOfIntegers.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -67,13 +67,13 @@ describe('IsChoiceType', () => {
     setup(this, data);
   });
 
-  it('should correctly accept matching types', function () {
-    this.integerIsChoiceOfIntegersAndDecimals.exec(this.ctx).should.be.true();
-    this.decimalIsChoiceOfIntegersAndDecimals.exec(this.ctx).should.be.true();
+  it('should correctly accept matching types', async function () {
+    (await this.integerIsChoiceOfIntegersAndDecimals.exec(this.ctx)).should.be.true();
+    (await this.decimalIsChoiceOfIntegersAndDecimals.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly reject non-matching types', function () {
-    this.stringIsChoiceOfIntegersAndDecimals.exec(this.ctx).should.be.false();
+  it('should correctly reject non-matching types', async function () {
+    (await this.stringIsChoiceOfIntegersAndDecimals.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -82,15 +82,15 @@ describe('IsCustomDataModelType', () => {
     setup(this, data, [p1]);
   });
 
-  it('should correctly accept matching types', function () {
-    this.encounterIsEncounter.exec(this.ctx).should.be.true();
-    this.encounterIsRecord.exec(this.ctx).should.be.true();
-    this.encounterIsAny.exec(this.ctx).should.be.true();
+  it('should correctly accept matching types', async function () {
+    (await this.encounterIsEncounter.exec(this.ctx)).should.be.true();
+    (await this.encounterIsRecord.exec(this.ctx)).should.be.true();
+    (await this.encounterIsAny.exec(this.ctx)).should.be.true();
   });
 
-  it('should correctly reject non-matching types', function () {
-    this.encounterIsCondition.exec(this.ctx).should.be.false();
-    this.encounterIsString.exec(this.ctx).should.be.false();
+  it('should correctly reject non-matching types', async function () {
+    (await this.encounterIsCondition.exec(this.ctx)).should.be.false();
+    (await this.encounterIsString.exec(this.ctx)).should.be.false();
   });
 });
 
@@ -99,37 +99,47 @@ describe('AsSystemType', () => {
     setup(this, data);
   });
 
-  it('should return back matching types', function () {
-    this.fiveAsInteger.exec(this.ctx).should.equal(5);
-    this.stringFiveAsString.exec(this.ctx).should.equal('5');
-    this.castFiveAsInteger.exec(this.ctx).should.equal(5);
-    this.castStringFiveAsString.exec(this.ctx).should.equal('5');
+  it('should return back matching types', async function () {
+    (await this.fiveAsInteger.exec(this.ctx)).should.equal(5);
+    (await this.stringFiveAsString.exec(this.ctx)).should.equal('5');
+    (await this.castFiveAsInteger.exec(this.ctx)).should.equal(5);
+    (await this.castStringFiveAsString.exec(this.ctx)).should.equal('5');
   });
 
-  it('should return null on non-matching types for non-strict cast', function () {
-    should(this.fiveAsString.exec(this.ctx)).be.null();
-    should(this.stringFiveAsInteger.exec(this.ctx)).be.null();
-    should(this.listAsInteger.exec(this.ctx)).be.null();
-    should(this.intervalAsInteger.exec(this.ctx)).be.null();
-    should(this.tupleAsInteger.exec(this.ctx)).be.null();
+  it('should return null on non-matching types for non-strict cast', async function () {
+    should(await this.fiveAsString.exec(this.ctx)).be.null();
+    should(await this.stringFiveAsInteger.exec(this.ctx)).be.null();
+    should(await this.listAsInteger.exec(this.ctx)).be.null();
+    should(await this.intervalAsInteger.exec(this.ctx)).be.null();
+    should(await this.tupleAsInteger.exec(this.ctx)).be.null();
   });
 
-  it('should throw on non-matching types for strict cast', function () {
-    (() => this.castFiveAsString.exec(this.ctx)).should.throw(
-      /Cannot cast {urn:hl7-org:elm-types:r1}Integer as {urn:hl7-org:elm-types:r1}String/
-    );
-    (() => this.castStringFiveAsInteger.exec(this.ctx)).should.throw(
-      /Cannot cast {urn:hl7-org:elm-types:r1}String as {urn:hl7-org:elm-types:r1}Integer/
-    );
-    (() => this.castListAsInteger.exec(this.ctx)).should.throw(
-      /Cannot cast List<{urn:hl7-org:elm-types:r1}Integer> as {urn:hl7-org:elm-types:r1}Integer/
-    );
-    (() => this.castIntervalAsInteger.exec(this.ctx)).should.throw(
-      /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as {urn:hl7-org:elm-types:r1}Integer/
-    );
-    (() => this.castTupleAsInteger.exec(this.ctx)).should.throw(
-      /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}Integer> as {urn:hl7-org:elm-types:r1}Integer/
-    );
+  it('should throw on non-matching types for strict cast', async function () {
+    await this.castFiveAsString
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast {urn:hl7-org:elm-types:r1}Integer as {urn:hl7-org:elm-types:r1}String/
+      );
+    await this.castStringFiveAsInteger
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast {urn:hl7-org:elm-types:r1}String as {urn:hl7-org:elm-types:r1}Integer/
+      );
+    await this.castListAsInteger
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast List<{urn:hl7-org:elm-types:r1}Integer> as {urn:hl7-org:elm-types:r1}Integer/
+      );
+    await this.castIntervalAsInteger
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as {urn:hl7-org:elm-types:r1}Integer/
+      );
+    await this.castTupleAsInteger
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}Integer> as {urn:hl7-org:elm-types:r1}Integer/
+      );
   });
 });
 
@@ -138,31 +148,39 @@ describe('AsListType', () => {
     setup(this, data);
   });
 
-  it('should return back matching types', function () {
-    this.listOfIntegersAsListOfIntegers.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
-    this.castListOfIntegersAsListOfIntegers.exec(this.ctx).should.eql([1, 2, 3, 4, 5]);
+  it('should return back matching types', async function () {
+    (await this.listOfIntegersAsListOfIntegers.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
+    (await this.castListOfIntegersAsListOfIntegers.exec(this.ctx)).should.eql([1, 2, 3, 4, 5]);
   });
 
-  it('should return null on non-matching types for non-strict cast', function () {
-    should(this.listOfStringsAsListOfIntegers.exec(this.ctx)).be.null();
-    should(this.integerAsListOfIntegers.exec(this.ctx)).be.null();
-    should(this.intervalAsListOfIntegers.exec(this.ctx)).be.null();
-    should(this.tupleAsListOfIntegers.exec(this.ctx)).be.null();
+  it('should return null on non-matching types for non-strict cast', async function () {
+    should(await this.listOfStringsAsListOfIntegers.exec(this.ctx)).be.null();
+    should(await this.integerAsListOfIntegers.exec(this.ctx)).be.null();
+    should(await this.intervalAsListOfIntegers.exec(this.ctx)).be.null();
+    should(await this.tupleAsListOfIntegers.exec(this.ctx)).be.null();
   });
 
-  it('should throw on non-matching types for strict cast', function () {
-    (() => this.castListOfStringsAsListOfIntegers.exec(this.ctx)).should.throw(
-      /Cannot cast List<{urn:hl7-org:elm-types:r1}String> as List<{urn:hl7-org:elm-types:r1}Integer>/
-    );
-    (() => this.castIntegerAsListOfIntegers.exec(this.ctx)).should.throw(
-      /Cannot cast {urn:hl7-org:elm-types:r1}Integer as List<{urn:hl7-org:elm-types:r1}Integer>/
-    );
-    (() => this.castIntervalAsListOfIntegers.exec(this.ctx)).should.throw(
-      /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as List<{urn:hl7-org:elm-types:r1}Integer>/
-    );
-    (() => this.castTupleAsListOfIntegers.exec(this.ctx)).should.throw(
-      /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}Integer> as List<{urn:hl7-org:elm-types:r1}Integer>/
-    );
+  it('should throw on non-matching types for strict cast', async function () {
+    await this.castListOfStringsAsListOfIntegers
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast List<{urn:hl7-org:elm-types:r1}String> as List<{urn:hl7-org:elm-types:r1}Integer>/
+      );
+    await this.castIntegerAsListOfIntegers
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast {urn:hl7-org:elm-types:r1}Integer as List<{urn:hl7-org:elm-types:r1}Integer>/
+      );
+    await this.castIntervalAsListOfIntegers
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as List<{urn:hl7-org:elm-types:r1}Integer>/
+      );
+    await this.castTupleAsListOfIntegers
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}Integer> as List<{urn:hl7-org:elm-types:r1}Integer>/
+      );
   });
 });
 
@@ -171,35 +189,43 @@ describe('AsIntervalType', () => {
     setup(this, data);
   });
 
-  it('should return back matching types', function () {
-    this.intervalOfIntegersAsIntervalOfIntegers
-      .exec(this.ctx)
-      .should.eql(new Interval(1, 5, true, true));
-    this.castIntervalOfIntegersAsIntervalOfIntegers
-      .exec(this.ctx)
-      .should.eql(new Interval(1, 5, true, true));
+  it('should return back matching types', async function () {
+    (await this.intervalOfIntegersAsIntervalOfIntegers.exec(this.ctx)).should.eql(
+      new Interval(1, 5, true, true)
+    );
+    (await this.castIntervalOfIntegersAsIntervalOfIntegers.exec(this.ctx)).should.eql(
+      new Interval(1, 5, true, true)
+    );
   });
 
-  it('should return null on non-matching types for non-strict cast', function () {
-    should(this.intervalOfDatesAsIntervalOfIntegers.exec(this.ctx)).be.null();
-    should(this.integerAsIntervalOfIntegers.exec(this.ctx)).be.null();
-    should(this.listAsIntervalOfIntegers.exec(this.ctx)).be.null();
-    should(this.tupleAsIntervalOfIntegers.exec(this.ctx)).be.null();
+  it('should return null on non-matching types for non-strict cast', async function () {
+    should(await this.intervalOfDatesAsIntervalOfIntegers.exec(this.ctx)).be.null();
+    should(await this.integerAsIntervalOfIntegers.exec(this.ctx)).be.null();
+    should(await this.listAsIntervalOfIntegers.exec(this.ctx)).be.null();
+    should(await this.tupleAsIntervalOfIntegers.exec(this.ctx)).be.null();
   });
 
-  it('should throw on non-matching types for strict cast', function () {
-    (() => this.castIntervalOfDatesAsIntervalOfIntegers.exec(this.ctx)).should.throw(
-      /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Date> as Interval<{urn:hl7-org:elm-types:r1}Integer>/
-    );
-    (() => this.castIntegerAsIntervalOfIntegers.exec(this.ctx)).should.throw(
-      /Cannot cast {urn:hl7-org:elm-types:r1}Integer as Interval<{urn:hl7-org:elm-types:r1}Integer>/
-    );
-    (() => this.castListAsIntervalOfIntegers.exec(this.ctx)).should.throw(
-      /Cannot cast List<{urn:hl7-org:elm-types:r1}Integer> as Interval<{urn:hl7-org:elm-types:r1}Integer>/
-    );
-    (() => this.castTupleAsIntervalOfIntegers.exec(this.ctx)).should.throw(
-      /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}Integer> as Interval<{urn:hl7-org:elm-types:r1}Integer>/
-    );
+  it('should throw on non-matching types for strict cast', async function () {
+    await this.castIntervalOfDatesAsIntervalOfIntegers
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Date> as Interval<{urn:hl7-org:elm-types:r1}Integer>/
+      );
+    await this.castIntegerAsIntervalOfIntegers
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast {urn:hl7-org:elm-types:r1}Integer as Interval<{urn:hl7-org:elm-types:r1}Integer>/
+      );
+    await this.castListAsIntervalOfIntegers
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast List<{urn:hl7-org:elm-types:r1}Integer> as Interval<{urn:hl7-org:elm-types:r1}Integer>/
+      );
+    await this.castTupleAsIntervalOfIntegers
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}Integer> as Interval<{urn:hl7-org:elm-types:r1}Integer>/
+      );
   });
 });
 
@@ -208,33 +234,45 @@ describe('AsTupleType', () => {
     setup(this, data);
   });
 
-  it('should return back matching types', function () {
-    this.tupleOfAIntegerBStringAsTupleOfAIntegerBString.exec(this.ctx).should.eql({ A: 1, B: '2' });
-    this.castTupleOfAIntegerBStringAsTupleOfAIntegerBString
+  it('should return back matching types', async function () {
+    (await this.tupleOfAIntegerBStringAsTupleOfAIntegerBString.exec(this.ctx)).should.eql({
+      A: 1,
+      B: '2'
+    });
+    (await this.castTupleOfAIntegerBStringAsTupleOfAIntegerBString.exec(this.ctx)).should.eql({
+      A: 1,
+      B: '2'
+    });
+  });
+
+  it('should return null on non-matching types for non-strict cast', async function () {
+    should(await this.tupleOfAStringBIntegerAsTupleOfAIntegerBString.exec(this.ctx)).be.null();
+    should(await this.integerAsTupleOfInteger.exec(this.ctx)).be.null();
+    should(await this.listAsTupleOfInteger.exec(this.ctx)).be.null();
+    should(await this.intervalAsTupleOfInteger.exec(this.ctx)).be.null();
+  });
+
+  it('should throw on non-matching types for strict cast', async function () {
+    await this.castTupleOfAStringBIntegerAsTupleOfAIntegerBString
       .exec(this.ctx)
-      .should.eql({ A: 1, B: '2' });
-  });
-
-  it('should return null on non-matching types for non-strict cast', function () {
-    should(this.tupleOfAStringBIntegerAsTupleOfAIntegerBString.exec(this.ctx)).be.null();
-    should(this.integerAsTupleOfInteger.exec(this.ctx)).be.null();
-    should(this.listAsTupleOfInteger.exec(this.ctx)).be.null();
-    should(this.intervalAsTupleOfInteger.exec(this.ctx)).be.null();
-  });
-
-  it('should throw on non-matching types for strict cast', function () {
-    (() => this.castTupleOfAStringBIntegerAsTupleOfAIntegerBString.exec(this.ctx)).should.throw(
-      /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}String, B {urn:hl7-org:elm-types:r1}Integer> as Tuple<A {urn:hl7-org:elm-types:r1}Integer, B {urn:hl7-org:elm-types:r1}String>/
-    );
-    (() => this.castIntegerAsTupleOfInteger.exec(this.ctx)).should.throw(
-      /Cannot cast {urn:hl7-org:elm-types:r1}Integer as Tuple<A {urn:hl7-org:elm-types:r1}Integer>/
-    );
-    (() => this.castListAsTupleOfInteger.exec(this.ctx)).should.throw(
-      /Cannot cast List<{urn:hl7-org:elm-types:r1}Integer> as Tuple<A {urn:hl7-org:elm-types:r1}Integer>/
-    );
-    (() => this.castIntervalAsTupleOfInteger.exec(this.ctx)).should.throw(
-      /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as Tuple<A {urn:hl7-org:elm-types:r1}Integer>/
-    );
+      .should.be.rejectedWith(
+        /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}String, B {urn:hl7-org:elm-types:r1}Integer> as Tuple<A {urn:hl7-org:elm-types:r1}Integer, B {urn:hl7-org:elm-types:r1}String>/
+      );
+    await this.castIntegerAsTupleOfInteger
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast {urn:hl7-org:elm-types:r1}Integer as Tuple<A {urn:hl7-org:elm-types:r1}Integer>/
+      );
+    await this.castListAsTupleOfInteger
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast List<{urn:hl7-org:elm-types:r1}Integer> as Tuple<A {urn:hl7-org:elm-types:r1}Integer>/
+      );
+    await this.castIntervalAsTupleOfInteger
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as Tuple<A {urn:hl7-org:elm-types:r1}Integer>/
+      );
   });
 });
 
@@ -243,33 +281,41 @@ describe('AsChoiceType', () => {
     setup(this, data);
   });
 
-  it('should return back matching types', function () {
-    this.integerAsChoiceOfIntegersAndStrings.exec(this.ctx).should.eql(5);
-    this.castIntegerAsChoiceOfIntegersAndStrings.exec(this.ctx).should.eql(5);
-    this.stringAsChoiceOfIntegersAndStrings.exec(this.ctx).should.eql('Foo');
-    this.castStringAsChoiceOfIntegersAndStrings.exec(this.ctx).should.eql('Foo');
+  it('should return back matching types', async function () {
+    (await this.integerAsChoiceOfIntegersAndStrings.exec(this.ctx)).should.eql(5);
+    (await this.castIntegerAsChoiceOfIntegersAndStrings.exec(this.ctx)).should.eql(5);
+    (await this.stringAsChoiceOfIntegersAndStrings.exec(this.ctx)).should.eql('Foo');
+    (await this.castStringAsChoiceOfIntegersAndStrings.exec(this.ctx)).should.eql('Foo');
   });
 
-  it('should return null on non-matching types for non-strict cast', function () {
-    should(this.decimalAsChoiceOfIntegersAndStrings.exec(this.ctx)).be.null();
-    should(this.listAsChoiceOfIntegersAndStrings.exec(this.ctx)).be.null();
-    should(this.intervalAsChoiceOfIntegersAndStrings.exec(this.ctx)).be.null();
-    should(this.tupleAsChoiceOfIntegersAndStrings.exec(this.ctx)).be.null();
+  it('should return null on non-matching types for non-strict cast', async function () {
+    should(await this.decimalAsChoiceOfIntegersAndStrings.exec(this.ctx)).be.null();
+    should(await this.listAsChoiceOfIntegersAndStrings.exec(this.ctx)).be.null();
+    should(await this.intervalAsChoiceOfIntegersAndStrings.exec(this.ctx)).be.null();
+    should(await this.tupleAsChoiceOfIntegersAndStrings.exec(this.ctx)).be.null();
   });
 
-  it('should throw on non-matching types for strict cast', function () {
-    (() => this.castDecimalAsChoiceOfIntegersAndStrings.exec(this.ctx)).should.throw(
-      /Cannot cast {urn:hl7-org:elm-types:r1}Decimal as Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>/
-    );
-    (() => this.castListAsChoiceOfIntegersAndStrings.exec(this.ctx)).should.throw(
-      /Cannot cast List<Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>> as Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>/
-    );
-    (() => this.castIntervalAsChoiceOfIntegersAndStrings.exec(this.ctx)).should.throw(
-      /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>/
-    );
-    (() => this.castTupleAsChoiceOfIntegersAndStrings.exec(this.ctx)).should.throw(
-      /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}Integer, B {urn:hl7-org:elm-types:r1}String> as Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>/
-    );
+  it('should throw on non-matching types for strict cast', async function () {
+    await this.castDecimalAsChoiceOfIntegersAndStrings
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast {urn:hl7-org:elm-types:r1}Decimal as Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>/
+      );
+    await this.castListAsChoiceOfIntegersAndStrings
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast List<Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>> as Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>/
+      );
+    await this.castIntervalAsChoiceOfIntegersAndStrings
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>/
+      );
+    await this.castTupleAsChoiceOfIntegersAndStrings
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Tuple<A {urn:hl7-org:elm-types:r1}Integer, B {urn:hl7-org:elm-types:r1}String> as Choice<{urn:hl7-org:elm-types:r1}Integer, {urn:hl7-org:elm-types:r1}String>/
+      );
   });
 });
 
@@ -278,40 +324,50 @@ describe('AsCustomDataModelType', () => {
     setup(this, data, [p1]);
   });
 
-  it('should return back matching types', function () {
-    this.encounterAsEncounter.exec(this.ctx).id.should.equal('http://cqframework.org/3/1');
-    this.castEncounterAsEncounter.exec(this.ctx).id.should.equal('http://cqframework.org/3/1');
-    this.encounterAsRecord.exec(this.ctx).id.should.equal('http://cqframework.org/3/1');
-    this.castEncounterAsRecord.exec(this.ctx).id.should.equal('http://cqframework.org/3/1');
-    this.encounterAsAny.exec(this.ctx).id.should.equal('http://cqframework.org/3/1');
-    this.castEncounterAsAny.exec(this.ctx).id.should.equal('http://cqframework.org/3/1');
-    this.namedTupleAsEncounter.exec(this.ctx).id.should.equal('1');
-    this.castNamedTupleAsEncounter.exec(this.ctx).id.should.equal('1');
+  it('should return back matching types', async function () {
+    (await this.encounterAsEncounter.exec(this.ctx)).id.should.equal('http://cqframework.org/3/1');
+    (await this.castEncounterAsEncounter.exec(this.ctx)).id.should.equal(
+      'http://cqframework.org/3/1'
+    );
+    (await this.encounterAsRecord.exec(this.ctx)).id.should.equal('http://cqframework.org/3/1');
+    (await this.castEncounterAsRecord.exec(this.ctx)).id.should.equal('http://cqframework.org/3/1');
+    (await this.encounterAsAny.exec(this.ctx)).id.should.equal('http://cqframework.org/3/1');
+    (await this.castEncounterAsAny.exec(this.ctx)).id.should.equal('http://cqframework.org/3/1');
+    (await this.namedTupleAsEncounter.exec(this.ctx)).id.should.equal('1');
+    (await this.castNamedTupleAsEncounter.exec(this.ctx)).id.should.equal('1');
   });
 
-  it('should return null on non-matching types for non-strict cast', function () {
-    should(this.encounterAsCondition.exec(this.ctx)).be.null();
-    should(this.encounterAsString.exec(this.ctx)).be.null();
-    should(this.listAsEncounter.exec(this.ctx)).be.null();
-    should(this.intervalAsEncounter.exec(this.ctx)).be.null();
+  it('should return null on non-matching types for non-strict cast', async function () {
+    should(await this.encounterAsCondition.exec(this.ctx)).be.null();
+    should(await this.encounterAsString.exec(this.ctx)).be.null();
+    should(await this.listAsEncounter.exec(this.ctx)).be.null();
+    should(await this.intervalAsEncounter.exec(this.ctx)).be.null();
     // Technically, this cast should fail, but this is a known bug that would require significant work to overcome
-    // should(this.tupleAsEncounter.exec(this.ctx)).be.null();
+    // should((await this.tupleAsEncounter.exec(this.ctx))).be.null();
   });
 
-  it('should throw on non-matching types for strict cast', function () {
-    (() => this.castEncounterAsCondition.exec(this.ctx)).should.throw(
-      /Cannot cast {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter as {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Condition/
-    );
-    (() => this.castEncounterAsString.exec(this.ctx)).should.throw(
-      /Cannot cast {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter as {urn:hl7-org:elm-types:r1}String/
-    );
-    (() => this.castListAsEncounter.exec(this.ctx)).should.throw(
-      /Cannot cast List<{https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter> as {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter/
-    );
-    (() => this.castIntervalAsEncounter.exec(this.ctx)).should.throw(
-      /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter/
-    );
+  it('should throw on non-matching types for strict cast', async function () {
+    await this.castEncounterAsCondition
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter as {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Condition/
+      );
+    await this.castEncounterAsString
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter as {urn:hl7-org:elm-types:r1}String/
+      );
+    await this.castListAsEncounter
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast List<{https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter> as {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter/
+      );
+    await this.castIntervalAsEncounter
+      .exec(this.ctx)
+      .should.be.rejectedWith(
+        /Cannot cast Interval<{urn:hl7-org:elm-types:r1}Integer> as {https:\/\/github\.com\/cqframework\/cql-execution\/simple}Encounter/
+      );
     // Technically, this cast should fail, but this is a known bug that would require significant work to overcome
-    // (() => this.castTupleAsEncounter.exec(this.ctx)).should.throw(/Cannot cast Tuple<id {urn:hl7-org:elm-types:r1}String> as {urn:hl7-org:elm-types:r1}Encounter/);
+    // await this.castTupleAsEncounter.exec(this.ctx).should.be.rejectedWith(/Cannot cast Tuple<id {urn:hl7-org:elm-types:r1}String> as {urn:hl7-org:elm-types:r1}Encounter/);
   });
 });

--- a/test/spec-tests/spec-test.ts
+++ b/test/spec-tests/spec-test.ts
@@ -51,9 +51,9 @@ describe('CQL Spec Tests (from XML)', () => {
               if (testCaseMap.has('expression') && testCaseMap.has('output')) {
                 const ctx = new PatientContext(library);
                 ctx.getExecutionDateTime().timezoneOffset = 0;
-                const actualExp = build(testCaseMap.get('expression'));
+                const actualExp = build(testCaseMap.get('expression')) as any;
                 let actual = actualExp.execute(ctx);
-                const expectedExp = build(testCaseMap.get('output'));
+                const expectedExp = build(testCaseMap.get('output')) as any;
                 let expected = expectedExp.execute(ctx);
                 if (expectedExp.json && expectedExp.json.type === 'Null') {
                   should(actual).be.null();

--- a/test/util/util-test.ts
+++ b/test/util/util-test.ts
@@ -27,48 +27,70 @@ describe('typeIsArray', () => {
 });
 
 describe('asyncMergeSort', () => {
-  const sortAsc = async (a: number, b: number) => a - b;
-  const sortDesc = async (a: number, b: number) => b - a;
+  const sortAsc = async (a: number | string, b: number | string) => {
+    if (a < b) return -1;
+    else if (a > b) return 1;
+    return 0;
+  };
+  const sortDesc = async (a: number | string, b: number | string) => {
+    if (a < b) return 1;
+    else if (a > b) return -1;
+    return 0;
+  };
 
   it('should not change empty array', async () => {
-    const arr: any[] = [];
+    const arr: any = [];
     const sorted = await asyncMergeSort(arr, sortAsc);
 
     sorted.should.eql([]);
   });
 
   it('should not change array with 1 element', async () => {
-    const arr: any[] = [1];
+    const arr = [1];
     const sorted = await asyncMergeSort(arr, sortAsc);
 
     sorted.should.eql([1]);
   });
 
   it('should sort array with 2 elements ascending', async () => {
-    const arr: any[] = [2, 1];
+    const arr = [2, 1];
     const sorted = await asyncMergeSort(arr, sortAsc);
 
     sorted.should.eql([1, 2]);
   });
 
   it('should sort array with 2 elements descending', async () => {
-    const arr: any[] = [1, 2];
+    const arr = [1, 2];
     const sorted = await asyncMergeSort(arr, sortDesc);
 
     sorted.should.eql([2, 1]);
   });
 
   it('should sort array ascending', async () => {
-    const arr: any[] = [3, -1, 0, 1, 5, 2];
+    const arr = [3, -1, 0, 1, 5, 2];
     const sorted = await asyncMergeSort(arr, sortAsc);
 
     sorted.should.eql([-1, 0, 1, 2, 3, 5]);
   });
 
   it('should sort array descending', async () => {
-    const arr: any[] = [3, -1, 0, 1, 5, 2];
+    const arr = [3, -1, 0, 1, 5, 2];
     const sorted = await asyncMergeSort(arr, sortDesc);
 
     sorted.should.eql([5, 3, 2, 1, 0, -1]);
+  });
+
+  it('should sort strings ascending', async () => {
+    const arr = ['def', 'abc', 'jkl', 'ghi'];
+    const sorted = await asyncMergeSort(arr, sortAsc);
+
+    sorted.should.eql(['abc', 'def', 'ghi', 'jkl']);
+  });
+
+  it('should sort complex object', async () => {
+    const arr = [{ val: 3 }, { val: 1 }, { val: 2 }];
+
+    const sorted = await asyncMergeSort(arr, async (a, b) => a.val - b.val);
+    sorted.should.eql([{ val: 1 }, { val: 2 }, { val: 3 }]);
   });
 });

--- a/test/util/util-test.ts
+++ b/test/util/util-test.ts
@@ -1,4 +1,5 @@
-import { typeIsArray } from '../../src/util/util';
+import { asyncMergeSort, typeIsArray } from '../../src/util/util';
+import 'should';
 
 describe('typeIsArray', () => {
   it('should properly identify arrays', () => {
@@ -22,5 +23,52 @@ describe('typeIsArray', () => {
     typeIsArray({ a: 1, b: 2, c: 3 }).should.be.false();
     typeIsArray({ a: [] }).should.be.false();
     typeIsArray(null).should.be.false();
+  });
+});
+
+describe('asyncMergeSort', () => {
+  const sortAsc = async (a: number, b: number) => a - b;
+  const sortDesc = async (a: number, b: number) => b - a;
+
+  it('should not change empty array', async () => {
+    const arr: any[] = [];
+    const sorted = await asyncMergeSort(arr, sortAsc);
+
+    sorted.should.eql([]);
+  });
+
+  it('should not change array with 1 element', async () => {
+    const arr: any[] = [1];
+    const sorted = await asyncMergeSort(arr, sortAsc);
+
+    sorted.should.eql([1]);
+  });
+
+  it('should sort array with 2 elements ascending', async () => {
+    const arr: any[] = [2, 1];
+    const sorted = await asyncMergeSort(arr, sortAsc);
+
+    sorted.should.eql([1, 2]);
+  });
+
+  it('should sort array with 2 elements descending', async () => {
+    const arr: any[] = [1, 2];
+    const sorted = await asyncMergeSort(arr, sortDesc);
+
+    sorted.should.eql([2, 1]);
+  });
+
+  it('should sort array ascending', async () => {
+    const arr: any[] = [3, -1, 0, 1, 5, 2];
+    const sorted = await asyncMergeSort(arr, sortAsc);
+
+    sorted.should.eql([-1, 0, 1, 2, 3, 5]);
+  });
+
+  it('should sort array descending', async () => {
+    const arr: any[] = [3, -1, 0, 1, 5, 2];
+    const sorted = await asyncMergeSort(arr, sortDesc);
+
+    sorted.should.eql([5, 3, 2, 1, 0, -1]);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
-    "sourceMap": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
# Summary

This PR convertes the ELM execution portions of the library to `async`, allowing for future patient sources to implement `findRecords` in a way that uses asynchronous operations (e.g. reaching out to an HTTP server or a database). Since a `Retrieve` can theoretically happen just about anywhere in the tree of ELM, the root ELM Expression `exec*` functions is now `async`, so all subclasses also have an `async`implementation of `exec*`

# New Behavior

From an execution standpoint, the results should be exactly the same as before. The only new behavior is that calling `execute` on an instance of the `Executor` class must now be done with an `await` or a `.then` since the result is a `Promise`. 

E.g.

``` TypeScript
// define executor and psource
// ...

executor
  .exec(psource)
  .then(result => { /* ... */ })
  .catch(err => { /* ... */ })
```

# Code Changes

* Convert every `execute`, `exec`, and `execArgs` to async
* Convert all usages of the above in the code to use `await`
  * Used `Promise.all` in cases where dealing with arrays of expressions to execute
* Implemented custom sorting with an `async` comparator function
  * The `SortClause` class was previously using the built in `.sort` function and calling `exec` within the comparator function to get the -1/1/0 ordering for the two elements. Since `exec` had to be `await`ed, it became impossible to use the built in function without relying on a specific iteration order of the array in order to precompute all the orders, which is inadvisable. Implemented a custom `asyncMergeSort` function that does `O(nlogn)` sorting while supporting an `async` comparison function
  * Added unit tests for above new utility
* Converted all elm unit tests to use `await` pattern for getting results and Promise rejection pattern for testing errors
* Updated examples and documentation to use `async/await` or `.then`

# Testing Guidance

* All the usual checks should pass
* Output of examples should be identical to prior code's
* Link dependency into project that uses execution and replace with the suggested pattern from the documentation/examples and make sure nothing breaks

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `yarn run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `yarn run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
