### PR TITLE
Async implementation fixes

### DIFF
--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -9449,7 +9449,7 @@ exports.asyncMergeSort = asyncMergeSort;
 async function merge(left, right, compareFn) {
     const sorted = [];
     while (left.length > 0 && right.length > 0) {
-        if ((await compareFn(left[0], right[0])) < 0) {
+        if ((await compareFn(left[0], right[0])) <= 0) {
             const sortedElem = left.shift();
             if (sortedElem !== undefined) {
                 sorted.push(sortedElem);

--- a/examples/browser/cql4browsers.js
+++ b/examples/browser/cql4browsers.js
@@ -6364,11 +6364,12 @@ class With extends expression_1.Expression {
         if (!(0, util_1.typeIsArray)(records)) {
             records = [records];
         }
-        const returns = await Promise.all(records.map((rec) => {
+        const returns = [];
+        for (const rec of records) {
             const childCtx = ctx.childContext();
             childCtx.set(this.alias, rec);
-            return this.suchThat.execute(childCtx);
-        }));
+            returns.push(await this.suchThat.execute(childCtx));
+        }
         return returns.some((x) => x);
     }
 }
@@ -6539,10 +6540,11 @@ class Query extends expression_1.Expression {
             for (const def of this.letClauses) {
                 rctx.set(def.identifier, await def.expression.execute(rctx));
             }
-            const relations = await Promise.all(this.relationship.map(rel => {
+            const relations = [];
+            for (const rel of this.relationship) {
                 const child_ctx = rctx.childContext();
-                return rel.execute(child_ctx);
-            }));
+                relations.push(await rel.execute(child_ctx));
+            }
             const passed = (0, util_1.allTrue)(relations) && (this.where ? await this.where.execute(rctx) : true);
             if (passed) {
                 if (this.returnClause != null) {
@@ -6618,16 +6620,18 @@ class MultiSource {
         let records = await this.expression.execute(ctx);
         this.isList = (0, util_1.typeIsArray)(records);
         records = this.isList ? records : [records];
-        return Promise.all(records.map(async (rec) => {
+        const results = [];
+        for (const rec of records) {
             const rctx = new context_1.Context(ctx);
             rctx.set(this.alias, rec);
             if (this.rest) {
-                return this.rest.forEach(rctx, func);
+                results.push(await this.rest.forEach(rctx, func));
             }
             else {
-                return func(rctx);
+                results.push(await func(rctx));
             }
-        }));
+        }
+        return results;
     }
 }
 

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -91,7 +91,7 @@ export async function asyncMergeSort<T>(arr: T[], compareFn: SortCompareFn<T>): 
 async function merge<T>(left: T[], right: T[], compareFn: SortCompareFn<T>) {
   const sorted: T[] = [];
   while (left.length > 0 && right.length > 0) {
-    if ((await compareFn(left[0], right[0])) < 0) {
+    if ((await compareFn(left[0], right[0])) <= 0) {
       const sortedElem = left.shift();
       if (sortedElem !== undefined) {
         sorted.push(sortedElem);

--- a/test/util/util-test.ts
+++ b/test/util/util-test.ts
@@ -93,4 +93,21 @@ describe('asyncMergeSort', () => {
     const sorted = await asyncMergeSort(arr, async (a, b) => a.val - b.val);
     sorted.should.eql([{ val: 1 }, { val: 2 }, { val: 3 }]);
   });
+
+  it('should preserve original order for items that are compared as equal', async () => {
+    const arr = [
+      { name: 'z', val: 3 },
+      { name: 'y', val: 1 },
+      { name: 'x', val: 2 },
+      { name: 'w', val: 1 }
+    ];
+
+    const sorted = await asyncMergeSort(arr, async (a, b) => a.val - b.val);
+    sorted.should.eql([
+      { name: 'y', val: 1 },
+      { name: 'w', val: 1 },
+      { name: 'x', val: 2 },
+      { name: 'z', val: 3 }
+    ]);
+  });
 });


### PR DESCRIPTION
When testing the `async-implementation` branch with some existing CDS Connect implementations, I ran into a couple of problems:

1. For certain test cases for certain artifacts, queries were crashing the engine because it was trying to call `.some(...)` on a variable that was not an array.
2. Some test cases failed because results did not come back in the expected order.

After some investigation, I determined that the first issue was related to how the query iterated through each record -- and more specifically, how it maintained the context. In the original (non-async) code, we performed a `.map(...)` on the record array; and in the new async code it kept the `.map(...)` function, but wrapped it in a `Promise.all` since the mapping invoked async functions.  Unfortunately, however, this meant that what used to be a synchronous iteration was now happening in parallel (sort of), and I _think_ the context was getting messed up as a result.  So the solution was to force synchronous iteration by using a `for... in...` loop instead.  I identified a few other spots that might suffer from the same problem and changed them too.  This seems to have fixed the problem in 1 above.

As for the unexpected change in the ordering of some lists returned by the engine, this turned out to be related to the new async merge sort function.  In the old sort, if two items were deemed equivalent (e.g. comparator function returns `0`), then they'd be returned in the same relative order as they appeared in the original (unsorted) list.  The new sort, however, did the opposite: it reversed their order form the original list.  Luckily, the fix was pretty simple: put the left side first if both left and right are equal.

Unfortunately, I couldn't easily reproduce issue 1 in tests.  It seems to be heavily dependent on timing and other factors.  In the unit tests, it seems like the async stuff was happening in the right sequence to not cause problems.  It was only in the wild where I could force it to do otherwise.  ~~I might be able to provide a standalone test case if you'd like.~~ _**UPDATE: I have created a test project that reproduces the issue so you can see the problem for yourself and confirm the solution fixes it.  Download [async-cql-query-test.zip](https://github.com/projecttacoma/cql-execution/files/9676177/async-cql-query-test.zip) and view the README.md for instructions.**_

I was able to reproduce issue 2 in tests and added a test that demonstrates it.

Pull requests into cql-execution require the following.
Submitter and reviewer should ✔ when done.
For items that are not-applicable, mark "N/A" and ✔.

[CDS Connect](https://cds.ahrq.gov/cdsconnect) and [Bonnie](https://github.com/projecttacoma/bonnie) are the main users of this repository.
It is strongly recommended to include a person from each of those projects as a reviewer.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been done and been reviewed (it does not contain: additional white space, not applicable code changes, debug statements, etc.)
- [x-ish] Tests are included and test edge cases
- [x] Tests have been run locally and pass
- [x] Code coverage has not gone down and all code touched or added is covered.
- [x] Code passes lint and prettier (hint: use `npm run test:plus` to run tests, lint, and prettier)
- [x] All dependent libraries are appropriately updated or have a corresponding PR related to this change
- [x] `cql4browsers.js` built with `npm run build:browserify` if source changed.

**Reviewer:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
